### PR TITLE
Add option to listpatch the cmd bar subfile in 03system.bin.

### DIFF
--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -569,8 +569,28 @@ namespace OpenKh.Patcher
                             }
                             Kh2.Battle.Plrp.Write(stream.SetPosition(0), plrpList);
                         break;
+                    case "cmd":
+                        var cmdList = Kh2.SystemData.Cmd.Read(stream).ToDictionary(x => x.Id, x => x);
+                        var moddedCmd = deserializer.Deserialize<Dictionary<ushort, Kh2.SystemData.Cmd>>(sourceText);
+                        foreach (var command in moddedCmd)
+                        {
+                            if (cmdList.ContainsKey(command.Key))
 
-                        default:
+                                {
+                                    cmdList[command.Key] = command.Value;
+                                }
+                            
+                            else
+                            {
+                                cmdList.Add(command.Key, command.Value);
+                            }
+
+                        }
+                        Kh2.SystemData.Cmd.Write(stream.SetPosition(0), cmdList.Values);
+                        break;
+
+
+                    default:
                             break;
                     }
              }

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -715,7 +715,7 @@ namespace OpenKh.Tests.Patcher
              {
                  var binarc = Bar.Read(stream);
                  var cmdStream = Kh2.SystemData.Cmd.Read(binarc[0].Stream);
-                 Assert.Equal(3, cmdStream[0].Id);
+                 Assert.Equal(1, cmdStream[0].Id);
                  Assert.Equal(3, cmdStream[0].Execute);
                  Assert.Equal(3, cmdStream[0].Argument);
                  Assert.Equal(1, cmdStream[0].SubMenu);

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -678,9 +678,9 @@ namespace OpenKh.Tests.Patcher
                     new Kh2.SystemData.Cmd
                     {
                         Id = 1,
-                        Execute = 3
-                        Argument = 3
-                        SubMenu = 1
+                        Execute = 3,
+                        Argument = 3,
+                        SubMenu = 1,
                         CmdIcon = 2
                     }
                     };

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -639,6 +639,7 @@ namespace OpenKh.Tests.Patcher
 
         }
         
+        [Fact]
         public void ListPatchCmdTest()
         {
             var patcher = new PatcherProcessor();
@@ -681,7 +682,6 @@ namespace OpenKh.Tests.Patcher
                         Execute = 3,
                         Argument = 3,
                         SubMenu = 1,
-                        CmdIcon = 2
                     }
                     };
                 using var cmdStream = new MemoryStream();
@@ -704,7 +704,6 @@ namespace OpenKh.Tests.Patcher
                 writer.WriteLine("  Execute: 3");
                 writer.WriteLine("  Argument: 3");
                 writer.WriteLine("  SubMenu: 1");
-                writer.WriteLine("  CmdIcon: 2");
                 writer.Flush();
             });
 
@@ -720,7 +719,6 @@ namespace OpenKh.Tests.Patcher
                  Assert.Equal(3, cmdStream[0].Execute);
                  Assert.Equal(3, cmdStream[0].Argument);
                  Assert.Equal(1, cmdStream[0].SubMenu);
-                 Assert.Equal(2, cmdStream[0].CmdIcon);
              });
 
         }

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -638,7 +638,93 @@ namespace OpenKh.Tests.Patcher
              });
 
         }
