### PR TITLE
Change FirstRun Variable and Quick Launch option

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -24,6 +24,7 @@ namespace OpenKh.Tools.ModsManager.Services
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
                 .Build();
 
+            public int WizardVersionNumber { get; set; }
             public string ModCollectionPath { get; internal set; }
             public string GameModPath { get; internal set; }
             public string GameDataPath { get; internal set; }
@@ -54,45 +55,11 @@ namespace OpenKh.Tools.ModsManager.Services
                 return _deserializer.Deserialize<Config>(reader);
             }
         }
-        
-         private class FirstRun
-        {
-            private static readonly IDeserializer _deserializer =
-                new DeserializerBuilder()
-                .IgnoreFields()
-                .IgnoreUnmatchedProperties()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .Build();
-            private static readonly ISerializer _serializer =
-                new SerializerBuilder()
-                .IgnoreFields()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .Build();
-            
-            public bool IsFirstRunComplete { get; set; }
-
-            public void Save(string fileName)
-            {
-                using var writer = new StreamWriter(fileName);
-                _serializer.Serialize(writer, this);
-            }
-
-            public static FirstRun Open(string fileName)
-            {
-                if (!File.Exists(fileName))
-                    return new FirstRun();
-
-                using var reader = new StreamReader(fileName);
-                return _deserializer.Deserialize<FirstRun>(reader);
-            }
-        }
 
         private static string StoragePath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
         private static string ConfigPath = Path.Combine(StoragePath, "mods-manager.yml");
-        private static string FirstRunPath = Path.Combine(StoragePath, "first-run-complete.yml");
         private static string EnabledModsPath = Path.Combine(StoragePath, "mods.txt");
         private static readonly Config _config = Config.Open(ConfigPath);
-        private static readonly FirstRun _config2 = FirstRun.Open(FirstRunPath);
 
         static ConfigurationService()
         {
@@ -131,13 +98,13 @@ namespace OpenKh.Tools.ModsManager.Services
         public static ICollection<string> FeaturedMods { get; private set; }
         public static ICollection<string> BlacklistedMods { get; private set; }
 
-        public static bool IsFirstRunComplete
+        public static int WizardVersionNumber
         {
-            get => _config2.IsFirstRunComplete;
+            get => _config.WizardVersionNumber;
             set
             {
-                _config2.IsFirstRunComplete = value;
-                _config2.Save(FirstRunPath);
+                _config.WizardVersionNumber = value;
+                _config.Save(ConfigPath);
             }
         }
 

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -42,6 +42,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         private bool _panaceaInstalled;
         private bool _devView;
         private string _quickLaunch = "kh2";
+        private int _wizardVersionNumber = 1;
 
         private const string RAW_FILES_FOLDER_NAME = "raw";
         private const string ORIGINAL_FILES_FOLDER_NAME = "original";
@@ -89,8 +90,8 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         public Visibility IsModUnselectedMessageVisible => !IsModSelected ? Visibility.Visible : Visibility.Collapsed;
         public Visibility PatchVisible => PC && !PanaceaInstalled || PC && DevView ? Visibility.Visible : Visibility.Collapsed;
         public Visibility ModLoader => !PC || PanaceaInstalled ? Visibility.Visible : Visibility.Collapsed;
-        public Visibility HideExtras => !PC ? Visibility.Visible : Visibility.Collapsed;
-        public Visibility QuickLaunchVis => PC && DevView ? Visibility.Visible : Visibility.Collapsed;
+        public Visibility HideStop => !PC ? Visibility.Visible : Visibility.Collapsed;
+        public Visibility HideQuickLaunch => PC && PanaceaInstalled && DevView ? Visibility.Visible : Visibility.Collapsed;
 
         public bool DevView
         {
@@ -100,7 +101,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 _devView = value;
                 ConfigurationService.DevView = DevView;
                 OnPropertyChanged(nameof(PatchVisible));
-                OnPropertyChanged(nameof(QuickLaunchVis));
+                OnPropertyChanged(nameof(HideQuickLaunch));
             }
         }
         public bool PanaceaInstalled
@@ -123,7 +124,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 OnPropertyChanged(nameof(PC));
                 OnPropertyChanged(nameof(ModLoader));
                 OnPropertyChanged(nameof(PatchVisible));
