### PR TITLE
Transfer XeEngine.Tools.Public repository reference to OpenKh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "XeEngine.Tools.Public"]
 	path = XeEngine.Tools.Public
-	url = https://github.com/Xeeynamo/XeEngine.Tools.Public
+	url = https://github.com/OpenKH/XeEngine.Tools.Public.git
 [submodule "nQuant"]
 	path = nQuant
 	url = https://github.com/OpenKH/nQuant.git


### PR DESCRIPTION
OpenKh depends on projects from `Xeeynamo/XeEngine.Tools.Public` repository.
But OpenKh contributors cannot provide fix problems or improve functionality easily (simply it is not under control of OpenKh project).
Thus I have forked `XeEngine.Tools.Public` repository to OpenKh organization, so that we can manage it demands to our needs.
It is MIT licensed.
https://github.com/OpenKH/XeEngine.Tools.Public

This will help to fix issue like #132