### PR TITLE
Seperate the Mod Loader and Patching Menus

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -34,8 +34,8 @@ namespace OpenKh.Tools.ModsManager.Services
             public string Pcsx2Location { get; internal set; }
             public string PcReleaseLocation { get; internal set; }
             public int RegionId { get; internal set; }
-            public bool BypassLauncher { get; internal set; }
             public string EpicGamesUserID { get; internal set; }
+            public bool PanaceaInstalled { get; internal set; }
 
             public void Save(string fileName)
             {
@@ -194,23 +194,21 @@ namespace OpenKh.Tools.ModsManager.Services
                 _config.Save(ConfigPath);
             }
         }
-
-        public static bool BypassLauncher
-        {
-            get => _config.BypassLauncher;
-            set
-            {
-                _config.BypassLauncher = value;
-                _config.Save(ConfigPath);
-            }
-        }
-
         public static string EpicGamesUserID
         {
             get => _config.EpicGamesUserID;
             set
             {
                 _config.EpicGamesUserID = value;
+                _config.Save(ConfigPath);
+            }
+        }
+        public static bool PanaceaInstalled
+        {
+            get => _config.PanaceaInstalled;
+            set
+            {
+                _config.PanaceaInstalled = value;
                 _config.Save(ConfigPath);
             }
         }

--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -53,9 +53,7 @@ namespace OpenKh.Tools.ModsManager.Services
             }
         }
 
-        private static string StoragePath = Directory.GetCurrentDirectory().IndexOf("system32") >= 0 ?
-            Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location) :
-            Directory.GetCurrentDirectory();
+        private static string StoragePath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
         private static string ConfigPath = Path.Combine(StoragePath, "mods-manager.yml");
         private static string EnabledModsPath = Path.Combine(StoragePath, "mods.txt");
         private static readonly Config _config = Config.Open(ConfigPath);

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -37,6 +37,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         private bool _isBuilding;
         private bool _pc;
         private bool _bypass;
+        private bool _devView;
 
         private const string RAW_FILES_FOLDER_NAME = "raw";
         private const string ORIGINAL_FILES_FOLDER_NAME = "original";
@@ -59,6 +60,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         public RelayCommand StopRunningInstanceCommand { get; set; }
         public RelayCommand WizardCommand { get; set; }
         public RelayCommand OpenLinkCommand { get; set; }
+        public RelayCommand DevViewCommand { get; set; }
 
         public ModViewModel SelectedValue
         {
@@ -82,10 +84,19 @@ namespace OpenKh.Tools.ModsManager.ViewModels
 
         public Visibility IsModInfoVisible => IsModSelected ? Visibility.Visible : Visibility.Collapsed;
         public Visibility IsModUnselectedMessageVisible => !IsModSelected ? Visibility.Visible : Visibility.Collapsed;
-        public Visibility PatchVisible => PC ? Visibility.Visible : Visibility.Collapsed;
-
+        public Visibility PatchVisible => PC && !Bypass || PC && DevView ? Visibility.Visible : Visibility.Collapsed;
         public Visibility ModLoader => !PC || Bypass ? Visibility.Visible : Visibility.Collapsed;
 
+        public bool DevView
+        {
+            get => _devView;
+            set
+            {
+                _devView = value;
+                OnPropertyChanged(nameof(PatchVisible));
+            }
+        }     
+        
         public bool PC
         {
             get => _pc;
@@ -120,12 +131,14 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     _bypass = true;
                     OnPropertyChanged(nameof(Bypass));
                     OnPropertyChanged(nameof(ModLoader));
+                    OnPropertyChanged(nameof(PatchVisible));
                 }
                 else
                 {
                     _bypass = false;
                     OnPropertyChanged(nameof(Bypass));
                     OnPropertyChanged(nameof(ModLoader));
+                    OnPropertyChanged(nameof(PatchVisible));
                 }
             }
         }
@@ -331,6 +344,12 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         Bypass = false;
                 }
             });
