### PR TITLE
Adds Japanese Event option to msg encoder

### DIFF
--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -360,6 +360,7 @@ namespace OpenKh.Patcher
                     var encoder = source.Language switch
                     {
                         "jp" => Encoders.JapaneseSystem,
+                        "je" => Encoders.JapaneseEvent,
                         "tr" => Encoders.TurkishSystem,
                         _ => Encoders.InternationalSystem,
                     };


### PR DESCRIPTION
JapaneseEvent & JapaneseSystem has different encoding results for some kanji, with some even not having any counterpart. Therefore, we need to add support for both types.