### PR TITLE
Adding OpenKh.Research.Pcsx2Kh2Link

### DIFF
--- a/OpenKh.Research.Pcsx2Kh2Link/OpenKh.Research.Pcsx2Kh2Link.csproj
+++ b/OpenKh.Research.Pcsx2Kh2Link/OpenKh.Research.Pcsx2Kh2Link.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenKh.Kh2\OpenKh.Kh2.csproj" />
+    <ProjectReference Include="..\OpenKh.Tools.Common\OpenKh.Tools.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/OpenKh.Research.Pcsx2Kh2Link/Program.cs
+++ b/OpenKh.Research.Pcsx2Kh2Link/Program.cs
@@ -73,7 +73,7 @@ namespace OpenKh.Research.Pcsx2Kh2Link
                                 var outFile = Path.Combine(OutputDir, entry.FileName);
                                 Directory.CreateDirectory(Path.GetDirectoryName(outFile));
 
-                                File.Create(outFile).Using(outStream => 
+                                File.Create(outFile).Using(outStream =>
                                     stream.BufferedStream
                                         .SetPosition(entry.Addr1)
                                         .Copy(outStream, Convert.ToInt32(entry.Len))

--- a/OpenKh.Research.Pcsx2Kh2Link/Program.cs
+++ b/OpenKh.Research.Pcsx2Kh2Link/Program.cs
@@ -25,11 +25,6 @@ namespace OpenKh.Research.Pcsx2Kh2Link
             {
                 return CommandLineApplication.Execute<Program>(args);
             }
-            catch (FileNotFoundException e)
-            {
-                Console.WriteLine($"The file {e.FileName} cannot be found. The program will now exit.");
-                return 2;
-            }
             catch (Exception e)
             {
                 Console.WriteLine($"FATAL ERROR: {e.Message}\n{e.StackTrace}");
@@ -59,7 +54,7 @@ namespace OpenKh.Research.Pcsx2Kh2Link
             public override string ToString() => $"{Addr1:X8}-{Addr1 + Len - 1:X8} {FileName}";
         }
 
-        [Command("list", Description = "list KH2 loaded items")]
+        [Command("list", Description = "list KH2fm loaded files")]
         private class ListCommand
         {
             protected int OnExecute(CommandLineApplication app)

--- a/OpenKh.Research.Pcsx2Kh2Link/Program.cs
+++ b/OpenKh.Research.Pcsx2Kh2Link/Program.cs
@@ -1,0 +1,104 @@
+﻿using OpenKh.Kh2;
+using OpenKh.Common;
+using McMaster.Extensions.CommandLineUtils;
+using System;
+using System.IO;
+using System.Reflection;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+using OpenKh.Tools.Common;
+using Xe.BinaryMapper;
+using System.Linq;
+using System.Text;
+
+namespace OpenKh.Research.Pcsx2Kh2Link
+{
+    [Command("OpenKh.Research.Pcsx2Kh2Link")]
+    [VersionOptionFromMember("--version", MemberName = nameof(GetVersion))]
+    [Subcommand(
+        typeof(ListCommand))]
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            try
+            {
+                return CommandLineApplication.Execute<Program>(args);
+            }
+            catch (FileNotFoundException e)
+            {
+                Console.WriteLine($"The file {e.FileName} cannot be found. The program will now exit.");
+                return 2;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"FATAL ERROR: {e.Message}\n{e.StackTrace}");
+                return -1;
+            }
+        }
+
+        protected int OnExecute(CommandLineApplication app)
+        {
+            app.ShowHelp();
+            return 1;
+        }
+
+        private static string GetVersion()
+            => typeof(Program).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+
+        class LoadedEntry
+        {
+            [Data] public uint Unk0 { get; set; }
+            [Data(Count = 24)] public string FileName { get; set; }
+            [Data(Count = 16)] public byte[] Unk1 { get; set; }
+            [Data] public int Len { get; set; }
+            [Data] public int Addr1 { get; set; }
+            [Data] public int Addr2 { get; set; }
+            [Data(Count = 24)] public byte[] Unk2 { get; set; }
+
+            public override string ToString() => $"{Addr1:X8}-{Addr1 + Len - 1:X8} {FileName}";
+        }
+
+        [Command("list", Description = "list KH2 loaded items")]
+        private class ListCommand
+        {
+            protected int OnExecute(CommandLineApplication app)
+            {
+                var processes = Process.GetProcessesByName("pcsx2");
+                if (processes.Length == 0)
+                {
+                    return 1;
+                }
+
+                foreach (var process in processes)
+                {
+                    Console.WriteLine(process);
+
+                    var processStream = new ProcessStream(process, ToolConstants.Pcsx2BaseAddress, ToolConstants.Ps2MemoryLength);
+                    var bufferedStream = new BufferedStream(processStream, 0x10000);
+
+                    bufferedStream.Position = 0x100130;
+                    var part = Encoding.GetEncoding("latin1").GetString(bufferedStream.ReadBytes(16));
+                    if (part != "\xFE\x01\x02\x3C\x00\x02\x03\x3C\x00\x00\x42\x24\x00\x00\x63\x24")
+                    {
+                        Console.WriteLine("This is not pcsx2 we are looking for.");
+                        continue;
+                    }
+
+                    bufferedStream.Position = 0x4F6480;
+                    var list = Enumerable.Range(0, 200)
+                        .Select(_ => BinaryMapping.ReadObject<LoadedEntry>(bufferedStream))
+                        .Where(it => it.Addr1 != 0)
+                        .ToArray();
+
+                    foreach (var entry in list)
+                    {
+                        Console.WriteLine(entry);
+                    }
+                }
+
+                return 0;
+            }
+        }
+    }
+}

