### PR TITLE
Mod Manger better launch game and making games "Seperate UI's"

### DIFF
--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -69,14 +69,24 @@ namespace OpenKh.Patcher
             Patch(originalAssets, outputDir, metadata, modBasePath);
         }
 
+        List<string> GamesList = new List<string>()
+        {
+            "kh2",
+            "kh1",
+            "bbs",
+            "recom",
+        };
+
         public void Patch(string originalAssets, string outputDir, Metadata metadata, string modBasePath, int platform = 1, bool fastMode = false, IDictionary<string, string> packageMap = null, string LaunchGame = null)
         {
+            
             var context = new Context(metadata, originalAssets, modBasePath, outputDir);
             try
             {
+                
                 if (metadata.Assets == null)
                     throw new Exception("No assets found.");
-                if (metadata.Game != null && metadata.Game != LaunchGame)
+                if (metadata.Game != null && GamesList.Contains(metadata.Game.ToLower()) && metadata.Game.ToLower() != LaunchGame)
                     return;
 
                 metadata.Assets.AsParallel().ForAll(assetFile =>

--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -44,7 +44,7 @@ namespace OpenKh.Tools.ModsManager.Services
             public bool kh2 { get; internal set; } = true;
             public bool bbs { get; internal set; }
             public bool recom { get; internal set; }
-            public string LaunchGame { get; internal set; }
+            public string LaunchGame { get; internal set; } = "kh2";
 
             public void Save(string fileName)
             {
@@ -97,15 +97,7 @@ namespace OpenKh.Tools.ModsManager.Services
                     .ToList();
             });
         }
-        public static string LaunchGame
-        {
-            get => _config.LaunchGame;
-            set
-            {
-                _config.LaunchGame = value;
-                _config.Save(ConfigPath);
-            }
-        }
+        
         public static ICollection<string> EnabledMods
         {
             get
@@ -324,6 +316,15 @@ namespace OpenKh.Tools.ModsManager.Services
             set
             {
                 _config.recom = value;
+                _config.Save(ConfigPath);
+            }
+        }
+        public static string LaunchGame
+        {
+            get => _config.LaunchGame;
+            set
+            {
+                _config.LaunchGame = value;
                 _config.Save(ConfigPath);
             }
         }

--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using YamlDotNet.Core.Tokens;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -63,7 +64,7 @@ namespace OpenKh.Tools.ModsManager.Services
 
         private static string StoragePath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
         private static string ConfigPath = Path.Combine(StoragePath, "mods-manager.yml");
-        private static string EnabledModsPathKH1 = Path.Combine(StoragePath,"kh1mods.txt");
+        private static string EnabledModsPathKH1 = Path.Combine(StoragePath, "kh1mods.txt");
         private static string EnabledModsPathKH2 = Path.Combine(StoragePath, "kh2mods.txt");
         private static string EnabledModsPathBBS = Path.Combine(StoragePath, "bbsmods.txt");
         private static string EnabledModsPathRECOM = Path.Combine(StoragePath, "recommods.txt");
@@ -96,26 +97,49 @@ namespace OpenKh.Tools.ModsManager.Services
                     .ToList();
             });
         }
-
-        public static ICollection<string> EnabledModsKH1
+        public static string LaunchGame
         {
-            get => File.Exists(EnabledModsPathKH1) ? File.ReadAllLines(EnabledModsPathKH1) : new string[0];
-            set => File.WriteAllLines(EnabledModsPathKH1, value);
+            get => _config.LaunchGame;
+            set
+            {
+                _config.LaunchGame = value;
+                _config.Save(ConfigPath);
+            }
         }