+
+            DevViewCommand = new RelayCommand(_ =>
+            {
+                DevView = !DevView;                
+            });
+
             OpenLinkCommand = new RelayCommand(url => Process.Start(new ProcessStartInfo(url as string)
             {
                 UseShellExecute = true

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -35,6 +35,8 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         private Pcsx2Injector _pcsx2Injector;
         private Process _runningProcess;
         private bool _isBuilding;
+        private bool _pc;
+        private bool _bypass;
 
         private const string RAW_FILES_FOLDER_NAME = "raw";
         private const string ORIGINAL_FILES_FOLDER_NAME = "original";
@@ -80,6 +82,43 @@ namespace OpenKh.Tools.ModsManager.ViewModels
 
         public Visibility IsModInfoVisible => IsModSelected ? Visibility.Visible : Visibility.Collapsed;
         public Visibility IsModUnselectedMessageVisible => !IsModSelected ? Visibility.Visible : Visibility.Collapsed;
+        public Visibility PatchVisible => PC ? Visibility.Visible : Visibility.Collapsed;
+
+        public Visibility ModLoader => !PC || Bypass ? Visibility.Visible : Visibility.Collapsed;
+
+        public bool PC
+        {
+            get => _pc;
+            set
+            {
+                _pc = value;
+                if (ConfigurationService.GameEdition == 2)
+                {
+                    _pc = true;
+                }
+                else
+                {
+                    _pc = false;
+                }
+            }
+        }
+
+        public bool Bypass
+        {
+            get => _bypass;
+            set
+            {
+                _bypass = value;
+                if (ConfigurationService.BypassLauncher)
+                {
+                    _bypass = true;
+                }
+                else
+                {
+                    _bypass = false;
+                }
+            }
+        }
 
         public bool IsBuilding
         {
@@ -99,6 +138,13 @@ namespace OpenKh.Tools.ModsManager.ViewModels
 
         public MainViewModel()
         {
+            if (ConfigurationService.GameEdition == 2)
+                PC = true;
+            else
+                PC = false;
+            if (ConfigurationService.BypassLauncher)
+                Bypass = true;
+
             Log.OnLogDispatch += (long ms, string tag, string message) =>
                 _debuggingWindow.Log(ms, tag, message);
 

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -95,10 +95,16 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 if (ConfigurationService.GameEdition == 2)
                 {
                     _pc = true;
+                    OnPropertyChanged(nameof(PC));
+                    OnPropertyChanged(nameof(ModLoader));
+                    OnPropertyChanged(nameof(PatchVisible));
                 }
                 else
                 {
                     _pc = false;
+                    OnPropertyChanged(nameof(PC));
+                    OnPropertyChanged(nameof(ModLoader));
+                    OnPropertyChanged(nameof(PatchVisible));
                 }
             }
         }
@@ -112,10 +118,14 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 if (ConfigurationService.BypassLauncher)
                 {
                     _bypass = true;
+                    OnPropertyChanged(nameof(Bypass));
+                    OnPropertyChanged(nameof(ModLoader));
                 }
                 else
                 {
                     _bypass = false;
+                    OnPropertyChanged(nameof(Bypass));
+                    OnPropertyChanged(nameof(ModLoader));
                 }
             }
         }
@@ -311,6 +321,14 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                                 $"show_console={false}",
                             });
                     }
