### PR TITLE
Downgrading Extended.Wpf.Toolkit to 3.6.0 (Ms-PL)

### DIFF
--- a/OpenKh.Tools.Kh2SystemEditor/OpenKh.Tools.Kh2SystemEditor.csproj
+++ b/OpenKh.Tools.Kh2SystemEditor/OpenKh.Tools.Kh2SystemEditor.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.2.0" />
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="3.6.0" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />
     <PackageReference Include="NPOI" Version="2.5.5" />
   </ItemGroup>

--- a/OpenKh.Tools.ModsManager/OpenKh.Tools.ModsManager.csproj
+++ b/OpenKh.Tools.ModsManager/OpenKh.Tools.ModsManager.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.2.0" />
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="3.6.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Runtime.Caching" Version="6.0.0" />


### PR DESCRIPTION
Downgrading Extended.Wpf.Toolkit package, in order to avoid possible license issue (#615)
Fix #615

2 tools use it.

- OpenKh.Tools.Kh2SystemEditor
- OpenKh.Tools.ModsManager

```sh
$ grep -inr --include "*.cs" --include "*.xaml" --exclude-dir obj -e Xceed.Wpf.Toolkit -e "wpftoolkit:"
OpenKh.Tools.Kh2SystemEditor/Views/FtstView.xaml:8:             xmlns:wpftoolkit="clr-namespace:Xceed.Wpf.Toolkit;assembly=Xceed.Wpf.Toolkit"
OpenKh.Tools.Kh2SystemEditor/Views/FtstView.xaml:36:                        <wpftoolkit:ColorPicker
OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs:45:        private Xceed.Wpf.Toolkit.WizardPage _wizardPageAfterIntro;
OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs:46:        public Xceed.Wpf.Toolkit.WizardPage WizardPageAfterIntro
OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs:55:        private Xceed.Wpf.Toolkit.WizardPage _wizardPageAfterGameData;
OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs:56:        public Xceed.Wpf.Toolkit.WizardPage WizardPageAfterGameData
OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs:65:        public Xceed.Wpf.Toolkit.WizardPage PageIsoSelection { get; internal set; }
OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs:66:        public Xceed.Wpf.Toolkit.WizardPage PageEosInstall { get; internal set; }
OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs:67:        public Xceed.Wpf.Toolkit.WizardPage PageEosConfig { get; internal set; }
OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs:68:        public Xceed.Wpf.Toolkit.WizardPage PageRegion { get; internal set; }
OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs:69:        public Xceed.Wpf.Toolkit.WizardPage LastPage { get; internal set; }
OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml.cs:38:        private void Wizard_Finish(object sender, Xceed.Wpf.Toolkit.Core.CancelRoutedEventArgs e)
```

These screenshots will cover the place of usage. It will help to verify the working with older package.

OpenKh.Tools.Kh2SystemEditor will work

![2022-08-15_16h25_47](https://user-images.githubusercontent.com/5955540/184593550-882c93fd-11fe-4b24-a3c5-6c87fbf5ce47.png)

OpenKh.Tools.ModsManager will work

![2022-08-15_16h25_18](https://user-images.githubusercontent.com/5955540/184593535-d6e1f567-bfc9-4daa-9bd3-079525627140.png)