-        public static ICollection<string> EnabledModsKH2
+        public static ICollection<string> EnabledMods
         {
-            get => File.Exists(EnabledModsPathKH2) ? File.ReadAllLines(EnabledModsPathKH2) : new string[0];
-            set => File.WriteAllLines(EnabledModsPathKH2, value);
-        }
-        public static ICollection<string> EnabledModsBBS
-        {
-            get => File.Exists(EnabledModsPathBBS) ? File.ReadAllLines(EnabledModsPathBBS) : new string[0];
-            set => File.WriteAllLines(EnabledModsPathBBS, value);
-        }
-        public static ICollection<string> EnabledModsRECOM
-        {
-            get => File.Exists(EnabledModsPathRECOM) ? File.ReadAllLines(EnabledModsPathRECOM) : new string[0];
-            set => File.WriteAllLines(EnabledModsPathRECOM, value);
+            get
+            {
+                switch (LaunchGame)
+                {
+                    case "kh1":
+                        return File.Exists(EnabledModsPathKH1) ? File.ReadAllLines(EnabledModsPathKH1) : new string[0];
+                    case "bbs":
+                        return File.Exists(EnabledModsPathBBS) ? File.ReadAllLines(EnabledModsPathBBS) : new string[0];
+                    case "recom":
+                        return File.Exists(EnabledModsPathRECOM) ? File.ReadAllLines(EnabledModsPathRECOM) : new string[0];
+                    default:
+                        return File.Exists(EnabledModsPathKH2) ? File.ReadAllLines(EnabledModsPathKH2) : new string[0];
+                }
+            }
+            set
+            {
+                switch (LaunchGame)
+                {
+                    case "kh1":
+                        File.WriteAllLines(EnabledModsPathKH1, value);
+                        break;
+                    case "bbs":
+                        File.WriteAllLines(EnabledModsPathBBS, value);
+                        break;
+                    case "recom":
+                        File.WriteAllLines(EnabledModsPathRECOM, value);
+                        break;
+                    default:
+                        File.WriteAllLines(EnabledModsPathKH2, value);
+                        break;
+                }
+            }
         }
 
         public static ICollection<string> FeaturedMods { get; private set; }
@@ -300,15 +324,6 @@ namespace OpenKh.Tools.ModsManager.Services
             set
             {
                 _config.recom = value;
-                _config.Save(ConfigPath);
-            }
-        }
-        public static string LaunchGame
-        {
-            get => _config.LaunchGame;
-            set
-            {
-                _config.LaunchGame = value;
                 _config.Save(ConfigPath);
             }
         }

--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -64,10 +64,10 @@ namespace OpenKh.Tools.ModsManager.Services
 
         private static string StoragePath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
         private static string ConfigPath = Path.Combine(StoragePath, "mods-manager.yml");
-        private static string EnabledModsPathKH1 = Path.Combine(StoragePath, "kh1mods.txt");
-        private static string EnabledModsPathKH2 = Path.Combine(StoragePath, "kh2mods.txt");
-        private static string EnabledModsPathBBS = Path.Combine(StoragePath, "bbsmods.txt");
-        private static string EnabledModsPathRECOM = Path.Combine(StoragePath, "recommods.txt");
+        private static string EnabledModsPathKH1 = Path.Combine(StoragePath, "mods-KH1.txt");
+        private static string EnabledModsPathKH2 = Path.Combine(StoragePath, "mods-KH2.txt");
+        private static string EnabledModsPathBBS = Path.Combine(StoragePath, "mods-BBS.txt");
+        private static string EnabledModsPathRECOM = Path.Combine(StoragePath, "mods-ReCoM.txt");
         private static readonly Config _config = Config.Open(ConfigPath);
 
         static ConfigurationService()

--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -63,7 +63,10 @@ namespace OpenKh.Tools.ModsManager.Services
 
         private static string StoragePath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
         private static string ConfigPath = Path.Combine(StoragePath, "mods-manager.yml");
-        private static string EnabledModsPath = Path.Combine(StoragePath, "mods.txt");
+        private static string EnabledModsPathKH1 = Path.Combine(StoragePath,"kh1mods.txt");
+        private static string EnabledModsPathKH2 = Path.Combine(StoragePath, "kh2mods.txt");
+        private static string EnabledModsPathBBS = Path.Combine(StoragePath, "bbsmods.txt");
+        private static string EnabledModsPathRECOM = Path.Combine(StoragePath, "recommods.txt");
         private static readonly Config _config = Config.Open(ConfigPath);
 
         static ConfigurationService()
@@ -94,10 +97,25 @@ namespace OpenKh.Tools.ModsManager.Services
             });
         }
 
