### PR TITLE
[Mods Manager] Add enmp as valid listpatch method

### DIFF
--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -616,26 +616,37 @@ namespace OpenKh.Patcher
                             }
                             Kh2.Battle.Plrp.Write(stream.SetPosition(0), plrpList);
                         break;
-                    case "cmd":
-                        var cmdList = Kh2.SystemData.Cmd.Read(stream).ToDictionary(x => x.Id, x => x);
-                        var moddedCmd = deserializer.Deserialize<Dictionary<ushort, Kh2.SystemData.Cmd>>(sourceText);
-                        foreach (var command in moddedCmd)
-                        {
-                            if (cmdList.ContainsKey(command.Key))
-
-                                {
-                                    cmdList[command.Key] = command.Value;
-                                }
-                            
-                            else
+                        
+                        case "cmd":
+                            var cmdList = Kh2.SystemData.Cmd.Read(stream).ToDictionary(x => x.Id, x => x);
+                            var moddedCmd = deserializer.Deserialize<Dictionary<ushort, Kh2.SystemData.Cmd>>(sourceText);
+                            foreach (var command in moddedCmd)
                             {
-                                cmdList.Add(command.Key, command.Value);
+                                if (cmdList.ContainsKey(command.Key))
+
+                                    {
+                                        cmdList[command.Key] = command.Value;
+                                    }
+
+                                else
+                                {
+                                    cmdList.Add(command.Key, command.Value);
+                                }
+
                             }
+                            Kh2.SystemData.Cmd.Write(stream.SetPosition(0), cmdList.Values);
+                            break;
 
-                        }
-                        Kh2.SystemData.Cmd.Write(stream.SetPosition(0), cmdList.Values);
-                        break;
-
+                        case "enmp":
+                            var enmpList = Kh2.Battle.Enmp.Read(stream);
+                            var moddedEnmp = deserializer.Deserialize<List<Kh2.Battle.Enmp>>(sourceText);
+                            foreach (var enmp in moddedEnmp)
+                            {
+                                var oldEnmp = enmpList.First(x => x.Id == enmp.Id);
+                                enmpList[enmpList.IndexOf(oldEnmp)] = enmp;
+                            }
+                            Kh2.Battle.Enmp.Write(stream.SetPosition(0), enmpList);
+                            break;
 
                     default:
                             break;

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -1496,8 +1496,6 @@ namespace OpenKh.Tests.Patcher
                     {
                         Id = 1,
                         Level = 1,
-                        Health = new short[32],
-                        MaxDamage = 1
                     }
                 };
 
@@ -1522,8 +1520,6 @@ namespace OpenKh.Tests.Patcher
                     {
                         Id = 7,
                         Level = 1,
-                        Health = new short[32],
-                        MaxDamage = 1
                     }
                 };
                 writer.Write(serializer.Serialize(moddedEnmp));
@@ -1539,7 +1535,7 @@ namespace OpenKh.Tests.Patcher
                 var binarc = Bar.Read(stream);
                 var enmp = Kh2.Battle.Enmp.Read(binarc[0].Stream);
 
-                Assert.Equal(50, enmp[0].Prize);
+                Assert.Equal(50, enmp[0].Level);
             });
         }
 

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -1454,6 +1454,7 @@ namespace OpenKh.Tests.Patcher
             });
         }
 
+        [Fact]
         public void ListPatchEnmpTest()
         {
             var patcher = new PatcherProcessor();

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -1494,19 +1494,32 @@ namespace OpenKh.Tests.Patcher
                 {
                     new Kh2.Battle.Enmp
                     {
-                        Id = 1,
+                        Id = 7,
                         Level = 1,
+                        Health = new short[32],
+                        MaxDamage = 1,
+                        MinDamage = 1,
+                        PhysicalWeakness = 1,
+                        FireWeakness = 1,
+                        IceWeakness = 1,
+                        ThunderWeakness = 1,
+                        DarkWeakness = 1,
+                        LightWeakness = 1,
+                        GeneralWeakness = 1,
+                        Experience = 1,
+                        Prize = 1,
+                        BonusLevel = 1
                     }
                 };
 
-                using var EnmpStream = new MemoryStream();
-                Kh2.Battle.Enmp.Write(EnmpStream, enmpEntry);
+                using var enmpStream = new MemoryStream();
+                Kh2.Battle.Enmp.Write(enmpStream, enmpEntry);
                 Bar.Write(stream, new Bar() {
                     new Bar.Entry()
                     {
                         Name = "enmp",
                         Type = Bar.EntryType.List,
-                        Stream = EnmpStream
+                        Stream = enmpStream
                     }
                 });
             });
@@ -1520,6 +1533,19 @@ namespace OpenKh.Tests.Patcher
                     {
                         Id = 7,
                         Level = 1,
+                        Health = new short[32],
+                        MaxDamage = 1,
+                        MinDamage = 1,
+                        PhysicalWeakness = 1,
+                        FireWeakness = 1,
+                        IceWeakness = 1,
+                        ThunderWeakness = 1,
+                        DarkWeakness = 1,
+                        LightWeakness = 1,
+                        GeneralWeakness = 1,
+                        Experience = 1,
+                        Prize = 1,
+                        BonusLevel = 1
                     }
                 };
                 writer.Write(serializer.Serialize(moddedEnmp));
@@ -1535,7 +1561,7 @@ namespace OpenKh.Tests.Patcher
                 var binarc = Bar.Read(stream);
                 var enmp = Kh2.Battle.Enmp.Read(binarc[0].Stream);
 
-                Assert.Equal(50, enmp[0].Level);
+                Assert.Equal(1, enmp[0].Level);
             });
         }
 

--- a/docs/tool/GUI.ModsManager/index.md
+++ b/docs/tool/GUI.ModsManager/index.md
@@ -187,6 +187,7 @@ Asset Example
  * `trsr`
  * `cmd`
  * `item`
+ * `enmp`
  * `fmlv`
  * `lvup`
  * `bons`
@@ -271,6 +272,32 @@ Items:
   Picture: 1
   Icon1: 9
   Icon2: 0
+```
+
+`enmp` Source Example
+```
+- Id: 0
+  Level: 1
+  Health: 
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  MaxDamage: 1
+  MinDamage: 1
+  PhysicalWeakness: 1
+  FireWeakness: 1
+  IceWeakness: 1
+  ThunderWeakness: 1
+  DarkWeakness: 1
+  LightWeakness: 1
+  GeneralWeakness: 1
+  Experience: 1
+  Prize: 1
+  BonusLevel: 1  
 ```
 
 `fmlv` Source Example


### PR DESCRIPTION
Adds enmp as a possible type for listpatching via .yml using the Mod Manager.

The enmp file controls various stats for enemies, like elemental resistances, battle level, and health.
Enmp listpatches are set up like this: 
![image](https://user-images.githubusercontent.com/72351816/202931983-b3799046-475e-4dcd-abbe-7deaeba4e5b7.png)

Documentation on how to listpatch the enmp subfile & tests have also been included.