### PR TITLE
[KH2SystemEditor] Split StatEntry ushort into two separate bytes.

### DIFF
--- a/OpenKh.Kh2/SystemData/Item.cs
+++ b/OpenKh.Kh2/SystemData/Item.cs
@@ -49,7 +49,8 @@ namespace OpenKh.Kh2.SystemData
             [Data] public byte Flag0 { get; set; }
             [Data] public byte Flag1 { get; set; }
             [Data] public Rank Rank { get; set; }
-            [Data] public ushort StatEntry { get; set; }
+            [Data] public byte StatEntry { get; set; }
+            [Data] public byte APCost { get; set; }
             [Data] public ushort Name { get; set; }
             [Data] public ushort Description { get; set; }
             [Data] public ushort ShopBuy { get; set; }

--- a/OpenKh.Tools.Kh2SystemEditor/Models/Export/ItemExport.cs
+++ b/OpenKh.Tools.Kh2SystemEditor/Models/Export/ItemExport.cs
@@ -34,7 +34,9 @@ namespace OpenKh.Tools.Kh2SystemEditor.Models.Export
         [ExportTarget]
         public Item.Rank Rank => Item.Rank;
         [ExportTarget]
-        public ushort StatEntry => Item.StatEntry;
+        public byte StatEntry => Item.StatEntry;
+        [ExportTarget]
+        public byte APCost => Item.APCost;
         [ExportTarget]
         public ushort NameId => Item.Name;
         [ExportTarget]

--- a/OpenKh.Tools.Kh2SystemEditor/ViewModels/ItemViewModel.cs
+++ b/OpenKh.Tools.Kh2SystemEditor/ViewModels/ItemViewModel.cs
@@ -36,7 +36,8 @@ namespace OpenKh.Tools.Kh2SystemEditor.ViewModels
             public byte Flag0  { get => Item.Flag0; set => Item.Flag0 = value; }
             public byte Flag1  { get => Item.Flag1; set => Item.Flag1 = value; }
             public Item.Rank Rank { get => Item.Rank; set => Item.Rank = value; }
-            public ushort StatEntry  { get => Item.StatEntry; set => Item.StatEntry = value; }
+            public byte StatEntry  { get => Item.StatEntry; set => Item.StatEntry = value; }
+            public byte APCost { get => Item.APCost; set => Item.APCost = value; }
             public ushort NameId
             {
                 get => Item.Name;

--- a/OpenKh.Tools.Kh2SystemEditor/Views/ItemView.xaml
+++ b/OpenKh.Tools.Kh2SystemEditor/Views/ItemView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="OpenKh.Tools.Kh2SystemEditor.Views.ItemView"
+<UserControl x:Class="OpenKh.Tools.Kh2SystemEditor.Views.ItemView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -93,6 +93,10 @@
 
                 <TextBlock Text="StatEntry" Margin="{StaticResource LabelMargin}"/>
                 <TextBox Text="{Binding StatEntry, UpdateSourceTrigger=PropertyChanged}"/>
+
+                <TextBlock Text="APCost" Margin="{StaticResource LabelMargin}"/>
+                <TextBox Text="{Binding APCost, UpdateSourceTrigger=PropertyChanged}"/>
+
 
                 <TextBlock Text="Name" Margin="{StaticResource LabelMargin}"/>
                 <Grid>


### PR DESCRIPTION
Currently in KH2SystemEditor, The StatEntry category in the Item category is a ushort. It should be two separate bytes however, one for StatEntry, and the other APCost for abilities. This fixes an issue where abilities would have StatEntry's of 256, 512, 1024, allowing them to be more easily modified.


![image](https://user-images.githubusercontent.com/72351816/190619202-db95a209-9d77-4aca-93e9-20925a587015.png)
This image demonstrates the changes. Once More goes from having a StatEntry of 1024 (being read as 0x0400) to having an APCost of 4 (being read as 0x04)