### PR TITLE
Edited mod manager for recent panacea PR to remove Bypass

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -34,7 +34,6 @@ namespace OpenKh.Tools.ModsManager.Services
             public string Pcsx2Location { get; internal set; }
             public string PcReleaseLocation { get; internal set; }
             public int RegionId { get; internal set; }
-            public string EpicGamesUserID { get; internal set; }
             public bool PanaceaInstalled { get; internal set; }
 
             public void Save(string fileName)
@@ -194,15 +193,7 @@ namespace OpenKh.Tools.ModsManager.Services
                 _config.Save(ConfigPath);
             }
         }
-        public static string EpicGamesUserID
-        {
-            get => _config.EpicGamesUserID;
-            set
-            {
-                _config.EpicGamesUserID = value;
-                _config.Save(ConfigPath);
-            }
-        }
+
         public static bool PanaceaInstalled
         {
             get => _config.PanaceaInstalled;

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -86,6 +86,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         public Visibility IsModUnselectedMessageVisible => !IsModSelected ? Visibility.Visible : Visibility.Collapsed;
         public Visibility PatchVisible => PC && !PanaceaInstalled || PC && DevView ? Visibility.Visible : Visibility.Collapsed;
         public Visibility ModLoader => !PC || PanaceaInstalled ? Visibility.Visible : Visibility.Collapsed;
+        public Visibility BRVisible => !PC ? Visibility.Visible : Visibility.Collapsed;
 
         public bool DevView
         {
@@ -119,6 +120,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     OnPropertyChanged(nameof(PC));
                     OnPropertyChanged(nameof(ModLoader));
                     OnPropertyChanged(nameof(PatchVisible));
+                    OnPropertyChanged(nameof(BRVisible));
                 }
                 else
                 {
@@ -126,6 +128,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     OnPropertyChanged(nameof(PC));
                     OnPropertyChanged(nameof(ModLoader));
                     OnPropertyChanged(nameof(PatchVisible));
+                    OnPropertyChanged(nameof(BRVisible));
                 }
             }
         }       
@@ -296,7 +299,6 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     ConfigPcsx2Location = ConfigurationService.Pcsx2Location,
                     ConfigPcReleaseLocation = ConfigurationService.PcReleaseLocation,
                     ConfigRegionId = ConfigurationService.RegionId,
-                    ConfigEpicGamesUserID = ConfigurationService.EpicGamesUserID,
                     ConfigPanaceaInstalled = ConfigurationService.PanaceaInstalled,
                 };
                 if (dialog.ShowDialog() == true)
@@ -308,7 +310,6 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     ConfigurationService.Pcsx2Location = dialog.ConfigPcsx2Location;
                     ConfigurationService.PcReleaseLocation = dialog.ConfigPcReleaseLocation;
                     ConfigurationService.RegionId = dialog.ConfigRegionId;
-                    ConfigurationService.EpicGamesUserID = dialog.ConfigEpicGamesUserID;
                     ConfigurationService.PanaceaInstalled = dialog.ConfigPanaceaInstalled;
                     ConfigurationService.IsFirstRunComplete = true;
 
@@ -424,17 +425,12 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     isPcsx2 = true;
                     break;
                 case 2:
-                    Log.Info("Starting Kingdom Hearts II: Final Mix");
-                    processStartInfo = new ProcessStartInfo
-                    {
-                        FileName = Path.Combine(ConfigurationService.PcReleaseLocation, "KINGDOM HEARTS II FINAL MIX.exe"),
-                        WorkingDirectory = ConfigurationService.PcReleaseLocation,
-                        Arguments = $"-AUTH_TYPE=refreshtoken -epiclocale=en -epicuserid={ConfigurationService.EpicGamesUserID} -eosoverride",
-                        RedirectStandardOutput = true,
-                        RedirectStandardError = true,
-                        UseShellExecute = false,
-                    };
-                    break;
+                    MessageBox.Show(
+                        "You cannot run the PC game from the Mods Manager. Choose Build Only then start the game as you normally would.",
+                        "Unable to start the game",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Warning);
+                    return Task.CompletedTask;
                 default:
                     return Task.CompletedTask;
             }

--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -270,7 +270,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                             PanaceaInstalled = false;
                             return false;
                         }
-                    PanaceaInstalled = false;
+                    PanaceaInstalled = true;
                     return true;
                 }
 
@@ -279,8 +279,6 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     CalculateChecksum(PanaceaDestinationLocation));
             }
         }
