### PR TITLE
Updates to utilize panacea changes.

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -33,11 +33,11 @@ namespace OpenKh.Tools.ModsManager.Services
             public string OpenKhGameEngineLocation { get; internal set; }
             public string Pcsx2Location { get; internal set; }
             public string PcReleaseLocation { get; internal set; }
-            public string PcShortcutLocation { get; internal set; }
             public string PcReleaseLanguage { get; internal set; } = "en";
             public int RegionId { get; internal set; }
             public bool PanaceaInstalled { get; internal set; }
             public bool DevView { get; internal set; }
+            public bool isEGSVersion { get; internal set; } = true;
 
             public void Save(string fileName)
             {
@@ -186,15 +186,6 @@ namespace OpenKh.Tools.ModsManager.Services
                 _config.Save(ConfigPath);
             }
         }
-        public static string PcShortcutLocation
-        {
-            get => _config.PcShortcutLocation;
-            set
-            {
-                _config.PcShortcutLocation = value;
-                _config.Save(ConfigPath);
-            }
-        }
 
         public static string PcReleaseLanguage
         {
@@ -231,6 +222,15 @@ namespace OpenKh.Tools.ModsManager.Services
             set
             {
                 _config.DevView = value;
+                _config.Save(ConfigPath);
+            }
+        }
+        public static bool IsEGSVersion
+        {
+            get => _config.isEGSVersion;
+            set
+            {
+                _config.isEGSVersion = value;
                 _config.Save(ConfigPath);
             }
         }

--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -87,38 +87,6 @@ namespace OpenKh.Tools.ModsManager.Services
             }
         }
 
-        private class FirstRun
-        {
-            private static readonly IDeserializer _deserializer =
-                new DeserializerBuilder()
-                .IgnoreFields()
-                .IgnoreUnmatchedProperties()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .Build();
-            private static readonly ISerializer _serializer =
-                new SerializerBuilder()
-                .IgnoreFields()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .Build();
-
-            public bool IsFirstRunComplete { get; set; }
-
-            public void Save(string fileName)
-            {
-                using var writer = new StreamWriter(fileName);
-                _serializer.Serialize(writer, this);
-            }
-
-            public static FirstRun Open(string fileName)
-            {
-                if (!File.Exists(fileName))
-                    return new FirstRun();
-
-                using var reader = new StreamReader(fileName);
-                return _deserializer.Deserialize<FirstRun>(reader);
-            }
-        }
-
         private static string StoragePath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
         private static string ConfigPath = Path.Combine(StoragePath, "mods-manager.yml");
         private static string FirstRunPath = Path.Combine(StoragePath, "first-run-complete.yml");

--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -92,7 +92,7 @@ namespace OpenKh.Tools.ModsManager.Services
         private static string FirstRunPath = Path.Combine(StoragePath, "first-run-complete.yml");
         private static string EnabledModsPath = Path.Combine(StoragePath, "mods.txt");
         private static readonly Config _config = Config.Open(ConfigPath);
-        private static readonly FirstRun __config = FirstRun.Open(FirstRunPath);
+        private static readonly FirstRun _config2 = FirstRun.Open(FirstRunPath);
 
         static ConfigurationService()
         {
@@ -133,11 +133,11 @@ namespace OpenKh.Tools.ModsManager.Services
 
         public static bool IsFirstRunComplete
         {
-            get => __config.IsFirstRunComplete;
+            get => _config2.IsFirstRunComplete;
             set
             {
-                __config.IsFirstRunComplete = value;
-                __config.Save(FirstRunPath);
+                _config2.IsFirstRunComplete = value;
+                _config2.Save(FirstRunPath);
             }
         }
 

--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -24,7 +24,6 @@ namespace OpenKh.Tools.ModsManager.Services
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
                 .Build();
 
-            public bool IsFirstRunComplete { get; set; }
             public string ModCollectionPath { get; internal set; }
             public string GameModPath { get; internal set; }
             public string GameDataPath { get; internal set; }
@@ -33,6 +32,7 @@ namespace OpenKh.Tools.ModsManager.Services
             public string OpenKhGameEngineLocation { get; internal set; }
             public string Pcsx2Location { get; internal set; }
             public string PcReleaseLocation { get; internal set; }
+            public string PcShortcutLocation { get; internal set; }
             public string PcReleaseLanguage { get; internal set; } = "en";
             public int RegionId { get; internal set; }
             public bool PanaceaInstalled { get; internal set; }
@@ -55,10 +55,44 @@ namespace OpenKh.Tools.ModsManager.Services
             }
         }
 