+        
+        public void ListPatchCmdTest()
+        {
+            var patcher = new PatcherProcessor();
+            var serializer = new Serializer();
+            var patch = new Metadata() { 
+                Assets = new List<AssetFile>()
+                {
+                    new AssetFile()
+                    {
+                        Name = "03system.bar",
+                        Method = "binarc",
+                        Source = new List<AssetFile>()
+                        {
+                            new AssetFile()
+                            {
+                                Name = "cmd",
+                                Method = "listpatch",
+                                Type = "List",
+                                Source = new List<AssetFile>()
+                                {
+                                    new AssetFile()
+                                    {
+                                        Name = "CmdList.yml",
+                                        Type = "cmd"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
 
+            File.Create(Path.Combine(AssetsInputDir, "03system.bar")).Using(stream =>
+            {
+                var cmdEntry = new List<Kh2.SystemData.Cmd>()
+                {
+                    new Kh2.SystemData.Cmd
+                    {
+                        Id = 1,
+                        Execute = 3
+                        Argument = 3
+                        SubMenu = 1
+                        CmdIcon = 2
+                    }
+                    };
+                using var cmdStream = new MemoryStream();
+                Kh2.SystemData.Cmd.Write(cmdStream, cmdEntry);
+                Bar.Write(stream, new Bar() {
+                    new Bar.Entry()
+                    {
+                        Name = "cmd",
+                        Type = Bar.EntryType.List,
+                        Stream = cmdStream
+                    }
+                });
+            });
+
+            File.Create(Path.Combine(ModInputDir, "CmdList.yml")).Using(stream =>
+            {
+                var writer = new StreamWriter(stream);
+                writer.WriteLine("1:");
+                writer.WriteLine("  Id: 1");
+                writer.WriteLine("  Execute: 3");
+                writer.WriteLine("  Argument: 3");
+                writer.WriteLine("  SubMenu: 1");
+                writer.WriteLine("  CmdIcon: 2");
+                writer.Flush();
+            });
+
+            patcher.Patch(AssetsInputDir, ModOutputDir, patch, ModInputDir);
+
+            AssertFileExists(ModOutputDir, "03system.bar");
+
+            File.OpenRead(Path.Combine(ModOutputDir, "03system.bar")).Using(stream =>
+             {
+                 var binarc = Bar.Read(stream);
+                 var cmdStream = Kh2.SystemData.Cmd.Read(binarc[0].Stream);
+                 Assert.Equal(3, cmdStream[0].Id);
+                 Assert.Equal(3, cmdStream[0].Execute);
+                 Assert.Equal(3, cmdStream[0].Argument);
+                 Assert.Equal(1, cmdStream[0].SubMenu);
+                 Assert.Equal(2, cmdStream[0].CmdIcon);
+             });
+
+        }
+        
         [Fact]
         public void ListPatchItemTest()
         {

--- a/docs/tool/GUI.ModsManager/index.md
+++ b/docs/tool/GUI.ModsManager/index.md
@@ -185,6 +185,7 @@ Asset Example
 
 * `listpatch` (KH2) - Can modify the following different types of list binaries found within KH2.
  * `trsr`
+ * `cmd`
  * `item`
  * `fmlv`
  * `lvup`
@@ -209,7 +210,34 @@ Asset Example
 2:
   ItemId: 347
 ```
-
+`cmd` Source Example
+```
+1:
+  Id: 1
+  Execute: 3
+  Argument: 3
+  SubMenu: 1
+  CmdIcon: 3
+  MessageId: 33249
+  Flags: 49
+  Range: -1
+  Dir: 0
+  DirRange: -1
+  Cost: 0
+  CmdCamera: 0
+  Priority: 100
+  CmdReceiver: 0
+  Time: 0
+  Require: 0
+  Mark: 1
+  CmdAction: 0
+  ReactionCount: 0
+  DistRange: 0
+  Score: 0
+  DisableForm: 63552
+  Group: 2
+  Reserve: 0
+```
 `item` Source Example
 ```
 Stats:


### PR DESCRIPTION
Adds cmd as a possible type for listpatching via .yml files using the Mod Manager.

cmdList.yml files are setup exactly like TrsrList.yml files.
![image](https://user-images.githubusercontent.com/72351816/191562735-e9821c27-3ad6-41c5-b156-0c38714bff1e.png)

The ID of the command being edited as the "title", (this should match the ID of the command being edited) followed by the edits inside to change an actual command. In this example, the "Attack" command found in the command menu has its text changed to use the text for "Magic".

This should allow for compatibility between multiple different mods that change the cmd file.