### PR TITLE
Open solution file with 'Visual Studio 2022'

### DIFF
--- a/OpenKh.sln
+++ b/OpenKh.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.32630.194
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenKh.Kh2", "OpenKh.Kh2\OpenKh.Kh2.csproj", "{D5B36CD1-5B5D-4CE9-A673-209AD386D68A}"
 EndProject


### PR DESCRIPTION
Currently `OpenKh.sln` is marked to open with `Visual Studio 2019`.

But I cannot build many tools, because Visual Studio 2019 doesn't recognize .NET 6.0.

```txt
Build started...
1>------ Build started: Project: OpenKh.Tools.Kh2SystemEditor, Configuration: Debug Any CPU ------
1>C:\Program Files\dotnet\sdk\6.0.108\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(134,5): warning NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.
```

So switching it to 'Visual Studio 2022' now so that Microsoft Visual Studio Version Selector will open `OpenKh.sln` with designated IDE.