### PR TITLE
Hotfix for OpenKh.Tools.Kh2MapStudio.exe

### DIFF
--- a/OpenKh.Kh2/Ard/AreaDataScript.cs
+++ b/OpenKh.Kh2/Ard/AreaDataScript.cs
@@ -355,7 +355,7 @@ namespace OpenKh.Kh2.Ard
                 var sb = new StringBuilder();
                 sb.AppendLine($"{nameof(AreaSettings)} {Unk00} {Unk02}");
                 foreach (var item in Settings)
-                    sb.AppendLine($"\t{item}");
+                    sb.AppendLine($" {item}");
 
                 return sb.ToString().Replace("\r", string.Empty);
             }
@@ -813,7 +813,7 @@ namespace OpenKh.Kh2.Ard
 
         public static string Decompile(IEnumerable<AreaDataScript> scripts) =>
             string.Join("\n\n", scripts.Select(x => x.ToString()));
-
+        
         public static IEnumerable<AreaDataScript> Compile(string text)
         {
             const char Comment = '#';
@@ -863,7 +863,7 @@ namespace OpenKh.Kh2.Ard
                         function.Parse(row, tokens);
                         script.Functions.Add(function);
 
-                        while (row < lines.Length && (lines[row].Length == 0 || lines[row][0] == '\t'))
+                        while (row < lines.Length && (lines[row].Length == 0 || lines[row][0] == ' '))
                         {
                             line = lines[row++];
                             cleanLine = line.Split(Comment);

--- a/OpenKh.Tests/kh2/ArdTests.cs
+++ b/OpenKh.Tests/kh2/ArdTests.cs
@@ -51,13 +51,13 @@ namespace OpenKh.Tests.kh2
             private const string SampleScriptDecompiled =
                 "Program 0x00\n" +
                 "AreaSettings 0 -1\n" +
-                "\tSetProgressFlag 0x380A\n" +
-                "\tSetEvent \"110\" Type 2\n" +
-                "\tSetJump Type 1 World NM Area 5 Entrance 0 LocalSet 0 FadeType 1\n" +
-                "\tSetPartyMenu 0\n" +
-                "\tSetProgressFlag 0x1234\n" +
-                "\tSetUnk05 0x1122\n" +
-                "\tSetInventory 666 777\n";
+                " SetProgressFlag 0x380A\n" +
+                " SetEvent \"110\" Type 2\n" +
+                " SetJump Type 1 World NM Area 5 Entrance 0 LocalSet 0 FadeType 1\n" +
+                " SetPartyMenu 0\n" +
+                " SetProgressFlag 0x1234\n" +
+                " SetUnk05 0x1122\n" +
+                " SetInventory 666 777\n";
 
             [Fact]
             public void ReadTest()


### PR DESCRIPTION
Hotfix for OpenKh.Tools.Kh2MapStudio.exe to allow spaces instead of tabs for sub commands, as tabs can't be entered.