-        public static ICollection<string> EnabledMods
+        public static ICollection<string> EnabledModsKH1
         {
-            get => File.Exists(EnabledModsPath) ? File.ReadAllLines(EnabledModsPath) : new string[0];
-            set => File.WriteAllLines(EnabledModsPath, value);
+            get => File.Exists(EnabledModsPathKH1) ? File.ReadAllLines(EnabledModsPathKH1) : new string[0];
+            set => File.WriteAllLines(EnabledModsPathKH1, value);
+        }
+        public static ICollection<string> EnabledModsKH2
+        {
+            get => File.Exists(EnabledModsPathKH2) ? File.ReadAllLines(EnabledModsPathKH2) : new string[0];
+            set => File.WriteAllLines(EnabledModsPathKH2, value);
+        }
+        public static ICollection<string> EnabledModsBBS
+        {
+            get => File.Exists(EnabledModsPathBBS) ? File.ReadAllLines(EnabledModsPathBBS) : new string[0];
+            set => File.WriteAllLines(EnabledModsPathBBS, value);
+        }
+        public static ICollection<string> EnabledModsRECOM
+        {
+            get => File.Exists(EnabledModsPathRECOM) ? File.ReadAllLines(EnabledModsPathRECOM) : new string[0];
+            set => File.WriteAllLines(EnabledModsPathRECOM, value);
         }
 
         public static ICollection<string> FeaturedMods { get; private set; }