+        private class FirstRun
+        {
+            private static readonly IDeserializer _deserializer =
+                new DeserializerBuilder()
+                .IgnoreFields()
+                .IgnoreUnmatchedProperties()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .Build();
+            private static readonly ISerializer _serializer =
+                new SerializerBuilder()
+                .IgnoreFields()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .Build();
+
+            public bool IsFirstRunComplete { get; set; }
+
+            public void Save(string fileName)
+            {
+                using var writer = new StreamWriter(fileName);
+                _serializer.Serialize(writer, this);
+            }
+
+            public static FirstRun Open(string fileName)
+            {
+                if (!File.Exists(fileName))
+                    return new FirstRun();
+
+                using var reader = new StreamReader(fileName);
+                return _deserializer.Deserialize<FirstRun>(reader);
+            }
+        }
+
         private static string StoragePath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
         private static string ConfigPath = Path.Combine(StoragePath, "mods-manager.yml");
+        private static string FirstRunPath = Path.Combine(StoragePath, "first-run-complete.yml");
         private static string EnabledModsPath = Path.Combine(StoragePath, "mods.txt");
         private static readonly Config _config = Config.Open(ConfigPath);
+        private static readonly FirstRun __config = FirstRun.Open(FirstRunPath);
 
         static ConfigurationService()
         {
@@ -99,11 +133,11 @@ namespace OpenKh.Tools.ModsManager.Services
 
         public static bool IsFirstRunComplete
         {
-            get => _config.IsFirstRunComplete;
+            get => __config.IsFirstRunComplete;
             set
             {
-                _config.IsFirstRunComplete = value;
-                _config.Save(ConfigPath);
+                __config.IsFirstRunComplete = value;
+                __config.Save(FirstRunPath);
             }
         }
 
@@ -183,6 +217,15 @@ namespace OpenKh.Tools.ModsManager.Services
             set
             {
                 _config.PcReleaseLocation = value;
+                _config.Save(ConfigPath);
+            }
+        }
+        public static string PcShortcutLocation
+        {
+            get => _config.PcShortcutLocation;
+            set
+            {
+                _config.PcShortcutLocation = value;
                 _config.Save(ConfigPath);
             }
         }

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -85,6 +85,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         public Visibility IsModUnselectedMessageVisible => !IsModSelected ? Visibility.Visible : Visibility.Collapsed;
         public Visibility PatchVisible => PC && !PanaceaInstalled || PC && DevView ? Visibility.Visible : Visibility.Collapsed;
         public Visibility ModLoader => !PC || PanaceaInstalled ? Visibility.Visible : Visibility.Collapsed;
+        public Visibility HideExtras => !PC ? Visibility.Visible : Visibility.Collapsed;
 
         public bool DevView
         {
@@ -116,6 +117,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 OnPropertyChanged(nameof(PC));
                 OnPropertyChanged(nameof(ModLoader));
                 OnPropertyChanged(nameof(PatchVisible));
+                OnPropertyChanged(nameof(HideExtras));
             }
         }
 
@@ -287,7 +289,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     ConfigPcReleaseLanguage = ConfigurationService.PcReleaseLanguage,
                     ConfigRegionId = ConfigurationService.RegionId,
                     ConfigPanaceaInstalled = ConfigurationService.PanaceaInstalled,