--- a/OpenKh.Research.Pcsx2Kh2Link/Program.cs
+++ b/OpenKh.Research.Pcsx2Kh2Link/Program.cs
@@ -41,19 +41,6 @@ namespace OpenKh.Research.Pcsx2Kh2Link
         private static string GetVersion()
             => typeof(Program).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
 
-        class LoadedEntry
-        {
-            [Data] public uint Unk0 { get; set; }
-            [Data(Count = 24)] public string FileName { get; set; }
-            [Data(Count = 16)] public byte[] Unk1 { get; set; }
-            [Data] public int Len { get; set; }
-            [Data] public int Addr1 { get; set; }
-            [Data] public int Addr2 { get; set; }
-            [Data(Count = 24)] public byte[] Unk2 { get; set; }
-
-            public override string ToString() => $"{Addr1:X8}-{Addr1 + Len - 1:X8} {FileName}";
-        }
-
         [Command("list", Description = "list KH2fm loaded files")]
         private class ListCommand
         {

--- a/OpenKh.Research.Pcsx2Kh2Link/Program.cs
+++ b/OpenKh.Research.Pcsx2Kh2Link/Program.cs
@@ -50,6 +50,8 @@ namespace OpenKh.Research.Pcsx2Kh2Link
 
                 foreach (var pcsx2 in search.Pcsx2Refs)
                 {
+                    Console.WriteLine(pcsx2);
+
                     using var stream = pcsx2.OpenStream();
 
                     try
@@ -59,9 +61,9 @@ namespace OpenKh.Research.Pcsx2Kh2Link
                             Console.WriteLine(entry);
                         }
                     }
-                    catch (LinkToPcsx2.KH2fmNotFoundException)
+                    catch (LinkToPcsx2.KH2fmNotFoundException ex)
                     {
-                        // ignore
+                        Console.Error.WriteLine(ex);
                     }
                 }
 

--- a/OpenKh.Tools.Common/LinkToPcsx2.cs
+++ b/OpenKh.Tools.Common/LinkToPcsx2.cs
@@ -66,6 +66,7 @@ namespace OpenKh.Tools.Common
 
             public void Dispose()
             {
+                BufferedStream.Dispose();
                 ProcessStream.Dispose();
             }
         }

--- a/OpenKh.Tools.Common/LinkToPcsx2.cs
+++ b/OpenKh.Tools.Common/LinkToPcsx2.cs
@@ -52,7 +52,14 @@ namespace OpenKh.Tools.Common
 
                 BufferedStream.Position = 0x4F6480;
                 return Enumerable.Range(0, 200)
-                    .Select(_ => BinaryMapping.ReadObject<LoadedEntry>(BufferedStream))
+                    .Select(
+                        _ =>
+                        {
+                            var it = BinaryMapping.ReadObject<LoadedEntry>(BufferedStream);
+                            it.FileName = it.FileName.Split('\0').First();
+                            return it;
+                        }
+                    )
                     .Where(it => it.Addr1 != 0)
                     .ToArray();
             }

