### PR TITLE
Fix Kh2MapStudio and Kh2MdlxEditor

### DIFF
--- a/OpenKh.AssimpUtils/Kh2MdlxAssimp.cs
+++ b/OpenKh.AssimpUtils/Kh2MdlxAssimp.cs
@@ -62,16 +62,16 @@ namespace OpenKh.AssimpUtils
 
                 foreach (MeshDescriptor iMeshDesc in dic_meshDescriptorsByMeshId[i])
                 {
-                    foreach (PositionColoredTextured vertex in iMeshDesc.Vertices)
+                    foreach (var (vertex, boneAssigns) in iMeshDesc.Vertices.Zip(iMeshDesc.VertexBoneWeights))
                     {
                         iMesh.Vertices.Add(new Assimp.Vector3D(vertex.X, vertex.Y, vertex.Z));
                         iMesh.TextureCoordinateChannels[0].Add(new Assimp.Vector3D(vertex.Tu, 1 - vertex.Tv, 0));
 
                         // VERTEX WEIGHTS
-                        if (vertex.BoneAssign != null)
+                        foreach (var boneAssign in boneAssigns)
                         {
-                            Assimp.Bone bone = AssimpGeneric.FindBone(iMesh.Bones, "Bone" + vertex.BoneAssign);
-                            bone.VertexWeights.Add(new Assimp.VertexWeight(currentVertex, 1));
+                            Assimp.Bone bone = AssimpGeneric.FindBone(iMesh.Bones, "Bone" + boneAssign.MatrixIndex);
+                            bone.VertexWeights.Add(new Assimp.VertexWeight(currentVertex, boneAssign.Weight));
                         }
 
                         currentVertex++;

--- a/OpenKh.Engine/Parsers/Kkdf2MdlxParser.cs
+++ b/OpenKh.Engine/Parsers/Kkdf2MdlxParser.cs
@@ -1,6 +1,7 @@
 using OpenKh.Common;
 using OpenKh.Kh2;
 using OpenKh.Ps2;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -172,6 +173,7 @@ namespace OpenKh.Engine.Parsers
         public List<MeshDescriptor> ProcessVerticesAndBuildModel(Matrix4x4[] matrices)
         {
             immutableExportedMesh.positionList.Clear();
+            var weights = new List<VertexBoxWeight[]>();
             for (var i = 0; i < immutableExportedMesh.vertexAssignments.Count; i++)
             {
                 var vertexAssignments = immutableExportedMesh.vertexAssignments[i];
@@ -181,6 +183,16 @@ namespace OpenKh.Engine.Parsers
                     vertexAssignments.Select(
                         vertexAssigns =>
                         {
+                            weights.Add(
+                                (vertexAssigns.Length == 1)
+                                ? vertexAssigns
+                                    .Select(it => new VertexBoxWeight(it.MatrixIndex, 1f))
+                                    .ToArray()
+                                : vertexAssigns
+                                    .Select(it => new VertexBoxWeight(it.MatrixIndex, vertices[it.VertexIndex].W))
+                                    .ToArray()
+                            );
+
                             Vector3 finalPos = Vector3.Zero;
                             if (vertexAssigns.Length == 1)
                             {
@@ -212,6 +224,7 @@ namespace OpenKh.Engine.Parsers
             {
                 var vertices = new List<PositionColoredTextured>();
                 var indices = new List<int>();
+                var vertexBoneWeights = new List<VertexBoxWeight[]>();
 
                 int triangleRefCount = part.triangleRefList.Count;
                 for (int triIndex = 0; triIndex < triangleRefCount; triIndex++)
@@ -222,22 +235,13 @@ namespace OpenKh.Engine.Parsers
                         VertexRef vertRef = triRef.list[i];
                         indices.Add(vertices.Count);
 
-                        // Weight vertex uses global Id. Convert it to part identifier.
-                        int tempVertexIndex = vertRef.vertexIndex;
-                        int tempPartIndex = 0;
-                        while (tempVertexIndex >= immutableExportedMesh.vertexAssignments[tempPartIndex].Length)
-                        {
-                            tempVertexIndex -= immutableExportedMesh.vertexAssignments[tempPartIndex].Length;
-                            tempPartIndex++;
-                        }
-                        int vertexBoneWeight = immutableExportedMesh.vertexAssignments[tempPartIndex][tempVertexIndex][0].MatrixIndex;
-
+                        vertexBoneWeights.Add(weights[vertRef.vertexIndex]);
 
                         vertices.Add(new PositionColoredTextured(
                             immutableExportedMesh.positionList[vertRef.vertexIndex],
                             immutableExportedMesh.uvList[vertRef.uvIndex],
-                            1.0f, 1.0f, 1.0f, 1.0f,
-                            vertexBoneWeight));
+                            1.0f, 1.0f, 1.0f, 1.0f
+                        ));
                     }
                 }
 
@@ -248,6 +252,7 @@ namespace OpenKh.Engine.Parsers
                         TextureIndex = part.TextureIndex,
                         Vertices = vertices.ToArray(),
                         Indices = indices.ToArray(),
+                        VertexBoneWeights = vertexBoneWeights.ToArray(),
                     }
                 );
             }

--- a/OpenKh.Engine/Parsers/MdlxParser.cs
+++ b/OpenKh.Engine/Parsers/MdlxParser.cs
@@ -17,9 +17,8 @@ namespace OpenKh.Engine.Parsers
         public float X, Y, Z;
         public float Tu, Tv;
         public float R, G, B, A;
-        public int? BoneAssign;
 
-        public PositionColoredTextured(float x, float y, float z, float tu, float tv, float r, float g, float b, float a, int? boneAssign = null)
+        public PositionColoredTextured(float x, float y, float z, float tu, float tv, float r, float g, float b, float a)
         {
             X = x;
             Y = y;
@@ -30,10 +29,9 @@ namespace OpenKh.Engine.Parsers
             G = g;
             B = b;
             A = a;
-            BoneAssign = boneAssign;
         }
 
-        public PositionColoredTextured(Vector3 pos, Vector2 uv, float r, float g, float b, float a, int? boneAssign = null)
+        public PositionColoredTextured(Vector3 pos, Vector2 uv, float r, float g, float b, float a)
         {
             X = pos.X;
             Y = pos.Y;
@@ -44,7 +42,23 @@ namespace OpenKh.Engine.Parsers
             G = g;
             B = b;
             A = a;
-            BoneAssign = boneAssign;
+        }
+    }
+
+    public class VertexBoxWeight
+    {
+        public int MatrixIndex;
+        public float Weight;
+
+        public VertexBoxWeight()
+        {
+
+        }
+
+        public VertexBoxWeight(int matrixIndex, float weight)
+        {
+            MatrixIndex = matrixIndex;
+            Weight = weight;
         }
     }
 
