### PR TITLE
bdscript: support pushImmf

### DIFF
--- a/OpenKh.Command.Bdxio/Models/BdxInstructionDesc.cs
+++ b/OpenKh.Command.Bdxio/Models/BdxInstructionDesc.cs
@@ -41,6 +41,7 @@ namespace OpenKh.Command.Bdxio.Models
             Ssub,
             Imm16,
             Imm32,
+            Float32,
         }
     }
 }

--- a/OpenKh.Command.Bdxio/Models/BdxInstructionDescs.cs
+++ b/OpenKh.Command.Bdxio/Models/BdxInstructionDescs.cs
@@ -22,7 +22,7 @@ namespace OpenKh.Command.Bdxio.Models
             #region Generated
 
 			new BdxInstructionDesc { Code = 0x0000, CodeMask = 0x003F, Name = "pushImm", CodeSize = 3, Args = new[] { new Arg { Name = "imm32", Type = ArgType.Imm32 } } },
-            new BdxInstructionDesc { Code = 0x0010, CodeMask = 0x003F, Name = "pushImm", CodeSize = 3, Args = new[] { new Arg { Name = "imm32", Type = ArgType.Imm32 } } },
+            new BdxInstructionDesc { Code = 0x0010, CodeMask = 0x003F, Name = "pushImmf", CodeSize = 3, Args = new[] { new Arg { Name = "float32", Type = ArgType.Float32 } } },
             new BdxInstructionDesc { Code = 0x0020, CodeMask = 0xFFFF, Name = "pushFromPSp", CodeSize = 2, Args = new[] { new Arg { Name = "imm16", Type = ArgType.Imm16 } } },
             new BdxInstructionDesc { Code = 0x0060, CodeMask = 0xFFFF, Name = "pushFromPWp", CodeSize = 2, Args = new[] { new Arg { Name = "imm16", Type = ArgType.Imm16, WorkPos = true } } },
             new BdxInstructionDesc { Code = 0x00A0, CodeMask = 0xFFFF, Name = "pushFromPSpVal", CodeSize = 2, Args = new[] { new Arg { Name = "imm16", Type = ArgType.Imm16 } } },

--- a/OpenKh.Command.Bdxio/Utils/BdxDecoder.cs
+++ b/OpenKh.Command.Bdxio/Utils/BdxDecoder.cs
@@ -162,6 +162,11 @@ namespace OpenKh.Command.Bdxio.Utils
                             {
                                 argValue = read.ReadInt32();
                             }
+                            else if (arg.Type == BdxInstructionDesc.ArgType.Float32)
+                            {
+                                argValue = read.ReadInt32();
+                                parsedArg.PreferFloat32 = true;
+                            }
                             else
                             {
                                 argValue = new BdxInstruction(codeWord).Ssub;
@@ -507,6 +512,7 @@ namespace OpenKh.Command.Bdxio.Utils
             public string? Label { get; set; }
             public int Value { get; set; }
             public int? AddrRef { get; set; }
+            public bool PreferFloat32 { get; set; }
         }
 
         public sealed class CodeContent : IAnnotation
@@ -727,6 +733,10 @@ namespace OpenKh.Command.Bdxio.Utils
                 if (arg.Label != null)
                 {
                     return $"{arg.Label}"; //offset
+                }
+                else if (arg.PreferFloat32)
+                {
+                    return BitConverter.ToSingle(BitConverter.GetBytes(arg.Value)).ToString("R");
                 }
                 else
                 {


### PR DESCRIPTION
Support to encode/decode `pushImmf` instrument in bdscript.

Both `pushImm` and `pushImmf` are recognized same and work equally on BD VM.

Just bdx compiler/decompiler can recognize difference of `pushImm` and `pushImmf`.

e.g. diff

```patch
--- V:/OpenKh-bdx~/OpenKh.Tests.Commands/bin/Debug/net6.0/G_EB100/a.bdscript	Wed Nov  9 09:06:52 2022
+++ V:/OpenKh-bdx/OpenKh.Tests.Commands/bin/Debug/net6.0/G_EB100/a.bdscript	Sat Nov 26 20:19:52 2022
@@ -7,7 +7,6 @@
   Addr: TR1
 - Key: 0
   Addr: TR0
-IsEmpty: false
 Name: g_eb100
 
 ---
@@ -65,21 +64,21 @@
  pushFromFSp 0
  syscall 3, 38 ; ?
  jnz L133
- pushImm 1065353216
+ pushImmf 1
  syscall 0, 17 ; trap_random_getf (1 in, 1 out)
  popToSp 4
  pushFromFSp 4
- pushImm 1045220557
+ pushImmf 0.2
  subf 
  infzf 
  jnz L131
  pushFromFSp 0
  pushImm 152
- pushImm 0
+ pushImmf 0
  syscall 3, 35 ; ?
  pushFromFSp 0
  pushImm 0
- pushImm 0
+ pushImmf 0
  syscall 3, 37 ; ?
  jmp L131
 L131:
@@ -102,7 +101,7 @@
  gosub 4, L192
  pushFromFSp 0
  pushImm 0
- pushImm 0
+ pushImmf 0
  syscall 3, 35 ; ?
  pushFromFSp 0
  syscall 3, 34 ; ?
@@ -110,11 +109,11 @@
  syscall 3, 74 ; ?
  popToSpVal 8
  pushFromFSpVal 8
- pushImm 0
+ pushImmf 0
  subf 
  infoezf 
  jnz L191
- pushImm 1092616192
+ pushImmf 10
  popToSpVal 8
  jmp L191
 L191:
```
