### PR TITLE
Update ConfigurationService.cs

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -54,11 +54,45 @@ namespace OpenKh.Tools.ModsManager.Services
                 return _deserializer.Deserialize<Config>(reader);
             }
         }
+        
+         private class FirstRun
+        {
+            private static readonly IDeserializer _deserializer =
+                new DeserializerBuilder()
+                .IgnoreFields()
+                .IgnoreUnmatchedProperties()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .Build();
+            private static readonly ISerializer _serializer =
+                new SerializerBuilder()
+                .IgnoreFields()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .Build();
+            
+            public bool IsFirstRunComplete { get; set; }
+
+            public void Save(string fileName)
+            {
+                using var writer = new StreamWriter(fileName);
+                _serializer.Serialize(writer, this);
+            }
+
+            public static FirstRun Open(string fileName)
+            {
+                if (!File.Exists(fileName))
+                    return new FirstRun();
+
+                using var reader = new StreamReader(fileName);
+                return _deserializer.Deserialize<FirstRun>(reader);
+            }
+        }
 
         private static string StoragePath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
         private static string ConfigPath = Path.Combine(StoragePath, "mods-manager.yml");
+        private static string FirstRunPath = Path.Combine(StoragePath, "first-run-complete.yml");
         private static string EnabledModsPath = Path.Combine(StoragePath, "mods.txt");
         private static readonly Config _config = Config.Open(ConfigPath);
+        private static readonly FirstRun __config = FirstRun.Open(FirstRunPath);
 
         static ConfigurationService()
         {
@@ -99,11 +133,11 @@ namespace OpenKh.Tools.ModsManager.Services
 
         public static bool IsFirstRunComplete
         {
-            get => _config.IsFirstRunComplete;
+            get => __config.IsFirstRunComplete;
             set
             {
-                _config.IsFirstRunComplete = value;
-                _config.Save(ConfigPath);
+                __config.IsFirstRunComplete = value;
+                __config.Save(FirstRunPath);
             }
         }
 

--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -24,7 +24,6 @@ namespace OpenKh.Tools.ModsManager.Services
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
                 .Build();
 
-            public bool IsFirstRunComplete { get; set; }
             public string ModCollectionPath { get; internal set; }
             public string GameModPath { get; internal set; }
             public string GameDataPath { get; internal set; }


### PR DESCRIPTION
Separate "IsFirstRunComplete" from base mods-manager.yml file into its own file. 

If changes are made to the mods manager that would require users to go through the setup wizard again we can provide the `first-run-complete.yml` with "isFirstRunComplete=False". This allows us to force the setup wizard to open after a user updates their mod manager. This can come in handy if support for more KH games or more ways to play KH on PC (if steam version comes out one day) is added to the mod manager and we need all users to re-verify their settings. It's also useful for Panacea Mod Loader updates as it can only be installed through the wizard and there's no way to know if there's an update outside of the setup wizard.