-                OnPropertyChanged(nameof(HideExtras));
+                OnPropertyChanged(nameof(HideStop));
             }
         }  
 
@@ -351,7 +352,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     ConfigurationService.RegionId = dialog.ConfigRegionId;
                     ConfigurationService.PanaceaInstalled = dialog.ConfigPanaceaInstalled;
                     ConfigurationService.IsEGSVersion = dialog.ConfigIsEGSVersion;
-                    ConfigurationService.IsFirstRunComplete = true;
+                    ConfigurationService.WizardVersionNumber = _wizardVersionNumber;
 
                     const int EpicGamesPC = 2;
                     if (ConfigurationService.GameEdition == EpicGamesPC &&
@@ -382,7 +383,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
             _pcsx2Injector = new Pcsx2Injector(new OperationDispatcher());
             FetchUpdates();
 
-            if (!ConfigurationService.IsFirstRunComplete)
+            if (ConfigurationService.WizardVersionNumber < _wizardVersionNumber)
                 WizardCommand.Execute(null);
         }
 

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -148,8 +148,8 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         return 0;
                 }
             }
-            set          
-            {                
+            set
+            {
                 switch (value)
                 {
                     case 0:
@@ -462,31 +462,15 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 case 2:
                     if (ConfigurationService.IsEGSVersion)
                     {
-                        if (File.Exists(Path.Combine(ConfigurationService.PcReleaseLocation, "panacea_settings.txt")))
+                        if (ConfigurationService.PanaceaInstalled)
                         {
-                            string[] file = File.ReadAllLines(Path.Combine(ConfigurationService.PcReleaseLocation, "panacea_settings.txt"));
-                            Array.Resize(ref file, file.Length + 1);
-                            file[file.Length - 1] = "quick_launch=" + _quickLaunch;
-                            File.WriteAllLines(Path.Combine(ConfigurationService.PcReleaseLocation, "panacea_settings.txt"), file);
-                        }
-                        else
-                        {
-                            File.WriteAllLines(Path.Combine(ConfigurationService.PcReleaseLocation, "panacea_settings.txt"),
-                            new string[]
-                            {
-                                $"mod_path={ConfigurationService.GameModPath}",
-                                $"show_console={false}",
-                                $"quick_launch={_quickLaunch}",
-                            });
-                        }
+                            File.AppendAllText(Path.Combine(ConfigurationService.PcReleaseLocation, "panacea_settings.txt"), "\nquick_launch=" + _quickLaunch);
+                        }                        
                         processStartInfo = new ProcessStartInfo
                         {
                             FileName = "com.epicgames.launcher://apps/4158b699dd70447a981fee752d970a3e%3A5aac304f0e8948268ddfd404334dbdc7%3A68c214c58f694ae88c2dab6f209b43e4?action=launch&silent=true",
                             UseShellExecute = true,
                         };
-                        Process.Start(processStartInfo);
-                        CloseAllWindows();
-                        return Task.CompletedTask;
                     }
                     else
                     {
@@ -496,10 +480,18 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                             WorkingDirectory = ConfigurationService.PcReleaseLocation,
                             UseShellExecute = false,
                         };
-                        Process.Start(processStartInfo);
-                        CloseAllWindows();
-                        return Task.CompletedTask;
+                        if (processStartInfo == null || !File.Exists(processStartInfo.FileName))
+                        {
+                            MessageBox.Show(
+                                "Unable to start game. Please make sure youre Kingdom Hearts executable is correctly named and in the correct folder.",
+                                "Run error", MessageBoxButton.OK, MessageBoxImage.Error);
+                            CloseAllWindows();
+                            return Task.CompletedTask;
+                        }
                     }
+                    Process.Start(processStartInfo);
+                    CloseAllWindows();
+                    return Task.CompletedTask;
                 default:
                     return Task.CompletedTask;
             }

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -462,10 +462,23 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 case 2:
                     if (ConfigurationService.IsEGSVersion)
                     {
-                        string[] file = File.ReadAllLines(Path.Combine(ConfigurationService.PcReleaseLocation, "panacea_settings.txt"));
-                        Array.Resize(ref file, file.Length + 1);
-                        file[file.Length-1] = "quick_launch=" + _quickLaunch;              
-                        File.WriteAllLines(Path.Combine(ConfigurationService.PcReleaseLocation, "panacea_settings.txt"), file);                        
+                        if (File.Exists(Path.Combine(ConfigurationService.PcReleaseLocation, "panacea_settings.txt")))
+                        {
+                            string[] file = File.ReadAllLines(Path.Combine(ConfigurationService.PcReleaseLocation, "panacea_settings.txt"));
+                            Array.Resize(ref file, file.Length + 1);
+                            file[file.Length - 1] = "quick_launch=" + _quickLaunch;
+                            File.WriteAllLines(Path.Combine(ConfigurationService.PcReleaseLocation, "panacea_settings.txt"), file);
+                        }
+                        else
+                        {
+                            File.WriteAllLines(Path.Combine(ConfigurationService.PcReleaseLocation, "panacea_settings.txt"),
+                            new string[]
+                            {
+                                $"mod_path={ConfigurationService.GameModPath}",
+                                $"show_console={false}",
+                                $"quick_launch={_quickLaunch}",
+                            });
+                        }
                         processStartInfo = new ProcessStartInfo
                         {
                             FileName = "com.epicgames.launcher://apps/4158b699dd70447a981fee752d970a3e%3A5aac304f0e8948268ddfd404334dbdc7%3A68c214c58f694ae88c2dab6f209b43e4?action=launch&silent=true",

--- a/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
@@ -68,7 +68,7 @@
                 <MenuItem Header="Build and Run" Command="{Binding BuildAndRunCommand}" InputGestureText="F5"/>
                 <MenuItem Header="Build Only" Command="{Binding BuildCommand}" InputGestureText="Ctrl+B"/>
                 <MenuItem Header="Run Only" Command="{Binding RunCommand}" InputGestureText="Ctrl+F5"/>
-                <MenuItem Header="Stop" Command="{Binding StopRunningInstanceCommand}" Visibility="{Binding HideExtras}" InputGestureText="Shift+F5"/>
+                <MenuItem Header="Stop" Command="{Binding StopRunningInstanceCommand}" Visibility="{Binding HideStop}" InputGestureText="Shift+F5"/>
             </MenuItem>
             <MenuItem Header="PC" Visibility="{Binding PatchVisible}">
                 <MenuItem Header="Build and Patch" Command="{Binding PatchCommand}" CommandParameter="false" InputGestureText="Ctrl+P"/>
@@ -77,13 +77,6 @@
             </MenuItem>
             <MenuItem Header="_Settings">
                 <MenuItem Header="Run _wizard" Command="{Binding WizardCommand}"  InputGestureText="Alt+W"/>
-                <ComboBox MinWidth="62" SelectedIndex="{Binding QuickLaunch}" Visibility="{Binding QuickLaunchVis}">
-                    <ComboBoxItem>kh2</ComboBoxItem>
-                    <ComboBoxItem>kh1</ComboBoxItem>
-                    <ComboBoxItem>bbs</ComboBoxItem>
-                    <ComboBoxItem>recom</ComboBoxItem>
-                    <ComboBoxItem>off</ComboBoxItem>
-                </ComboBox>
             </MenuItem>
             <MenuItem Header="_Info">
                 <MenuItem IsEnabled="False">
@@ -129,6 +122,15 @@
                     </MenuItem.Icon>
                 </MenuItem>
                 <MenuItem Header="Dev View" IsCheckable="True" IsChecked="{Binding DevView}"/>
+            </MenuItem>
+            <MenuItem Header="Quick Launch"  Visibility="{Binding HideQuickLaunch}">                
+                <ComboBox SelectedIndex="{Binding QuickLaunch}">
+                    <ComboBoxItem>kh2</ComboBoxItem>
+                    <ComboBoxItem>kh1</ComboBoxItem>
+                    <ComboBoxItem>bbs</ComboBoxItem>
+                    <ComboBoxItem>recom</ComboBoxItem>
+                    <ComboBoxItem>off</ComboBoxItem>
+                </ComboBox>               
             </MenuItem>
         </Menu>
 


### PR DESCRIPTION
Redid Alios' change to allow the wizard to run on an update. firstRunComplete is now wizardVersionNumber and if the new _wizardVersionNumber in MainViewModel.cs is greater than what is in mods-manager.yml the wizard is run again.

Moves Quick Launch option to its own menu that is now labeled so it is not a random dropdown box and also hide the Quick Launch Menu properly with no extra whitespace.