--- a/OpenKh.Tools.Common/LinkToPcsx2.cs
+++ b/OpenKh.Tools.Common/LinkToPcsx2.cs
@@ -17,6 +17,8 @@ namespace OpenKh.Tools.Common
         {
             public Process Process { get; }
 
+            public override string ToString() => $"PID={Process.Id}, Name={Process.ProcessName}";
+
             public ProcessRef(Process p)
             {
                 Process = p;
@@ -43,6 +45,7 @@ namespace OpenKh.Tools.Common
 
             public LoadedEntry[] GetKH2FMLoadedEntries()
             {
+                // Check if this is pcsx2 KH2fm instance, by reading part of `SLPM_666.75` (1130h-113fh)
                 BufferedStream.Position = 0x100130;
                 var part = Encoding.GetEncoding("latin1").GetString(BufferedStream.ReadBytes(16));
                 if (part != "\xFE\x01\x02\x3C\x00\x02\x03\x3C\x00\x00\x42\x24\x00\x00\x63\x24")
@@ -73,7 +76,7 @@ namespace OpenKh.Tools.Common
 
         public class KH2fmNotFoundException : Exception
         {
-            public KH2fmNotFoundException() : base("This is not pcsx2 we are looking for.")
+            public KH2fmNotFoundException() : base("KH2fm is not found in this PCSX2.")
             {
 
             }

--- a/OpenKh.Tools.Common/LinkToPcsx2.cs
+++ b/OpenKh.Tools.Common/LinkToPcsx2.cs
@@ -1,0 +1,102 @@
+﻿using OpenKh.Common;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xe.BinaryMapper;
+
+namespace OpenKh.Tools.Common
+{
+    public sealed class LinkToPcsx2 : IDisposable
+    {
+        public ProcessRef[] Pcsx2Refs { get; }
+
+        public sealed class ProcessRef : IDisposable
+        {
+            public Process Process { get; }
+
+            public ProcessRef(Process p)
+            {
+                Process = p;
+            }
+
+            public Pcsx2ProcessStream OpenStream() => new Pcsx2ProcessStream(Process);
+
+            public void Dispose()
+            {
+                Process.Dispose();
+            }
+        }
+
+        public sealed class Pcsx2ProcessStream : IDisposable
+        {
+            public ProcessStream ProcessStream { get; }
+            public BufferedStream BufferedStream { get; }
+
+            public Pcsx2ProcessStream(Process process)
+            {
+                ProcessStream = new ProcessStream(process, ToolConstants.Pcsx2BaseAddress, ToolConstants.Ps2MemoryLength);
+                BufferedStream = new BufferedStream(ProcessStream, 0x10000);
+            }
+
+            public LoadedEntry[] GetKH2FMLoadedEntries()
+            {
+                BufferedStream.Position = 0x100130;
+                var part = Encoding.GetEncoding("latin1").GetString(BufferedStream.ReadBytes(16));
+                if (part != "\xFE\x01\x02\x3C\x00\x02\x03\x3C\x00\x00\x42\x24\x00\x00\x63\x24")
+                {
+                    throw new KH2fmNotFoundException();
+                }
+
+                BufferedStream.Position = 0x4F6480;
+                return Enumerable.Range(0, 200)
+                    .Select(_ => BinaryMapping.ReadObject<LoadedEntry>(BufferedStream))
+                    .Where(it => it.Addr1 != 0)
+                    .ToArray();
+            }
+
+            public void Dispose()
+            {
+                ProcessStream.Dispose();
+            }
+        }
+
+        public class KH2fmNotFoundException : Exception
+        {
+            public KH2fmNotFoundException() : base("This is not pcsx2 we are looking for.")
+            {
+
+            }
+        }
+
+        public class LoadedEntry
+        {
+            [Data] public uint Unk0 { get; set; }
+            [Data(Count = 24)] public string FileName { get; set; }
+            [Data(Count = 16)] public byte[] Unk1 { get; set; }
+            [Data] public int Len { get; set; }
+            [Data] public int Addr1 { get; set; }
+            [Data] public int Addr2 { get; set; }
+            [Data(Count = 24)] public byte[] Unk2 { get; set; }
+
+            public override string ToString() => $"{Addr1:X8}-{Addr1 + Len - 1:X8} {FileName}";
+        }
+
+        public LinkToPcsx2()
+        {
+            Pcsx2Refs = Process.GetProcessesByName("pcsx2")
+                .Select(p => new ProcessRef(p))
+                .ToArray();
+        }
+
+        public void Dispose()
+        {
+            foreach (var p in Pcsx2Refs)
+            {
+                p.Dispose();
+            }
+        }
+    }
+}

--- a/OpenKh.sln
+++ b/OpenKh.sln
@@ -98,11 +98,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenKh.Tools.Kh2MapCollisio
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenKh.Command.CoctChanger", "OpenKh.Command.CoctChanger\OpenKh.Command.CoctChanger.csproj", "{08487D2A-8091-4DC9-AC31-3130CE0842D1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenKh.Command.SpawnScript", "OpenKh.Command.SpawnScript\OpenKh.Command.SpawnScript.csproj", "{696CDCFC-6AC4-4062-82A0-CAD2EB4EB2CE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenKh.Command.SpawnScript", "OpenKh.Command.SpawnScript\OpenKh.Command.SpawnScript.csproj", "{696CDCFC-6AC4-4062-82A0-CAD2EB4EB2CE}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenKh.Command.MapGen", "OpenKh.Command.MapGen\OpenKh.Command.MapGen.csproj", "{340458E3-FE2B-470E-9C4F-D3E58F218670}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenKh.Tools.IdxImg", "OpenKh.Tools.IdxImg\OpenKh.Tools.IdxImg.csproj", "{1B89F510-3B9A-4A3B-A08F-4FFB5C5B817B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenKh.Tools.IdxImg", "OpenKh.Tools.IdxImg\OpenKh.Tools.IdxImg.csproj", "{1B89F510-3B9A-4A3B-A08F-4FFB5C5B817B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenKh.Research.Pcsx2Kh2Link", "OpenKh.Research.Pcsx2Kh2Link\OpenKh.Research.Pcsx2Kh2Link.csproj", "{4FD4E3C9-C9C8-412E-9298-A9A4C4F6D7B1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -787,6 +789,22 @@ Global
 		{1B89F510-3B9A-4A3B-A08F-4FFB5C5B817B}.Release|x64.Build.0 = Release|Any CPU
 		{1B89F510-3B9A-4A3B-A08F-4FFB5C5B817B}.Release|x86.ActiveCfg = Release|Any CPU
 		{1B89F510-3B9A-4A3B-A08F-4FFB5C5B817B}.Release|x86.Build.0 = Release|Any CPU
+		{4FD4E3C9-C9C8-412E-9298-A9A4C4F6D7B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4FD4E3C9-C9C8-412E-9298-A9A4C4F6D7B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4FD4E3C9-C9C8-412E-9298-A9A4C4F6D7B1}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{4FD4E3C9-C9C8-412E-9298-A9A4C4F6D7B1}.Debug|ARM.Build.0 = Debug|Any CPU
+		{4FD4E3C9-C9C8-412E-9298-A9A4C4F6D7B1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4FD4E3C9-C9C8-412E-9298-A9A4C4F6D7B1}.Debug|x64.Build.0 = Debug|Any CPU
+		{4FD4E3C9-C9C8-412E-9298-A9A4C4F6D7B1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4FD4E3C9-C9C8-412E-9298-A9A4C4F6D7B1}.Debug|x86.Build.0 = Debug|Any CPU
+		{4FD4E3C9-C9C8-412E-9298-A9A4C4F6D7B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4FD4E3C9-C9C8-412E-9298-A9A4C4F6D7B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4FD4E3C9-C9C8-412E-9298-A9A4C4F6D7B1}.Release|ARM.ActiveCfg = Release|Any CPU
+		{4FD4E3C9-C9C8-412E-9298-A9A4C4F6D7B1}.Release|ARM.Build.0 = Release|Any CPU
+		{4FD4E3C9-C9C8-412E-9298-A9A4C4F6D7B1}.Release|x64.ActiveCfg = Release|Any CPU
+		{4FD4E3C9-C9C8-412E-9298-A9A4C4F6D7B1}.Release|x64.Build.0 = Release|Any CPU
+		{4FD4E3C9-C9C8-412E-9298-A9A4C4F6D7B1}.Release|x86.ActiveCfg = Release|Any CPU
+		{4FD4E3C9-C9C8-412E-9298-A9A4C4F6D7B1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -834,6 +852,7 @@ Global
 		{696CDCFC-6AC4-4062-82A0-CAD2EB4EB2CE} = {9C52D787-9819-4B89-989B-EEA6FEB20731}
 		{340458E3-FE2B-470E-9C4F-D3E58F218670} = {9C52D787-9819-4B89-989B-EEA6FEB20731}
 		{1B89F510-3B9A-4A3B-A08F-4FFB5C5B817B} = {402B2669-D594-4DFA-965B-02A92626ADC6}
+		{4FD4E3C9-C9C8-412E-9298-A9A4C4F6D7B1} = {9AEB4887-7C23-4992-A26D-A1E73DC4FE53}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1DF3960B-4FE5-4E56-92D4-2FC0A912E823}


### PR DESCRIPTION
```bat
H>OpenKh.Research.Pcsx2Kh2Link.exe list

System.Diagnostics.Process (pcsx2)
00650C40-00B9FC3F map/jp/eh18.map
00642440-0065043F msg/jp/eh.bar
00650440-00650C3F libretto-eh.bar
004FA440-0053F43F 00effect.bar
0053F440-00551C3F magic/FIRE_3.mag
00551C40-0056CC3F magic/BLIZZARD_3.mag
0056CC40-005A743F magic/THUNDER_3.mag
005A7440-005BFC3F magic/CURE_3.mag
005BFC40-005DDC3F magic/MAGNET_3.mag
005DDC40-0060E43F magic/REFLECT_3.mag
0061F440-00625C3F obj/PRIZE.mdlx
00625C40-0062CC3F obj/PRIZE_BOX_YELLOW.mdl
0062CC40-00633C3F obj/PRIZE_BOX_RED.mdlx
00633C40-0063B43F obj/PRIZE_BOX_BLUE.mdlx
0063B440-0064243F obj/PRIZE_BOX_GREEN.mdlx
00BB0440-00C1B43F obj/P_EX100.mdlx
00C1B440-00CA043F obj/P_EX100.a.fm
00CA0440-00F1E43F obj/P_EX100.mset
00F1E440-00F2F43F obj/W_EX010_N0.mdlx
00F2F440-00F5BC3F obj/W_EX010_N0.a.fm
00F5BC40-00F9DC3F obj/W_EX010.mset
00BA0440-00BA0C3F obj/WORLD_POINT.mdlx
00BA0C40-00BB043F obj/WORLD_POINT.a.fm
00FC9E40-0102863F obj/P_EH000.mdlx
01028640-01032E3F obj/P_EH000_MEMO.mset
01032E40-01094E3F obj/P_EX030.mdlx
01094E40-0109F63F obj/P_EX030_MEMO.mset
0109F640-010FBE3F obj/P_EX020.mdlx
010FBE40-01104E3F obj/P_EX020_MEMO.mset
00B9FC40-00BA043F obj/F_EX000.mdlx
01104E40-0115863F obj/P_EX220_RTN.mdlx
01158640-0117A63F obj/P_EX220_RTN.mset
0117A640-011DFE3F obj/N_EX560_RTN.mdlx
011DFE40-0120BE3F obj/N_EX560_RTN.mset
0120BE40-01267E3F obj/P_EH000_RTN.mdlx
01267E40-0127DE3F obj/P_EH000_RTN.mset
0127DE40-012D8E3F obj/P_EX020_RTN.mdlx
012D8E40-012ED63F obj/P_EX020_RTN.mset
012ED640-0134DE3F obj/P_EX030_RTN.mdlx
0134DE40-01364E3F obj/P_EX030_RTN.mset
01364E40-01399E3F limit/fm/trinity_zz.bar
```

PS

- Sample BinaryTemplate is https://gitlab.com/kenjiuno/khkh_xldM/-/blob/master/VisAddrRange/loadedFileList.bt
- This bt is valid for `eeMemory.bin` in `sstates/SLPM-66675 (F266B00B).00.p2s` zip file.