@@ -115,7 +133,7 @@ namespace OpenKh.Tools.ModsManager.Services
 
         public static string ModCollectionPath
         {
-            get => _config.ModCollectionPath ?? Path.GetFullPath(Path.Combine(StoragePath, "mods"));
+            get => _config.ModCollectionPath ?? Path.GetFullPath(Path.Combine(StoragePath, "mods", LaunchGame));
             set
             {
                 _config.ModCollectionPath = value;

--- a/OpenKh.Tools.ModsManager/Services/ModsService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ModsService.cs
@@ -81,12 +81,42 @@ namespace OpenKh.Tools.ModsManager.Services
         {
             get
             {
-                var mods = UnorderedMods.ToList();
-                foreach (var mod in ConfigurationService.EnabledMods)
+                switch (ConfigurationService.LaunchGame)
                 {
-                    if (mods.Contains(mod))
-                        yield return mod;
+                    case "kh1":
+                        var modskh1 = UnorderedMods.ToList();
+                        foreach (var mod in ConfigurationService.EnabledModsKH1)
+                        {
+                            if (modskh1.Contains(mod))
+                                yield return mod;
+                        }
+                        break;
+                    case "kh2":
+                        var modskh2 = UnorderedMods.ToList();
+                        foreach (var mod in ConfigurationService.EnabledModsKH2)
+                        {
+                            if (modskh2.Contains(mod))
+                                yield return mod;
+                        }
+                        break;
+                    case "bbs":
+                        var modsbbs = UnorderedMods.ToList();
+                        foreach (var mod in ConfigurationService.EnabledModsKH1)
+                        {
+                            if (modsbbs.Contains(mod))
+                                yield return mod;
+                        }
+                        break;
+                    case "recom":
+                        var modsrecom = UnorderedMods.ToList();
+                        foreach (var mod in ConfigurationService.EnabledModsKH1)
+                        {
+                            if (modsrecom.Contains(mod))
+                                yield return mod;
+                        }
+                        break;
                 }
+                
             }
         }
 
@@ -285,21 +315,74 @@ namespace OpenKh.Tools.ModsManager.Services
             Path.Combine(ConfigurationService.ModCollectionPath, repositoryName);
 
         public static IEnumerable<ModModel> GetMods(IEnumerable<string> modNames)
-        {
-            var enabledMods = ConfigurationService.EnabledMods;
-            foreach (var modName in modNames)
+        {            
+            switch (ConfigurationService.LaunchGame)
             {
-                var modPath = GetModPath(modName);
-                yield return new ModModel
-                {
-                    Name = modName,
-                    Path = modPath,
-                    IconImageSource = Path.Combine(modPath, "icon.png"),
-                    PreviewImageSource = Path.Combine(modPath, "preview.png"),
-                    Metadata = File.OpenRead(Path.Combine(modPath, ModMetadata)).Using(Metadata.Read),
-                    IsEnabled = enabledMods.Contains(modName)
-                };
-            }
+                case "kh1":
+                    var enabledModsKH1 = ConfigurationService.EnabledModsKH1;
+                    foreach (var modName in modNames)
+                    {
+                        var modPath = GetModPath(modName);
+                        yield return new ModModel
+                        {
+                            Name = modName,
+                            Path = modPath,
+                            IconImageSource = Path.Combine(modPath, "icon.png"),
+                            PreviewImageSource = Path.Combine(modPath, "preview.png"),
+                            Metadata = File.OpenRead(Path.Combine(modPath, ModMetadata)).Using(Metadata.Read),
+                            IsEnabled = enabledModsKH1.Contains(modName)
+                        };
+                    }
+                    break;
+                case "kh2":
+                    var enabledModsKH2 = ConfigurationService.EnabledModsKH2;
+                    foreach (var modName in modNames)
+                    {
+                        var modPath = GetModPath(modName);
+                        yield return new ModModel
+                        {
+                            Name = modName,
+                            Path = modPath,
+                            IconImageSource = Path.Combine(modPath, "icon.png"),
+                            PreviewImageSource = Path.Combine(modPath, "preview.png"),
+                            Metadata = File.OpenRead(Path.Combine(modPath, ModMetadata)).Using(Metadata.Read),
+                            IsEnabled = enabledModsKH2.Contains(modName)
+                        };
+                    }
+                    break;
+                case "bbs":
+                    var enabledModsBBS = ConfigurationService.EnabledModsBBS;
+                    foreach (var modName in modNames)
+                    {
+                        var modPath = GetModPath(modName);
+                        yield return new ModModel
+                        {
+                            Name = modName,
+                            Path = modPath,
+                            IconImageSource = Path.Combine(modPath, "icon.png"),
+                            PreviewImageSource = Path.Combine(modPath, "preview.png"),
+                            Metadata = File.OpenRead(Path.Combine(modPath, ModMetadata)).Using(Metadata.Read),
+                            IsEnabled = enabledModsBBS.Contains(modName)
+                        };
+                    }
+                    break;
+                case "recom":
+                    var enabledModsRECOM = ConfigurationService.EnabledModsRECOM;
+                    foreach (var modName in modNames)
+                    {
+                        var modPath = GetModPath(modName);
+                        yield return new ModModel
+                        {
+                            Name = modName,
+                            Path = modPath,
+                            IconImageSource = Path.Combine(modPath, "icon.png"),
+                            PreviewImageSource = Path.Combine(modPath, "preview.png"),
+                            Metadata = File.OpenRead(Path.Combine(modPath, ModMetadata)).Using(Metadata.Read),
+                            IsEnabled = enabledModsRECOM.Contains(modName)
+                        };
+                    }
+                    break;
+            }            
         }
 
         public static async IAsyncEnumerable<ModUpdateModel> FetchUpdates()

--- a/OpenKh.Tools.ModsManager/Services/ModsService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ModsService.cs
@@ -81,42 +81,12 @@ namespace OpenKh.Tools.ModsManager.Services
         {
             get
             {
-                switch (ConfigurationService.LaunchGame)
+                var mods = UnorderedMods.ToList();
+                foreach (var mod in ConfigurationService.EnabledMods)
                 {
-                    case "kh1":
-                        var modskh1 = UnorderedMods.ToList();
-                        foreach (var mod in ConfigurationService.EnabledModsKH1)
-                        {
-                            if (modskh1.Contains(mod))
-                                yield return mod;
-                        }
-                        break;
-                    case "kh2":
-                        var modskh2 = UnorderedMods.ToList();
-                        foreach (var mod in ConfigurationService.EnabledModsKH2)
-                        {
-                            if (modskh2.Contains(mod))
-                                yield return mod;
-                        }
-                        break;
-                    case "bbs":
-                        var modsbbs = UnorderedMods.ToList();
-                        foreach (var mod in ConfigurationService.EnabledModsKH1)
-                        {
-                            if (modsbbs.Contains(mod))
-                                yield return mod;
-                        }
-                        break;
-                    case "recom":
-                        var modsrecom = UnorderedMods.ToList();
-                        foreach (var mod in ConfigurationService.EnabledModsKH1)
-                        {
-                            if (modsrecom.Contains(mod))
-                                yield return mod;
-                        }
-                        break;
-                }
-                
+                    if (mods.Contains(mod))
+                        yield return mod;
+                }                
             }
         }
 
@@ -315,73 +285,20 @@ namespace OpenKh.Tools.ModsManager.Services
             Path.Combine(ConfigurationService.ModCollectionPath, repositoryName);
 
         public static IEnumerable<ModModel> GetMods(IEnumerable<string> modNames)
-        {            
-            switch (ConfigurationService.LaunchGame)
+        {
+            var enabledMods = ConfigurationService.EnabledMods;
+            foreach (var modName in modNames)
             {
-                case "kh1":
-                    var enabledModsKH1 = ConfigurationService.EnabledModsKH1;
-                    foreach (var modName in modNames)
-                    {
-                        var modPath = GetModPath(modName);
-                        yield return new ModModel
-                        {
-                            Name = modName,
-                            Path = modPath,
-                            IconImageSource = Path.Combine(modPath, "icon.png"),
-                            PreviewImageSource = Path.Combine(modPath, "preview.png"),
-                            Metadata = File.OpenRead(Path.Combine(modPath, ModMetadata)).Using(Metadata.Read),
-                            IsEnabled = enabledModsKH1.Contains(modName)
-                        };
-                    }
-                    break;
-                case "kh2":
-                    var enabledModsKH2 = ConfigurationService.EnabledModsKH2;
-                    foreach (var modName in modNames)
-                    {
-                        var modPath = GetModPath(modName);
-                        yield return new ModModel
-                        {
-                            Name = modName,
-                            Path = modPath,
-                            IconImageSource = Path.Combine(modPath, "icon.png"),
-                            PreviewImageSource = Path.Combine(modPath, "preview.png"),
-                            Metadata = File.OpenRead(Path.Combine(modPath, ModMetadata)).Using(Metadata.Read),
-                            IsEnabled = enabledModsKH2.Contains(modName)
-                        };
-                    }
-                    break;
-                case "bbs":
-                    var enabledModsBBS = ConfigurationService.EnabledModsBBS;
-                    foreach (var modName in modNames)
-                    {
-                        var modPath = GetModPath(modName);
-                        yield return new ModModel
-                        {
-                            Name = modName,
-                            Path = modPath,
-                            IconImageSource = Path.Combine(modPath, "icon.png"),
-                            PreviewImageSource = Path.Combine(modPath, "preview.png"),
-                            Metadata = File.OpenRead(Path.Combine(modPath, ModMetadata)).Using(Metadata.Read),
-                            IsEnabled = enabledModsBBS.Contains(modName)
-                        };
-                    }
-                    break;
-                case "recom":
-                    var enabledModsRECOM = ConfigurationService.EnabledModsRECOM;
-                    foreach (var modName in modNames)
-                    {
-                        var modPath = GetModPath(modName);
-                        yield return new ModModel
-                        {
-                            Name = modName,
-                            Path = modPath,
-                            IconImageSource = Path.Combine(modPath, "icon.png"),
-                            PreviewImageSource = Path.Combine(modPath, "preview.png"),
-                            Metadata = File.OpenRead(Path.Combine(modPath, ModMetadata)).Using(Metadata.Read),
-                            IsEnabled = enabledModsRECOM.Contains(modName)
-                        };
-                    }
-                    break;
+                var modPath = GetModPath(modName);
+                yield return new ModModel
+                {
+                    Name = modName,
+                    Path = modPath,
+                    IconImageSource = Path.Combine(modPath, "icon.png"),
+                    PreviewImageSource = Path.Combine(modPath, "preview.png"),
+                    Metadata = File.OpenRead(Path.Combine(modPath, ModMetadata)).Using(Metadata.Read),
+                    IsEnabled = enabledMods.Contains(modName)
+                };
             }            
         }
 

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -571,37 +571,11 @@ namespace OpenKh.Tools.ModsManager.ViewModels
 
         public void ModEnableStateChanged()
         {
-            switch (_launchGame)
-            {
-                case "kh1":
-                    ConfigurationService.EnabledModsKH1 = ModsList
-                        .Where(x => x.Enabled)
-                        .Select(x => x.Source)
-                        .ToList();
-                    OnPropertyChanged(nameof(BuildAndRunCommand));
-                    break;
-                case "kh2":
-                    ConfigurationService.EnabledModsKH2 = ModsList
-                        .Where(x => x.Enabled)
-                        .Select(x => x.Source)
-                        .ToList();
-                    OnPropertyChanged(nameof(BuildAndRunCommand));
-                    break;
-                case "bbs":
-                    ConfigurationService.EnabledModsBBS = ModsList
-                        .Where(x => x.Enabled)
-                        .Select(x => x.Source)
-                        .ToList();
-                    OnPropertyChanged(nameof(BuildAndRunCommand));
-                    break;
-                case "recom":
-                    ConfigurationService.EnabledModsRECOM = ModsList
-                        .Where(x => x.Enabled)
-                        .Select(x => x.Source)
-                        .ToList();
-                    OnPropertyChanged(nameof(BuildAndRunCommand));
-                    break;
-            }
+            ConfigurationService.EnabledMods = ModsList
+                .Where(x => x.Enabled)
+                .Select(x => x.Source)
+                .ToList();
+            OnPropertyChanged(nameof(BuildAndRunCommand));
         }
 
         private void MoveSelectedModDown()

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -209,10 +209,6 @@ namespace OpenKh.Tools.ModsManager.ViewModels
 
         public MainViewModel()
         {
-            if (_supportedGames.Contains(ConfigurationService.LaunchGame))
-                _launchGame = ConfigurationService.LaunchGame;
-            else
-                ConfigurationService.LaunchGame = _launchGame;
             if (ConfigurationService.GameEdition == 2)
             {
                 PC = true;
@@ -221,6 +217,10 @@ namespace OpenKh.Tools.ModsManager.ViewModels
             }
             else
                 PC = false;
+            if (_supportedGames.Contains(ConfigurationService.LaunchGame) && PC)
+                _launchGame = ConfigurationService.LaunchGame;
+            else
+                ConfigurationService.LaunchGame = _launchGame;
 
             Log.OnLogDispatch += (long ms, string tag, string message) =>
                 _debuggingWindow.Log(ms, tag, message);

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -42,6 +42,13 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         private bool _panaceaInstalled;
         private bool _devView;
         private string _launchGame = "kh2";
+        private List<string> _supportedGames = new List<string>()
+        {
+            "kh2",
+            "kh1",
+            "bbs",
+            "recom"
+        };
         private int _wizardVersionNumber = 1;
         private string[] executable = new string[]
         {
@@ -202,7 +209,10 @@ namespace OpenKh.Tools.ModsManager.ViewModels
 
         public MainViewModel()
         {
-            ConfigurationService.LaunchGame = _launchGame;
+            if (_supportedGames.Contains(ConfigurationService.LaunchGame))
+                _launchGame = ConfigurationService.LaunchGame;
+            else
+                ConfigurationService.LaunchGame = _launchGame;
             if (ConfigurationService.GameEdition == 2)
             {
                 PC = true;

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -180,6 +180,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         ConfigurationService.LaunchGame = "kh2";
                         break;
                 }
+                ReloadModsList();
             }
         }
 
@@ -560,11 +561,37 @@ namespace OpenKh.Tools.ModsManager.ViewModels
 
         public void ModEnableStateChanged()
         {
-            ConfigurationService.EnabledMods = ModsList
-                .Where(x => x.Enabled)
-                .Select(x => x.Source)
-                .ToList();
-            OnPropertyChanged(nameof(BuildAndRunCommand));
+            switch (_launchGame)
+            {
+                case "kh1":
+                    ConfigurationService.EnabledModsKH1 = ModsList
+                        .Where(x => x.Enabled)
+                        .Select(x => x.Source)
+                        .ToList();
+                    OnPropertyChanged(nameof(BuildAndRunCommand));
+                    break;
+                case "kh2":
+                    ConfigurationService.EnabledModsKH2 = ModsList
+                        .Where(x => x.Enabled)
+                        .Select(x => x.Source)
+                        .ToList();
+                    OnPropertyChanged(nameof(BuildAndRunCommand));
+                    break;
+                case "bbs":
+                    ConfigurationService.EnabledModsBBS = ModsList
+                        .Where(x => x.Enabled)
+                        .Select(x => x.Source)
+                        .ToList();
+                    OnPropertyChanged(nameof(BuildAndRunCommand));
+                    break;
+                case "recom":
+                    ConfigurationService.EnabledModsRECOM = ModsList
+                        .Where(x => x.Enabled)
+                        .Select(x => x.Source)
+                        .ToList();
+                    OnPropertyChanged(nameof(BuildAndRunCommand));
+                    break;
+            }
         }
 
         private void MoveSelectedModDown()

--- a/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
@@ -94,13 +94,13 @@
                 </MenuItem>
                 <Separator/>
                 <MenuItem Header="Download _latest version" Command="{Binding OpenLinkCommand}"
-                    CommandParameter="https://github.com/Xeeynamo/OpenKh/releases">
+                    CommandParameter="https://github.com/OpenKH/OpenKh/releases">
                     <MenuItem.Icon>
                         <Image Source="{StaticResource WebURL_16x}"/>
                     </MenuItem.Icon>
                 </MenuItem>
                 <MenuItem Header="OpenKH source code" Command="{Binding OpenLinkCommand}"
-                    CommandParameter="https://github.com/Xeeynamo/OpenKh">
+                    CommandParameter="https://github.com/OpenKH/OpenKh">
                     <MenuItem.Icon>
                         <Image Source="{StaticResource WebURL_16x}"/>
                     </MenuItem.Icon>
@@ -112,7 +112,7 @@
                     </MenuItem.Icon>
                 </MenuItem>
                 <MenuItem Header="Report bug or missing features" Command="{Binding OpenLinkCommand}"
-                    CommandParameter="https://github.com/Xeeynamo/OpenKh/issues">
+                    CommandParameter="https://github.com/OpenKH/OpenKh/issues">
                     <MenuItem.Icon>
                         <Image Source="{StaticResource WebURL_16x}"/>
                     </MenuItem.Icon>

--- a/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
@@ -124,17 +124,15 @@
                     </MenuItem.Icon>
                 </MenuItem>
                 <MenuItem Header="Dev View" IsCheckable="True" IsChecked="{Binding DevView}"/>
-            </MenuItem>
-            <MenuItem Header="Launch Game" Visibility="{Binding isPC}">                
-                <ComboBox SelectedIndex="{Binding GametoLaunch}">
-                    <ComboBoxItem>kh2</ComboBoxItem>
-                    <ComboBoxItem>kh1</ComboBoxItem>
-                    <ComboBoxItem>bbs</ComboBoxItem>
-                    <ComboBoxItem>recom</ComboBoxItem>
-                </ComboBox>               
-            </MenuItem>
+            </MenuItem>            
         </Menu>
-
+        <ComboBox SelectedIndex="{Binding GametoLaunch}" Visibility="{Binding isPC}" HorizontalAlignment="Right" Margin="0,0,10,0" MinWidth="144">
+            <ComboBoxItem>Kingdom Hearts 2</ComboBoxItem>
+            <ComboBoxItem>Kingdom Hearts 1</ComboBoxItem>
+            <ComboBoxItem>Birth by Sleep</ComboBoxItem>
+            <ComboBoxItem>Re:Chain of Memories</ComboBoxItem>
+        </ComboBox>
         <local:ModManagerView Grid.Row="1" DataContext="{Binding}"/>
+
     </Grid>
 </Window>

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -140,7 +140,7 @@
                     <CheckBox IsChecked="{Binding kh1}" Content="KH1-13GB" Margin="0 0 10 4"/>
                     <CheckBox IsChecked="{Binding kh2}" Content="KH2-25GB" Margin="0 0 10 4"/>
                     <CheckBox IsChecked="{Binding bbs}" Content="BBS-10GB" Margin="0 0 10 4"/>
-                    <CheckBox IsChecked="{Binding recom}" Content="ReCOM-10GB" Margin="0 0 10 4"/>
+                    <CheckBox IsChecked="{Binding recom}" Content="ReCoM-10GB" Margin="0 0 10 4"/>
                 </StackPanel>
                 <TextBlock Margin="0 0 0 3">Extraction folder location:</TextBlock>
                 <Grid Margin="0 0 0 3">


### PR DESCRIPTION
First commit is to better make sure mods are built if they match the launch game if it exists but not skip if its not exactly formatted. EX: it expects kh2 but if the mod maker types Kingdom Hearts 2 it wont skip it. Also moves the Launch Game Combo Box out of a sub menu and to the right.

Second is to seperate UIs for installed mods so the user only sees mods installed for the game the have chosen currently assuming the user installed the mod with the game they intended to use it with. This puts all mods in the mods folder into a subfolder with the games name and is not currently backwards compatible. Im not sure this second part code is done the best would like input.