### PR TITLE
Fix AreaSettings parser

### DIFF
--- a/OpenKh.Kh2/Ard/AreaDataScript.cs
+++ b/OpenKh.Kh2/Ard/AreaDataScript.cs
@@ -863,7 +863,7 @@ namespace OpenKh.Kh2.Ard
                         function.Parse(row, tokens);
                         script.Functions.Add(function);
 
-                        while (row < lines.Length && (lines[row].Length == 0 || lines[row][0] == ' ' || lines[row][0] == '\t'))
+                        while (row < lines.Length && (lines[row].Length == 0 || char.IsWhiteSpace(lines[row][0])))
                         {
                             line = lines[row++];
                             cleanLine = line.Split(Comment);

--- a/OpenKh.Kh2/Ard/AreaDataScript.cs
+++ b/OpenKh.Kh2/Ard/AreaDataScript.cs
@@ -863,7 +863,7 @@ namespace OpenKh.Kh2.Ard
                         function.Parse(row, tokens);
                         script.Functions.Add(function);
 
-                        while (row < lines.Length && (lines[row].Length == 0 || lines[row][0] == ' '))
+                        while (row < lines.Length && (lines[row].Length == 0 || lines[row][0] == ' ' || lines[row][0] == '\t'))
                         {
                             line = lines[row++];
                             cleanLine = line.Split(Comment);


### PR DESCRIPTION
At Discord, an user reported that mod (GoA ROM) doesn't work.

![2022-09-07_12h17_55](https://user-images.githubusercontent.com/5955540/188781064-09f86168-ef02-4e35-a3ce-fad90ff3d7d1.png)

This pr will fix this issue.

Reproduce:

1. Launch Mods Manager.
2. Mods menu → Install a new mod
3. e.g. `KH2FM-Mods-Num/GoA-ROM-Edition`
4. Turn on check
   ![2022-09-07_12h57_29](https://user-images.githubusercontent.com/5955540/188785603-73c7b9aa-cbb4-4899-9bc9-9c5c97a67a27.png)
5. Game menu → Build... → Build only

The build operation will succeed without error after fix.