+                    if (ConfigurationService.GameEdition == 2)
+                        PC = true;
+                    else
+                        PC = false;
+                    if (ConfigurationService.BypassLauncher)
+                        Bypass = true;
+                    else
+                        Bypass = false;
                 }
             });
             OpenLinkCommand = new RelayCommand(url => Process.Start(new ProcessStartInfo(url as string)

--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -227,6 +227,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
 
         public RelayCommand InstallPanaceaCommand { get; }
         public RelayCommand RemovePanaceaCommand { get; }
+        public bool PanaceaInstalled { get; set; }
         private string PanaceaSourceLocation => Path.Combine(AppContext.BaseDirectory, PanaceaDllName);
         private string PanaceaDestinationLocation => Path.Combine(PcReleaseLocation, "DBGHELP.dll");
         public Visibility PanaceaNotInstalledVisibility => !IsLastPanaceaVersionInstalled ? Visibility.Visible : Visibility.Collapsed;
@@ -236,17 +237,27 @@ namespace OpenKh.Tools.ModsManager.ViewModels
             get
             {
                 if (PcReleaseLocation == null)
+                {
                     // Won't be able to find the source location
+                    PanaceaInstalled = false;
                     return false;
+                }
 
                 if (!File.Exists(PanaceaSourceLocation))
+                {
                     // While debugging it is most likely to not have the compiled
                     // DLL into the right place. So don't bother.
+                    PanaceaInstalled = true;
                     return true;
+                }
+                  
 
                 if (!File.Exists(PanaceaDestinationLocation))
+                {
                     // DBGHELP.dll is not installed
+                    PanaceaInstalled = false;
                     return false;
+                }
 
                 byte[] CalculateChecksum(string fileName) =>
                     System.Security.Cryptography.MD5.Create().Using(md5 =>
@@ -255,7 +266,11 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 {
                     for (var i = 0; i < left.Length; i++)
                         if (left[i] != right[i])
+                        {
+                            PanaceaInstalled = false;
                             return false;
+                        }
+                    PanaceaInstalled = false;
                     return true;
                 }
 
@@ -265,18 +280,6 @@ namespace OpenKh.Tools.ModsManager.ViewModels
             }
         }
 
-        public Visibility BypassLauncherVisibility => BypassLauncher ? Visibility.Visible : Visibility.Collapsed;
-        private bool _bypassLauncher;
-
-        public bool BypassLauncher
-        {
-            get => _bypassLauncher;
-            set
-            {
-                _bypassLauncher = value;
-                OnPropertyChanged(nameof(BypassLauncherVisibility));
-            }
-        }
         public string EpicGamesUserID { get; set; }
 
         public SetupWizardViewModel()
@@ -320,6 +323,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 OnPropertyChanged(nameof(IsLastPanaceaVersionInstalled));
                 OnPropertyChanged(nameof(PanaceaInstalledVisibility));
                 OnPropertyChanged(nameof(PanaceaNotInstalledVisibility));
+                PanaceaInstalled = true;
             });
             RemovePanaceaCommand = new RelayCommand(_ =>
             {
@@ -328,6 +332,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 OnPropertyChanged(nameof(IsLastPanaceaVersionInstalled));
                 OnPropertyChanged(nameof(PanaceaInstalledVisibility));
                 OnPropertyChanged(nameof(PanaceaNotInstalledVisibility));
+                PanaceaInstalled = false;
             });
         }
 

--- a/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
@@ -122,6 +122,7 @@
                         <Image Source="{StaticResource WebURL_16x}"/>
                     </MenuItem.Icon>
                 </MenuItem>
+                <MenuItem Header="Dev View" IsCheckable="True" Command="{Binding DevViewCommand}"/>
             </MenuItem>
         </Menu>
 

--- a/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
@@ -64,16 +64,17 @@
                 <Separator/>
                 <MenuItem Header="E_xit" Command="{Binding ExitCommand}" InputGestureText="Alt+F4"/>
             </MenuItem>
-            <MenuItem Header="Game">
-                <MenuItem Header="Build...">
-                    <MenuItem Header="Build Only" Command="{Binding BuildCommand}" InputGestureText="Ctrl+B"/>
-                    <MenuItem Header="Build and Patch [PC]" Command="{Binding PatchCommand}" CommandParameter="false" InputGestureText="Ctrl+P"/>
-                    <MenuItem Header="Build and Patch [Fast/PC]" Command="{Binding PatchCommand}" CommandParameter="true" InputGestureText="Ctrl+P+F"/>
-                    <MenuItem Header="Build and Run [OpenKH/PCSX2/PC]" Command="{Binding BuildAndRunCommand}" InputGestureText="F5"/>
-                </MenuItem>
+            <MenuItem Header="Mod Loader" Visibility="{Binding ModLoader}">
+                <MenuItem Header="Build Only" Command="{Binding BuildCommand}" InputGestureText="Ctrl+B"/>
                 <MenuItem Header="Run [OpenKH/PCSX2/PC]" Command="{Binding RunCommand}" InputGestureText="Ctrl+F5"/>
+                <MenuItem Header="Build and Run [OpenKH/PCSX2/PC]" Command="{Binding BuildAndRunCommand}" InputGestureText="F5"/>
+                <MenuItem Header="Stop [PCSX2]" Command="{Binding StopRunningInstanceCommand}" InputGestureText="Shift+F5"/>
+            </MenuItem>
+            <MenuItem Header="PC" Visibility="{Binding PatchVisible}">
+                <MenuItem Header="Build Only" Command="{Binding BuildCommand}" InputGestureText="Ctrl+B"/>
+                <MenuItem Header="Build and Patch [PC]" Command="{Binding PatchCommand}" CommandParameter="false" InputGestureText="Ctrl+P"/>
+                <MenuItem Header="Build and Patch [Fast/PC]" Command="{Binding PatchCommand}" CommandParameter="true" InputGestureText="Ctrl+P+F"/>
                 <MenuItem Header="Restore [PC]" Command="{Binding RestoreCommand}" InputGestureText="Ctrl+R"/>
