### PR TITLE
Make Panacea Game/Version Agnostic

### DIFF
--- a/OpenKh.Research.Panacea/KingdomApi.h
+++ b/OpenKh.Research.Panacea/KingdomApi.h
@@ -1,25 +1,6 @@
 #pragma once
 #include "OpenKH.h"
 
-enum KingdomApiFunction
-{
-    Axa_CFileMan_LoadFile,
-    Axa_CFileMan_GetFileSize,
-    Axa_AxaResourceMan_SetResourceItem,
-    Axa_PackageMan_GetFileInfo,
-    Axa_CFileMan_LoadFileWithMalloc,
-    Axa_CalcHash,
-    Axa_CFileMan_GetRemasteredCount,
-    Axa_CFileMan_GetRemasteredEntry,
-    Axa_PackageFile_GetRemasteredAsset,
-    Axa_SetReplacePath,
-    Axa_FreeAllPackages,
-    Axa_CFileMan_GetAudioStream,
-    Axa_OpenFile,
-    Axa_DebugPrint,
-    KingdomApiFunction_END
-};
-
 const int Bbs_File_load = 0xE7D70;
 const int Bbs_CRsrcData_loadCallback = 0x113800;
 

--- a/OpenKh.Research.Panacea/OpenKh.Research.Panacea.vcxproj
+++ b/OpenKh.Research.Panacea/OpenKh.Research.Panacea.vcxproj
@@ -25,7 +25,7 @@
     <RootNamespace>OpenKhResearchPanacea</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -73,13 +73,13 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>C:\Program Files\Epic Games\KH_1.5_2.5\</OutDir>
     <TargetName>DBGHELP</TargetName>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>C:\Program Files\Epic Games\KH_1.5_2.5\</OutDir>
     <TargetName>DBGHELP</TargetName>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/OpenKh.Research.Panacea/dllmain.cpp
+++ b/OpenKh.Research.Panacea/dllmain.cpp
@@ -5,12 +5,15 @@
 #define MiniDumpWriteDump MiniDumpWriteDump_
 #include <DbgHelp.h>
 #undef MiniDumpWriteDump
+#include <Shlwapi.h>
 #include "OpenKH.h"
 
 typedef BOOL(WINAPI* PFN_MiniDumpWriteDump)(HANDLE hProcess, DWORD ProcessId, HANDLE hFile, MINIDUMP_TYPE DumpType, PMINIDUMP_EXCEPTION_INFORMATION ExceptionParam, PMINIDUMP_USER_STREAM_INFORMATION UserStreamParam, PMINIDUMP_CALLBACK_INFORMATION CallbackParam);
 PFN_MiniDumpWriteDump MiniDumpWriteDumpPtr;
 void HookDbgHelp()
 {
+    if (PathFileExists(L"LuaBackend.dll"))
+        LoadLibrary(L"LuaBackend.dll");
     const char OriginalDllName[] = "\\DBGHELP.dll";
     char buffer[MAX_PATH];
 


### PR DESCRIPTION
It now uses signatures to locate the functions it needs to hook, and my initial test shows that the signatures get a hit in every game in the 1.5+2.5 collection, including the launcher and theater. Currently I've left it locked to only supporting KH2, until such a time as the mod manager can support multiple games.