-                    ConfigPcShortcutLocation = ConfigurationService.PcShortcutLocation,
+                    ConfigIsEGSVersion = ConfigurationService.IsEGSVersion,
                 };
                 if (dialog.ShowDialog() == true)
                 {
@@ -299,7 +301,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     ConfigurationService.PcReleaseLocation = dialog.ConfigPcReleaseLocation;
                     ConfigurationService.RegionId = dialog.ConfigRegionId;
                     ConfigurationService.PanaceaInstalled = dialog.ConfigPanaceaInstalled;
-                    ConfigurationService.PcShortcutLocation = dialog.ConfigPcShortcutLocation;
+                    ConfigurationService.IsEGSVersion = dialog.ConfigIsEGSVersion;
                     ConfigurationService.IsFirstRunComplete = true;
 
                     const int EpicGamesPC = 2;
@@ -408,23 +410,28 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     isPcsx2 = true;
                     break;
                 case 2:
-                    if (!File.Exists(ConfigurationService.PcShortcutLocation))
+                    if (ConfigurationService.IsEGSVersion)
                     {
-                        MessageBox.Show(
-                            "You can only run the game from the Mods Manager by selecting a shortcut made through EGS.\nThere either is no shortcut provided or it has been renamed or moved.\nRepeat the wizard to locate the shortcut.",
-                            "Unable to start the game",
-                            MessageBoxButton.OK,
-                            MessageBoxImage.Warning);
+                        processStartInfo = new ProcessStartInfo
+                        {
+                            FileName = "com.epicgames.launcher://apps/4158b699dd70447a981fee752d970a3e%3A5aac304f0e8948268ddfd404334dbdc7%3A68c214c58f694ae88c2dab6f209b43e4?action=launch&silent=true",
+                            UseShellExecute = true,
+                        };
+                        Process.Start(processStartInfo);
+                        CloseAllWindows();
                         return Task.CompletedTask;
                     }
-                    processStartInfo = new ProcessStartInfo
+                    else
                     {
-                        FileName = ConfigurationService.PcShortcutLocation,
-                        UseShellExecute = true,
-                    };
-                    Process.Start(processStartInfo);
-                    CloseAllWindows();
-                    return Task.CompletedTask;
+                        processStartInfo = new ProcessStartInfo
+                        {
+                            FileName =  Path.Combine(ConfigurationService.PcReleaseLocation, "KINGDOM HEARTS II FINAL MIX.exe"),
+                            UseShellExecute = false,
+                        };
+                        Process.Start(processStartInfo);
+                        CloseAllWindows();
+                        return Task.CompletedTask;
+                    }
                 default:
                     return Task.CompletedTask;
             }

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -90,6 +90,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         public Visibility PatchVisible => PC && !PanaceaInstalled || PC && DevView ? Visibility.Visible : Visibility.Collapsed;
         public Visibility ModLoader => !PC || PanaceaInstalled ? Visibility.Visible : Visibility.Collapsed;
         public Visibility HideExtras => !PC ? Visibility.Visible : Visibility.Collapsed;
+        public Visibility QuickLaunchVis => PC && DevView ? Visibility.Visible : Visibility.Collapsed;
 
         public bool DevView
         {
@@ -99,6 +100,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 _devView = value;
                 ConfigurationService.DevView = DevView;
                 OnPropertyChanged(nameof(PatchVisible));
+                OnPropertyChanged(nameof(QuickLaunchVis));
             }
         }
         public bool PanaceaInstalled
@@ -360,7 +362,6 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                             {
                                 $"mod_path={ConfigurationService.GameModPath}",
                                 $"show_console={false}",
-                                $"quick_launch=off",
                             });
                     }
                     if (ConfigurationService.GameEdition == 2)

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -10,6 +10,9 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using Xe.Tools;
@@ -38,6 +41,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         private bool _pc;
         private bool _panaceaInstalled;
         private bool _devView;
