### PR TITLE
Workaround for GitHub Actions `Error: Resource not accessible by integration`

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -46,6 +46,7 @@ jobs:
 
     - name: "GitHub release latest"
       uses: "marvinpinto/action-automatic-releases@latest"
+      continue-on-error: true # at non master branch this will always fail
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "latest"
@@ -56,6 +57,7 @@ jobs:
 
     - name: "GitHub release numbered"
       uses: "marvinpinto/action-automatic-releases@latest"
+      continue-on-error: true # at non master branch this will always fail
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "release2-${{github.run_number}}"


### PR DESCRIPTION
![2022-11-11_09h10_22](https://user-images.githubusercontent.com/5955540/201232190-5f13eb67-c825-4640-a87f-c9a57359a5b5.png)

Thus apply `continue-on-error: true` to `marvinpinto/action-automatic-releases@latest`