@@ -54,6 +68,7 @@ namespace OpenKh.Engine.Parsers
         public int[] Indices;
         public int TextureIndex;
         public bool IsOpaque;
+        public VertexBoxWeight[][] VertexBoneWeights;
     }
 
     public class MdlxParser : IModelMotion


### PR DESCRIPTION
Fix Kh2MapStudio crashing by exception thrown. It occurred on opening map file . Recover PositionColoredTextured size to expected size.

```
System.ArgumentOutOfRangeException: Vertex stride of vertexDeclaration should be at least as big as the stride of the actual vertices. (Parameter 'vertexDeclaration')
   at Microsoft.Xna.Framework.Graphics.GraphicsDevice.DrawUserIndexedPrimitives[T](PrimitiveType primitiveType, T[] vertexData, Int32 vertexOffset, Int32 numVertices, Int32[] indexData, Int32 indexOffset, Int32 primitiveCount, VertexDeclaration vertexDeclaration)
   at OpenKh.Tools.Kh2MapStudio.MapRenderer.RenderMeshNew(EffectPass pass, MeshGroup mesh, Boolean passRenderOpaque) in V:\OpenKh-mapgen\OpenKh.Tools.Kh2MapStudio\MapRenderer.cs:line 376
   at OpenKh.Tools.Kh2MapStudio.MapRenderer.<Draw>b__93_0(EffectPass pass) in V:\OpenKh-mapgen\OpenKh.Tools.Kh2MapStudio\MapRenderer.cs:line 280
   at OpenKh.Engine.MonoGame.KingdomShader.Pass(Action`1 action) in V:\OpenKh-mapgen\OpenKh.Engine.MonoGame\KingdomShader.cs:line 118
   at OpenKh.Tools.Kh2MapStudio.MapRenderer.Draw() in V:\OpenKh-mapgen\OpenKh.Tools.Kh2MapStudio\MapRenderer.cs:line 272
   at OpenKh.Tools.Kh2MapStudio.App.MainWindow() in V:\OpenKh-mapgen\OpenKh.Tools.Kh2MapStudio\App.cs:line 202
   at OpenKh.Tools.Kh2MapStudio.App.MainLoop() in V:\OpenKh-mapgen\OpenKh.Tools.Kh2MapStudio\App.cs:line 133
   at OpenKh.Tools.Kh2MapStudio.Program.MainLoop(MonoGameImGuiBootstrap obj) in V:\OpenKh-mapgen\OpenKh.Tools.Kh2MapStudio\Program.cs:line 60
   at OpenKh.Tools.Common.CustomImGui.MonoGameImGuiBootstrap.Draw(GameTime gameTime) in V:\OpenKh-mapgen\OpenKh.Tools.Common.CustomImGui\MonoGameImGuiBootstrap.cs:line 77
   at Microsoft.Xna.Framework.Game.DoDraw(GameTime gameTime)
   at Microsoft.Xna.Framework.Game.Tick()
   at Microsoft.Xna.Framework.SdlGamePlatform.RunLoop()
   at Microsoft.Xna.Framework.Game.Run(GameRunBehavior runBehavior)
   at OpenKh.Tools.Kh2MapStudio.Program.Run() in V:\OpenKh-mapgen\OpenKh.Tools.Kh2MapStudio\Program.cs:line 55
   at OpenKh.Tools.Kh2MapStudio.Program.OnExecute(CommandLineApplication app) in V:\OpenKh-mapgen\OpenKh.Tools.Kh2MapStudio\Program.cs:line 20
```

Fix Kh2MdlxEditor so that it can export multiple weighted bone structure. e.g. utilized by H_EX500.mdlx, H_BB050_TSURU.mdlx, and so on

![2022-09-01_01h40_00](https://user-images.githubusercontent.com/5955540/187732707-0b8669ea-5f8b-4233-b8f0-a882d1e25418.png)