-                <MenuItem Header="Stop" Command="{Binding StopRunningInstanceCommand}" InputGestureText="Shift+F5"/>
             </MenuItem>
             <MenuItem Header="_Settings">
                 <MenuItem Header="Run _wizard" Command="{Binding WizardCommand}" InputGestureText="Alt+W"/>

--- a/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
@@ -65,9 +65,9 @@
                 <MenuItem Header="E_xit" Command="{Binding ExitCommand}" InputGestureText="Alt+F4"/>
             </MenuItem>
             <MenuItem Header="Mod Loader" Visibility="{Binding ModLoader}">
+                <MenuItem Header="Build and Run [OpenKH/PCSX2/PC]" Command="{Binding BuildAndRunCommand}" InputGestureText="F5"/>
                 <MenuItem Header="Build Only" Command="{Binding BuildCommand}" InputGestureText="Ctrl+B"/>
                 <MenuItem Header="Run [OpenKH/PCSX2/PC]" Command="{Binding RunCommand}" InputGestureText="Ctrl+F5"/>
-                <MenuItem Header="Build and Run [OpenKH/PCSX2/PC]" Command="{Binding BuildAndRunCommand}" InputGestureText="F5"/>
                 <MenuItem Header="Stop [PCSX2]" Command="{Binding StopRunningInstanceCommand}" InputGestureText="Shift+F5"/>
             </MenuItem>
             <MenuItem Header="PC" Visibility="{Binding PatchVisible}">

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -238,18 +238,8 @@
             Description="Change the way the launcher behaves."
             PreviousPage="{Binding ElementName=PageEosInstall}"
             NextPage="{Binding ElementName=PageGameData}">
-            <StackPanel>
-                <TextBlock Margin="0 0 0 3" TextWrapping="Wrap">
-                    To run the game within the Mods Manager, you need to bypass the launcher.
-                    You only need it to if you often change mods so you can test them faster
-                    or if you are developing one.
-                </TextBlock>
-                <CheckBox
-                    Margin="0 0 0 10"
-                    IsChecked="{Binding BypassLauncher}"
-                    Content="Bypass the launcher"/>
-
-                <StackPanel Visibility="{Binding BypassLauncherVisibility}">
+            <StackPanel>               
+                <StackPanel>
                     <Grid Margin="0 0 0 3">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml.cs
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml.cs
@@ -32,8 +32,8 @@ namespace OpenKh.Tools.ModsManager.Views
         public string ConfigPcReleaseLocation { get => _vm.PcReleaseLocation; set => _vm.PcReleaseLocation = value; }
         public string ConfigGameDataLocation { get => _vm.GameDataLocation; set => _vm.GameDataLocation = value; }
         public int ConfigRegionId { get => _vm.RegionId; set => _vm.RegionId = value; }
-        public bool ConfigBypassLauncher { get => _vm.BypassLauncher; set => _vm.BypassLauncher = value; }
         public string ConfigEpicGamesUserID { get => _vm.EpicGamesUserID; set => _vm.EpicGamesUserID = value; }
+        public bool ConfigPanaceaInstalled { get => _vm.PanaceaInstalled; set => _vm.PanaceaInstalled = value; }
 
         private void Wizard_Finish(object sender, Xceed.Wpf.Toolkit.Core.CancelRoutedEventArgs e)
         {


### PR DESCRIPTION
Also hide a menu if it cannot be used. If a setting is updated by running the wizard a restart of the Mod Manager is required to properly hide or display a menu if the changed setting means one of the two menus visibility should change.

I had added some code to the end of the wizard relay command so whenever the wizard was run the variables were properly updated but without refreshing/redrawing? the Mod Manager window the visibility of the Mod Loader or PC Menu wouldnt change without restarting Mod Manager entirely
```
if (ConfigurationService.GameEdition == 2)
{
   PC = true;
}
else
{
   PC = false;
}
```