+        private string _quickLaunch = "kh2";
 
         private const string RAW_FILES_FOLDER_NAME = "raw";
         private const string ORIGINAL_FILES_FOLDER_NAME = "original";
@@ -118,6 +122,32 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 OnPropertyChanged(nameof(ModLoader));
                 OnPropertyChanged(nameof(PatchVisible));
                 OnPropertyChanged(nameof(HideExtras));
+            }
+        }  
+
+        public int QuickLaunch
+        {
+            get => 0;
+            set            
+            {                
+                switch (value)
+                {
+                    case 0:
+                        _quickLaunch = "kh2";
+                        break;
+                    case 1:
+                        _quickLaunch = "kh1";
+                        break;
+                    case 2:
+                        _quickLaunch = "bbs";
+                        break;
+                    case 3:
+                        _quickLaunch = "recom";
+                        break;
+                    default:
+                        _quickLaunch = "off";
+                        break;
+                }
             }
         }
 
@@ -313,6 +343,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                             {
                                 $"mod_path={ConfigurationService.GameModPath}",
                                 $"show_console={false}",
+                                $"quick_launch=off",
                             });
                     }
                     if (ConfigurationService.GameEdition == 2)
@@ -412,6 +443,15 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 case 2:
                     if (ConfigurationService.IsEGSVersion)
                     {
+                        string[] file = File.ReadAllLines(Path.Combine(ConfigurationService.PcReleaseLocation, "panacea_settings.txt"));
+                        if (Array.Find(file, element => element.StartsWith("quick")) != null)
+                            file[Array.FindIndex(file, element => element.StartsWith("quick"))] = "quick_launch=" + _quickLaunch;
+                        else
+                        {
+                            Array.Resize(ref file, file.Length + 1);
+                            file[file.Length-1] = "quick_launch=" + _quickLaunch;                            
+                        }
+                        File.WriteAllLines(Path.Combine(ConfigurationService.PcReleaseLocation, "panacea_settings.txt"), file);                        
                         processStartInfo = new ProcessStartInfo
                         {
                             FileName = "com.epicgames.launcher://apps/4158b699dd70447a981fee752d970a3e%3A5aac304f0e8948268ddfd404334dbdc7%3A68c214c58f694ae88c2dab6f209b43e4?action=launch&silent=true",

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -127,8 +127,25 @@ namespace OpenKh.Tools.ModsManager.ViewModels
 
         public int QuickLaunch
         {
-            get => 0;
-            set            
+            get
+            {
+                switch (_quickLaunch)
+                {
+                    case "kh2":
+                        return 0;
+                    case "kh1":
+                        return 1;
+                    case "bbs":
+                        return 2;
+                    case "recom":
+                        return 3;
+                    case "off":
+                        return 4;
+                    default:
+                        return 0;
+                }
+            }
+            set          
             {                
                 switch (value)
                 {
@@ -444,13 +461,8 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     if (ConfigurationService.IsEGSVersion)
                     {
                         string[] file = File.ReadAllLines(Path.Combine(ConfigurationService.PcReleaseLocation, "panacea_settings.txt"));
-                        if (Array.Find(file, element => element.StartsWith("quick")) != null)
-                            file[Array.FindIndex(file, element => element.StartsWith("quick"))] = "quick_launch=" + _quickLaunch;
-                        else
-                        {
-                            Array.Resize(ref file, file.Length + 1);
-                            file[file.Length-1] = "quick_launch=" + _quickLaunch;                            
-                        }
+                        Array.Resize(ref file, file.Length + 1);
+                        file[file.Length-1] = "quick_launch=" + _quickLaunch;              
                         File.WriteAllLines(Path.Combine(ConfigurationService.PcReleaseLocation, "panacea_settings.txt"), file);                        
                         processStartInfo = new ProcessStartInfo
                         {

--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -30,9 +30,6 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         private static List<FileDialogFilter> _pcsx2Filter = FileDialogFilterComposer
             .Compose()
             .AddExtensions("PCSX2 Emulator", "exe");
-        private static List<FileDialogFilter> _pcShortcutFilter = FileDialogFilterComposer
-            .Compose()
-            .AddExtensions("PC Shortcut", "url", "lnk");
 
         const int OpenKHGameEngine = 0;
         const int PCSX2 = 1;
@@ -45,7 +42,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         private string _pcReleaseLocation;
         private string _pcReleaseLanguage;
         private string _gameDataLocation;
-        private string _pcShortcutLocation;
+        private bool _isEGSVersion;
 
         private Xceed.Wpf.Toolkit.WizardPage _wizardPageAfterIntro;
         public Xceed.Wpf.Toolkit.WizardPage WizardPageAfterIntro
@@ -71,7 +68,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         public Xceed.Wpf.Toolkit.WizardPage PageEosInstall { get; internal set; }
         public Xceed.Wpf.Toolkit.WizardPage PageEosConfig { get; internal set; }
         public Xceed.Wpf.Toolkit.WizardPage PageRegion { get; internal set; }
-        public Xceed.Wpf.Toolkit.WizardPage PCShortcutLocation { get; internal set; }
+        public Xceed.Wpf.Toolkit.WizardPage PCLaunchOption { get; internal set; }
         public Xceed.Wpf.Toolkit.WizardPage LastPage { get; internal set; }
 
         public WizardPageStackService PageStack { get; set; } = new WizardPageStackService();
@@ -191,7 +188,6 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         }
 
         public RelayCommand SelectPcReleaseCommand { get; }
-        public RelayCommand SelectPcShortcutCommand { get; }
         public Visibility PcReleaseConfigVisibility => GameEdition == EpicGames ? Visibility.Visible : Visibility.Collapsed;
         public string PcReleaseLocation
         {
@@ -207,12 +203,12 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 OnPropertyChanged(nameof(IsGameDataFound));
             }
         }
-        public string PcShortcutLocation
+        public bool IsEGSVersion
         {
-            get => _pcShortcutLocation;
+            get => _isEGSVersion;
             set
             {
-                _pcShortcutLocation = value;
+                _isEGSVersion = value;
                 OnPropertyChanged();
             }
         }
@@ -366,8 +362,6 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 OnPropertyChanged(nameof(PanaceaNotInstalledVisibility));
                 PanaceaInstalled = false;
             });
-            SelectPcShortcutCommand = new RelayCommand(_ =>
-               FileDialog.OnOpen(fileName => PcShortcutLocation = fileName, _pcShortcutFilter));
         }
 
         private async Task ExtractGameData(string isoLocation, string gameDataLocation)

--- a/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
@@ -76,8 +76,8 @@
                 <MenuItem Header="Restore" Command="{Binding RestoreCommand}" InputGestureText="Ctrl+R"/>
             </MenuItem>
             <MenuItem Header="_Settings">
-                <MenuItem Header="Run _wizard" Command="{Binding WizardCommand}" InputGestureText="Alt+W"/>
-                <ComboBox Width="62" SelectedIndex="{Binding QuickLaunch}">
+                <MenuItem Header="Run _wizard" Command="{Binding WizardCommand}"  InputGestureText="Alt+W"/>
+                <ComboBox MinWidth="62" SelectedIndex="{Binding QuickLaunch}" Visibility="{Binding QuickLaunchVis}">
                     <ComboBoxItem>kh2</ComboBoxItem>
                     <ComboBoxItem>kh1</ComboBoxItem>
                     <ComboBoxItem>bbs</ComboBoxItem>

--- a/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
@@ -65,15 +65,15 @@
                 <MenuItem Header="E_xit" Command="{Binding ExitCommand}" InputGestureText="Alt+F4"/>
             </MenuItem>
             <MenuItem Header="Mod Loader" Visibility="{Binding ModLoader}">
-                <MenuItem Header="Build and Run [OpenKH/PCSX2/PCShortcut]" Command="{Binding BuildAndRunCommand}" InputGestureText="F5"/>
-                <MenuItem Header="Build Only [OpenKH/PCSX2/PC]" Command="{Binding BuildCommand}" InputGestureText="Ctrl+B"/>
-                <MenuItem Header="Run [OpenKH/PCSX2/PCShortcut]" Command="{Binding RunCommand}" InputGestureText="Ctrl+F5"/>
-                <MenuItem Header="Stop [PCSX2]" Command="{Binding StopRunningInstanceCommand}" InputGestureText="Shift+F5"/>
+                <MenuItem Header="Build and Run" Command="{Binding BuildAndRunCommand}" InputGestureText="F5"/>
+                <MenuItem Header="Build Only" Command="{Binding BuildCommand}" InputGestureText="Ctrl+B"/>
+                <MenuItem Header="Run Only" Command="{Binding RunCommand}" InputGestureText="Ctrl+F5"/>
+                <MenuItem Header="Stop" Command="{Binding StopRunningInstanceCommand}" Visibility="{Binding HideExtras}" InputGestureText="Shift+F5"/>
             </MenuItem>
             <MenuItem Header="PC" Visibility="{Binding PatchVisible}">
-                <MenuItem Header="Build and Patch [PC]" Command="{Binding PatchCommand}" CommandParameter="false" InputGestureText="Ctrl+P"/>
-                <MenuItem Header="Build and Patch [Fast/PC]" Command="{Binding PatchCommand}" CommandParameter="true" InputGestureText="Ctrl+P+F"/>
-                <MenuItem Header="Restore [PC]" Command="{Binding RestoreCommand}" InputGestureText="Ctrl+R"/>
+                <MenuItem Header="Build and Patch" Command="{Binding PatchCommand}" CommandParameter="false" InputGestureText="Ctrl+P"/>
+                <MenuItem Header="Build and Fast Patch" Command="{Binding PatchCommand}" CommandParameter="true" InputGestureText="Ctrl+P+F"/>
+                <MenuItem Header="Restore" Command="{Binding RestoreCommand}" InputGestureText="Ctrl+R"/>
             </MenuItem>
             <MenuItem Header="_Settings">
                 <MenuItem Header="Run _wizard" Command="{Binding WizardCommand}" InputGestureText="Alt+W"/>

--- a/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
@@ -77,6 +77,13 @@
             </MenuItem>
             <MenuItem Header="_Settings">
                 <MenuItem Header="Run _wizard" Command="{Binding WizardCommand}" InputGestureText="Alt+W"/>
+                <ComboBox Width="62" SelectedIndex="{Binding QuickLaunch}">
+                    <ComboBoxItem>kh2</ComboBoxItem>
+                    <ComboBoxItem>kh1</ComboBoxItem>
+                    <ComboBoxItem>bbs</ComboBoxItem>
+                    <ComboBoxItem>recom</ComboBoxItem>
+                    <ComboBoxItem>off</ComboBoxItem>
+                </ComboBox>
             </MenuItem>
             <MenuItem Header="_Info">
                 <MenuItem IsEnabled="False">

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -241,7 +241,8 @@
             PreviousPage="{Binding PageStack.Back}"
             NextPage="{Binding ElementName=PageGameData}">
             <StackPanel>
-                <TextBlock Margin="0 0 0 3" TextWrapping="Wrap">Please select the KINGDOM HEARTS HD 1.5+2.5 ReMIX shortcut you created. To Create a shortcut in the Library view of EGS, right click the game, Manage, Create Desktop Shortcut</TextBlock>
+                <TextBlock Margin="0 0 0 3" TextAlignment="Center" TextWrapping="Wrap">**OPTIONAL: Shortcut Location**</TextBlock>
+                <TextBlock Margin="0 0 0 3" TextAlignment="Center" TextWrapping="Wrap">Select the location of the PC Launcher Shortcut</TextBlock>                
                 <Grid Margin="0 0 0 3">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
@@ -252,7 +253,7 @@
                         <Image Source="{StaticResource FolderOpen_16x}"/>
                     </Button>
                 </Grid>
-                <TextBlock Margin="0 0 0 3" TextWrapping="Wrap">NOTE: Always be sure to use a supported version as updated might break the compatibility</TextBlock>
+                <TextBlock Margin="0 0 0 3" TextWrapping="Wrap">You can launch KINGDOM HEARTS HD 1.5+2.5 ReMIX from the Mod Manager by targeting the shortcut made by EGS here. To make a shortcut, open the Epic Games Store and go to Library. Click on the 3 dots next to KINGDOM HEARTS HD 1.5+2.5 ReMIX and choose "Manage". Then click "Create Desktop Shortcut".</TextBlock>
             </StackPanel>
         </xctk:WizardPage>
         <xctk:WizardPage

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -197,7 +197,7 @@
             Title="Install OpenKH Panacea (Optional and Experimental)"
             Description="Install automatic mod loading support into the game's folder."
             PreviousPage="{Binding PageStack.Back}"
-            NextPage="{Binding ElementName=PCShortcutLocation}">
+            NextPage="{Binding ElementName=PCLaunchOption}">
             <StackPanel>
                 <TextBlock Margin="0 0 0 3" TextWrapping="Wrap">
                         OpenKH Panacea allows the PC version of Kingdom Hearts to load the mods you have installed, without
@@ -234,26 +234,20 @@
             </StackPanel>
         </xctk:WizardPage>
         <xctk:WizardPage
-            x:Name="PCShortcutLocation"
+            x:Name="PCLaunchOption"
             PageType="Interior"
-            Title="Shortcut Location"            
-            Description="Selected the location of the PC shortcut."
+            Title="Launch Option"            
+            Description="How OpenKH Mod Manager needs to launch Kingdom Hearts"
             PreviousPage="{Binding PageStack.Back}"
             NextPage="{Binding ElementName=PageGameData}">
             <StackPanel>
-                <TextBlock Margin="0 0 0 3" TextAlignment="Center" TextWrapping="Wrap">**OPTIONAL: Shortcut Location**</TextBlock>
-                <TextBlock Margin="0 0 0 3" TextAlignment="Center" TextWrapping="Wrap">Select the location of the PC Launcher Shortcut</TextBlock>                
-                <Grid Margin="0 0 0 3">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="20"/>
-                    </Grid.ColumnDefinitions>
-                    <TextBox Grid.Column="0" Text="{Binding PcShortcutLocation, UpdateSourceTrigger=PropertyChanged}"/>
-                    <Button Grid.Column="1" Grid.Row="4" Command="{Binding SelectPcShortcutCommand}">
-                        <Image Source="{StaticResource FolderOpen_16x}"/>
-                    </Button>
-                </Grid>
-                <TextBlock Margin="0 0 0 3" TextWrapping="Wrap">You can launch KINGDOM HEARTS HD 1.5+2.5 ReMIX from the Mod Manager by targeting the shortcut made by EGS here. To make a shortcut, open the Epic Games Store and go to Library. Click on the 3 dots next to KINGDOM HEARTS HD 1.5+2.5 ReMIX and choose "Manage". Then click "Create Desktop Shortcut".</TextBlock>
+                <TextBlock Margin="0 0 0 3" TextWrapping="Wrap">
+                    OpenKH Mod Manager is able to start the game when using Panacea but needs to know how you normally run it. If you launch Kingdom hearts through the Epic Games Launcher leave the box below checked.
+                </TextBlock>
+                <CheckBox
+                    Margin="0 0 0 10"
+                    IsChecked="{Binding IsEGSVersion}"
+                    Content="KH from the Epic Games Store and launcher"/>
             </StackPanel>
         </xctk:WizardPage>
         <xctk:WizardPage

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -237,17 +237,17 @@
             x:Name="PCLaunchOption"
             PageType="Interior"
             Title="Launch Option"            
-            Description="How OpenKH Mod Manager needs to launch Kingdom Hearts"
+            Description="Configure Mods Manager to launch Kingdom Hearts"
             PreviousPage="{Binding PageStack.Back}"
             NextPage="{Binding ElementName=PageGameData}">
             <StackPanel>
                 <TextBlock Margin="0 0 0 3" TextWrapping="Wrap">
-                    OpenKH Mod Manager is able to start the game when using Panacea but needs to know how you normally run it. If you launch Kingdom hearts through the Epic Games Launcher leave the box below checked.
+                    OpenKH Mods Manager has the ability to launch Kingdom Hearts directly. Leave the box below checked to have Mods Manager launch the game via Epic Games.    
                 </TextBlock>
                 <CheckBox
                     Margin="0 0 0 10"
                     IsChecked="{Binding IsEGSVersion}"
-                    Content="KH from the Epic Games Store and launcher"/>
+                    Content="Launch via Epic Games"/>
             </StackPanel>
         </xctk:WizardPage>
         <xctk:WizardPage

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml.cs
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml.cs
@@ -22,7 +22,7 @@ namespace OpenKh.Tools.ModsManager.Views
             _vm.PageIsoSelection = PageIsoSelection;
             _vm.PageEosInstall = PageEosInstall;
             _vm.PageRegion = PageRegion;
-            _vm.PCShortcutLocation = PCShortcutLocation;
+            _vm.PCLaunchOption = PCLaunchOption;
             _vm.LastPage = LastPage;
 
             _vm.PageStack.OnPageChanged(wizard.CurrentPage);
@@ -37,7 +37,7 @@ namespace OpenKh.Tools.ModsManager.Views
         public string ConfigGameDataLocation { get => _vm.GameDataLocation; set => _vm.GameDataLocation = value; }
         public int ConfigRegionId { get => _vm.RegionId; set => _vm.RegionId = value; }
         public bool ConfigPanaceaInstalled { get => _vm.PanaceaInstalled; set => _vm.PanaceaInstalled = value; }
-        public string ConfigPcShortcutLocation { get => _vm.PcShortcutLocation; set => _vm.PcShortcutLocation = value; }
+        public bool ConfigIsEGSVersion { get => _vm.IsEGSVersion; set => _vm.IsEGSVersion = value; }
 
         private void Wizard_Finish(object sender, Xceed.Wpf.Toolkit.Core.CancelRoutedEventArgs e)
         {


### PR DESCRIPTION
renamed the new __config Alios made to be _config2.

Pancea can now quick launch games in the KH 1.5 2.5 collection using a setting in panacea_settings.txt. added a dropdown only visible when Mods Manager is set to PC and the user has DevView enabled to allow launching any game in the collection quickly from Mod Manager. It is hidden by default but also kh2 by default since that the primary use for Mods Manager right now. If the user uses the EGS version when running either through run only or build and run pancea_settings.txt is read and quick_launch=`_quicklaunch` is appended to launch the chosen game kh2 by default. Unfortunately the Combo Box does now hide nice.
![image](https://user-images.githubusercontent.com/47014056/191905225-db48542d-08a8-457e-9f78-c5258134ce2a.png)
![image](https://user-images.githubusercontent.com/47014056/191905216-b766d3ef-cba9-4f84-8f87-852977954e7e.png)

Added a menu for the user in setup wizard to check whether or not they use the EGS version of KH it is checked by default. If unchecked OpenKH Mods Manager just starts the kh2 exe when running for PC.