### PR TITLE
[Mod Manager] Fix missing movie cutscenes when region is changed off of FM

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/Pcsx2Injector.cs
+++ b/OpenKh.Tools.ModsManager/Services/Pcsx2Injector.cs
@@ -470,6 +470,10 @@ namespace OpenKh.Tools.ModsManager.Services
             // Fix weird game bug where KH2FM would crash on map change
             // when the region is different from JP or FM.
             WritePatch(stream, 0x015ABE8, ADDIU(V0, Zero, 1));
+            
+            // Fix issue where KH2FM fails to load movie cutscenes
+            // when the region is different from FM.
+            WritePatch(stream, 0x022BC68, ADDIU(A2, A1, -0x6130));
         }
 
         private void ResetHooks() => _nextHookPtr = BaseHookPtr;


### PR DESCRIPTION
Hello! I’m a KH2FM rando player, and I wanted to look into why the movie cutscenes were missing (and causing the slow STT loads). The issue is actually caused by a larger issue in that if the region is changed off of FM, and the mod manager lets the file fallback to the emulator, then the file will fail to load because the game uses the region identifier as part of the directory it’s trying to load.

So for the movies, I found the instruction that asks for the region pointer (which will have been changed) so it can load the file, and I rewrote it to instead just give it the fm pointer, regardless of region. It is similar to the fix with the crash on map change. Seems to work, at least for the fallback mechanic. Hope this helps!

More info:
Instruction at 0022BC68.
Instead of loading pointer from 33CAF0 into a2, write in the fm pointer address (369ED0) into a2.
This is done by adding a1 with -0x6130, since a1 conveniently holds 370000 at this time.