### PR TITLE
Recover auto release with GitHub Action

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,9 +2,9 @@ name: .NET
 
 on:
   push:
-    branches: [ "master" ]
-  pull_request:
     branches: [ "master", "fix-*" ]
+  pull_request:
+    branches: [ "master" ]
 
 jobs:
   build:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -44,12 +44,22 @@ jobs:
         filename: openkh.zip
         path: openkh
 
-    - name: "GitHub release"
+    - name: "GitHub release latest"
       uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "latest"
         prerelease: true
-        title: "Development Build"
+        title: "OpenKh Latest Build"
+        files: |
+          openkh.zip
+
+    - name: "GitHub release numbered"
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "release2-${{github.run_number}}"
+        prerelease: true
+        title: "OpenKh Build ${{github.run_number}}"
         files: |
           openkh.zip

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,9 +2,9 @@ name: .NET
 
 on:
   push:
-    branches: [ "master", "fix-*" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "master", "fix-*" ]
+    branches: [ "master" ]
 
 jobs:
   build:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,7 +30,7 @@ jobs:
       
     - name: setup-msbuild
       uses: microsoft/setup-msbuild@v1.1.3
-    - name: msbuild
+    - name: msbuild panacea
       run: |
         msbuild OpenKh.Research.Panacea\OpenKh.Research.Panacea.vcxproj /p:Configuration=Release /p:Platform=x64
         copy "OpenKh.Research.Panacea\Release\*.dll" bin\

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -29,9 +29,11 @@ jobs:
       shell: pwsh
 
     - name: zip
-      uses: montudor/action-zip@v1.0.0
+      uses: TheDoctor0/zip-release@0.6.2
       with:
-        args: -r openkh bin
+        filename: openkh.zip
+        path: bin
+
     - uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "fix-*" ]
 
 jobs:
   build:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,9 +2,9 @@ name: .NET
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "fix-*" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "fix-*" ]
 
 jobs:
   build:
@@ -21,7 +21,19 @@ jobs:
         dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore --configuration ".NET Debug"
-    - name: Test
-      run: dotnet test --no-build --verbosity normal --configuration ".NET Debug"
+    - name: pre-build.ps1
+      run: powershell -ExecutionPolicy Unrestricted ./pre-build.ps1
+      shell: pwsh
+    - name: build.ps1
+      run: powershell -ExecutionPolicy Unrestricted ./build.ps1
+      shell: pwsh
+    - name: zip
+      run: zip -r openkh bin
+    - uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "latest"
+        prerelease: true
+        title: "Development Build"
+        files: |
+          openkh.zip

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,13 +28,17 @@ jobs:
       run: powershell -ExecutionPolicy Unrestricted ./build.ps1
       shell: pwsh
 
+    - name: bin → openkh
+      run: ren bin openkh
+      shell: pwsh
     - name: zip
       uses: TheDoctor0/zip-release@0.6.2
       with:
         filename: openkh.zip
-        path: bin
+        path: openkh
 
-    - uses: "marvinpinto/action-automatic-releases@latest"
+    - name: "GitHub release"
+      uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "latest"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -27,7 +27,14 @@ jobs:
     - name: build.ps1
       run: powershell -ExecutionPolicy Unrestricted ./build.ps1
       shell: pwsh
-
+      
+    - name: setup-msbuild
+      uses: microsoft/setup-msbuild@v1.1.3
+    - name: msbuild
+      run: |
+        msbuild OpenKh.Research.Panacea\OpenKh.Research.Panacea.vcxproj /p:Configuration=Release /p:Platform=x64
+        copy "OpenKh.Research.Panacea\Release\*.dll" bin\
+      
     - name: bin → openkh
       run: ren bin openkh
       shell: pwsh

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -27,8 +27,11 @@ jobs:
     - name: build.ps1
       run: powershell -ExecutionPolicy Unrestricted ./build.ps1
       shell: pwsh
+
     - name: zip
-      run: zip -r openkh bin
+      uses: montudor/action-zip@v1.0.0
+      with:
+        args: -r openkh bin
     - uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/build.ps1
+++ b/build.ps1
@@ -12,6 +12,7 @@
 
 param (
     [string] $configuration = "Release",
+    [string] $sourceConfiguration = ".NET Release",
     [string] $verbosity = "minimal",
     [string] $output = "bin"
 )
@@ -48,7 +49,7 @@ dotnet restore
 Test-Success $LASTEXITCODE
 
 # Run tests
-dotnet test --configuration $configuration --verbosity $verbosity
+dotnet test --configuration $sourceConfiguration --verbosity $verbosity
 Test-Success $LASTEXITCODE
 
 # Create temporary solution
@@ -73,7 +74,7 @@ Get-CSProjects "OpenKh.Game*" | ForEach-Object {
 }
 
 # Publish solution
-dotnet publish $solution --configuration $configuration --verbosity $verbosity --framework net6.0 --output $output /p:DebugType=None /p:DebugSymbols=false
+dotnet publish $solution --configuration $configuration --verbosity $verbosity --output $output /p:DebugType=None /p:DebugSymbols=false
 
 # Remove the temporary solution after the solution is published
 Remove-Item $solution -ErrorAction Ignore


### PR DESCRIPTION
This will enable auto build and release of .NET projects, and also panacea, in zip file.

Create 2 release tags:
- `latest`
- `release2-${{github.run_number}}`

Sample from: https://github.com/kenjiuno/OpenKh/releases

![2022-10-20_22h08_33](https://user-images.githubusercontent.com/5955540/196957379-ee6dfbb6-db2d-4b7d-a743-89af67f7df3a.png)

![2022-10-20_22h08_24](https://user-images.githubusercontent.com/5955540/196957385-a13cc13e-8e2f-40f2-bd42-7504114a4bfd.png)