-
-        public string EpicGamesUserID { get; set; }
 
         public SetupWizardViewModel()
         {

--- a/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
@@ -65,13 +65,12 @@
                 <MenuItem Header="E_xit" Command="{Binding ExitCommand}" InputGestureText="Alt+F4"/>
             </MenuItem>
             <MenuItem Header="Mod Loader" Visibility="{Binding ModLoader}">
-                <MenuItem Header="Build and Run [OpenKH/PCSX2/PC]" Command="{Binding BuildAndRunCommand}" InputGestureText="F5"/>
+                <MenuItem Header="Build and Run [OpenKH/PCSX2]" Command="{Binding BuildAndRunCommand}" InputGestureText="F5" Visibility="{Binding BRVisible}"/>
                 <MenuItem Header="Build Only" Command="{Binding BuildCommand}" InputGestureText="Ctrl+B"/>
-                <MenuItem Header="Run [OpenKH/PCSX2/PC]" Command="{Binding RunCommand}" InputGestureText="Ctrl+F5"/>
+                <MenuItem Header="Run [OpenKH/PCSX2]" Command="{Binding RunCommand}" InputGestureText="Ctrl+F5"/>
                 <MenuItem Header="Stop [PCSX2]" Command="{Binding StopRunningInstanceCommand}" InputGestureText="Shift+F5"/>
             </MenuItem>
             <MenuItem Header="PC" Visibility="{Binding PatchVisible}">
-                <MenuItem Header="Build Only" Command="{Binding BuildCommand}" InputGestureText="Ctrl+B"/>
                 <MenuItem Header="Build and Patch [PC]" Command="{Binding PatchCommand}" CommandParameter="false" InputGestureText="Ctrl+P"/>
                 <MenuItem Header="Build and Patch [Fast/PC]" Command="{Binding PatchCommand}" CommandParameter="true" InputGestureText="Ctrl+P+F"/>
                 <MenuItem Header="Restore [PC]" Command="{Binding RestoreCommand}" InputGestureText="Ctrl+R"/>

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -195,7 +195,7 @@
             Title="Install OpenKH Panacea (Optional and Experimental)"
             Description="Install automatic mod loading support into the game's folder."
             PreviousPage="{Binding ElementName=PageGameEdition}"
-            NextPage="{Binding ElementName=PageEosConfig}">
+            NextPage="{Binding ElementName=PageGameData}">
             <StackPanel>
                 <TextBlock Margin="0 0 0 3" TextWrapping="Wrap">
                         OpenKH Panacea allows the PC version of Kingdom Hearts to load the mods you have installed, without
@@ -230,43 +230,7 @@
                         Command="{Binding RemovePanaceaCommand}"/>
                 </StackPanel>
             </StackPanel>
-        </xctk:WizardPage>
-        <xctk:WizardPage
-            x:Name="PageEosConfig"
-            PageType="Interior"
-            Title="Configure Kingdom Hearts HD 1.5+2.5 ReMIX"
-            Description="Change the way the launcher behaves."
-            PreviousPage="{Binding ElementName=PageEosInstall}"
-            NextPage="{Binding ElementName=PageGameData}">
-            <StackPanel>               
-                <StackPanel>
-                    <Grid Margin="0 0 0 3">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock
-                            Grid.Column="0"
-                            Text="Epic Games User ID"
-                            Margin="0 0 3 0"/>
-                        <TextBox
-                            Grid.Column="1"
-                            Width="Auto"
-                            Text="{Binding EpicGamesUserID}"/>
-                    </Grid>
-                    <TextBlock Margin="0 0 0 3" TextWrapping="Wrap">
-                        When bypassing the launcher, you need to specify your Epic Games User ID otherwise your
-                        existing saves will not work. Click the link below to find you User ID. It is right after
-                        the Account Info text.
-                        <Hyperlink NavigateUri="https://www.epicgames.com/account/personal"
-                                   TextDecorations="{x:Null}" RequestNavigate="NavigateURL">
-                            <TextBlock Text="https://www.epicgames.com/account/personal"
-                                       Foreground="{DynamicResource textHyperlink}"/>
-                        </Hyperlink>
-                    </TextBlock>
-                </StackPanel>
-            </StackPanel>
-        </xctk:WizardPage>
+        </xctk:WizardPage>        
         <xctk:WizardPage
             x:Name="LastPage"
             PageType="Exterior"

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml.cs
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml.cs
@@ -20,7 +20,6 @@ namespace OpenKh.Tools.ModsManager.Views
 
             _vm.PageIsoSelection = PageIsoSelection;
             _vm.PageEosInstall = PageEosInstall;
-            _vm.PageEosConfig = PageEosConfig;
             _vm.PageRegion = PageRegion;
             _vm.LastPage = LastPage;
         }
@@ -32,7 +31,6 @@ namespace OpenKh.Tools.ModsManager.Views
         public string ConfigPcReleaseLocation { get => _vm.PcReleaseLocation; set => _vm.PcReleaseLocation = value; }
         public string ConfigGameDataLocation { get => _vm.GameDataLocation; set => _vm.GameDataLocation = value; }
         public int ConfigRegionId { get => _vm.RegionId; set => _vm.RegionId = value; }
-        public string ConfigEpicGamesUserID { get => _vm.EpicGamesUserID; set => _vm.EpicGamesUserID = value; }
         public bool ConfigPanaceaInstalled { get => _vm.PanaceaInstalled; set => _vm.PanaceaInstalled = value; }
 
         private void Wizard_Finish(object sender, Xceed.Wpf.Toolkit.Core.CancelRoutedEventArgs e)


### PR DESCRIPTION
Also hid Build and Run if using Panacea on PC. Didnt hide run or stop even though it doesnt work on PC so the menu isnt one option hid build and run so build only is the first option for panacea. Main memory mentioned the possibility of making mod manager launch a shortcut for KH that you can make through epic games.
`com.epicgames.launcher://apps/4158b699dd70447a981fee752d970a3e%3A5aac304f0e8948268ddfd404334dbdc7%3A68c214c58f694ae88c2dab6f209b43e4?action=launch&silent=true`
but this shortcut would need to be consistent or a variable added so the end user can enable build and run through means the EGS already allows