### PR TITLE
Mod Manager Fixes

### DIFF
--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -76,7 +76,7 @@ namespace OpenKh.Patcher
             "kh2",
             "kh1",
             "bbs",
-            "recom",
+            "Recom",
         };
 
         public void Patch(string originalAssets, string outputDir, Metadata metadata, string modBasePath, int platform = 1, bool fastMode = false, IDictionary<string, string> packageMap = null, string LaunchGame = null)
@@ -115,7 +115,7 @@ namespace OpenKh.Patcher
                             case "bbs":
                                 _packageFile = assetFile.Package != null && !fastMode ? assetFile.Package : "bbs_first";
                                 break;
-                            case "recom":
+                            case "Recom":
                                 if (assetFile!= null)
                                 _packageFile = "Recom";
                                 break;

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -88,7 +88,7 @@ namespace OpenKh.Patcher
                 
                 if (metadata.Assets == null)
                     throw new Exception("No assets found.");
-                if (metadata.Game != null && GamesList.Contains(metadata.Game.ToLower()) && metadata.Game.ToLower() != LaunchGame)
+                if (metadata.Game.ToLower() != null && GamesList.Contains(metadata.Game.ToLower()) && metadata.Game.ToLower() != LaunchGame.ToLower())
                     return;
 
                 metadata.Assets.AsParallel().ForAll(assetFile =>

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -88,7 +88,7 @@ namespace OpenKh.Patcher
                 
                 if (metadata.Assets == null)
                     throw new Exception("No assets found.");
-                if (metadata.Game.ToLower() != null && GamesList.Contains(metadata.Game.ToLower()) && metadata.Game.ToLower() != LaunchGame.ToLower())
+                if (metadata.Game != null && GamesList.Contains(metadata.Game.ToLower()) && metadata.Game.ToLower() != LaunchGame.ToLower())
                     return;
 
                 metadata.Assets.AsParallel().ForAll(assetFile =>

--- a/OpenKh.Research.Panacea/OpenKH.cpp
+++ b/OpenKh.Research.Panacea/OpenKH.cpp
@@ -238,7 +238,7 @@ void OpenKH::ReadSettings(const char* filename)
         {
             if (!_stricmp(value, "kh1"))
                 QuickLaunch = 1;
-            else if (!_stricmp(value, "recom"))
+            else if (!_stricmp(value, "Recom"))
                 QuickLaunch = 2;
             else if (!_stricmp(value, "kh2"))
                 QuickLaunch = 3;

--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -79,8 +79,8 @@ namespace OpenKh.Tools.ModsManager.Services
                 Directory.CreateDirectory(Path.Combine(modsPath, "kh1"));
             if (!Directory.Exists(Path.Combine(modsPath, "bbs")))
                 Directory.CreateDirectory(Path.Combine(modsPath, "bbs"));
-            if (!Directory.Exists(Path.Combine(modsPath, "recom")))
-                Directory.CreateDirectory(Path.Combine(modsPath, "recom"));
+            if (!Directory.Exists(Path.Combine(modsPath, "Recom")))
+                Directory.CreateDirectory(Path.Combine(modsPath, "Recom"));
            
 
             Task.Run(async () =>
@@ -116,7 +116,7 @@ namespace OpenKh.Tools.ModsManager.Services
                         return File.Exists(EnabledModsPathKH1) ? File.ReadAllLines(EnabledModsPathKH1) : new string[0];
                     case "bbs":
                         return File.Exists(EnabledModsPathBBS) ? File.ReadAllLines(EnabledModsPathBBS) : new string[0];
-                    case "recom":
+                    case "Recom":
                         return File.Exists(EnabledModsPathRECOM) ? File.ReadAllLines(EnabledModsPathRECOM) : new string[0];
                     default:
                         return File.Exists(EnabledModsPathKH2) ? File.ReadAllLines(EnabledModsPathKH2) : new string[0];
@@ -132,7 +132,7 @@ namespace OpenKh.Tools.ModsManager.Services
                     case "bbs":
                         File.WriteAllLines(EnabledModsPathBBS, value);
                         break;
-                    case "recom":
+                    case "Recom":
                         File.WriteAllLines(EnabledModsPathRECOM, value);
                         break;
                     default:

--- a/OpenKh.Tools.ModsManager/Services/ModsService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ModsService.cs
@@ -182,7 +182,7 @@ namespace OpenKh.Tools.ModsManager.Services
                 else if (fileName.Contains(".compcpatch"))
                 {
                     _yamlGen.Title = modName + " (COMPCPATCH)";
-                    _yamlGen.Game = "recom";
+                    _yamlGen.Game = "Recom";
                     _yamlGen.Description = "This is an automatically generated metadata for this COMPCPATCH Modification.";
                 }
                 else if (fileName.Contains(".bbspcpatch"))

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -47,7 +47,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
             "kh2",
             "kh1",
             "bbs",
-            "recom"
+            "Recom"
         };
         private int _wizardVersionNumber = 1;
         private string[] executable = new string[]
@@ -158,7 +158,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     case "bbs":
                         launchExecutable = 2;
                         return 2;
-                    case "recom":
+                    case "Recom":
                         launchExecutable = 3;
                         return 3;
                     default:
@@ -184,8 +184,8 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         ConfigurationService.LaunchGame = "bbs";
                         break;
                     case 3:
-                        _launchGame = "recom";
-                        ConfigurationService.LaunchGame = "recom";
+                        _launchGame = "Recom";
+                        ConfigurationService.LaunchGame = "Recom";
                         break;
                     default:
                         _launchGame = "kh2";
@@ -683,8 +683,8 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                             case "bbs":
                                 _pkgSoft = fastMode ? "bbs_first" : _dirPart;
                                 break;
-                            case "recom":
-                                _pkgSoft = "recom";
+                            case "Recom":
+                                _pkgSoft = "Recom";
                                 break;
                             default:
                                 _pkgSoft = fastMode ? "kh2_first" : _dirPart;
@@ -795,7 +795,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         }
                         else
                         {
-                            foreach (var file in Directory.GetFiles(Path.Combine(ConfigurationService.PcReleaseLocation, "BackupImage")).Where(x => x.Contains(".pkg") && (x.Contains(_launchGame) || x.Contains("Recom"))))
+                            foreach (var file in Directory.GetFiles(Path.Combine(ConfigurationService.PcReleaseLocation, "BackupImage")).Where(x => x.Contains(".pkg") && (x.Contains(_launchGame))))
                             {
                                 Log.Info($"Restoring Package File {file.Replace(".pkg", "")}");
 

--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -147,7 +147,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 {
                     OpenKHGameEngine => LastPage,
                     PCSX2 => PageIsoSelection,
-                    EpicGames => IsLastPanaceaVersionInstalled ? PageEosConfig : PageEosInstall,
+                    EpicGames => PageEosInstall,
                     _ => null,
                 };
                 WizardPageAfterGameData = GameEdition switch

--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -285,8 +285,9 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         public bool IsNotExtracting { get; private set; }
         public bool IsGameDataFound => (IsNotExtracting && GameService.FolderContainsUniqueFile(GameId, Path.Combine(GameDataLocation, "kh2")) || 
             (GameEdition == EpicGames && (GameService.FolderContainsUniqueFile("kh2", Path.Combine(GameDataLocation, "kh2")) || 
-            GameService.FolderContainsUniqueFile("kh1", Path.Combine(GameDataLocation, "kh1"))|| Directory.Exists(Path.Combine(GameDataLocation, "bbs")) ||
-            Directory.Exists(Path.Combine(GameDataLocation, "recom")))));
+            GameService.FolderContainsUniqueFile("kh1", Path.Combine(GameDataLocation, "kh1")) || 
+            File.Exists(Path.Combine(GameDataLocation, "bbs", "message")) ||
+            File.Exists(Path.Combine(GameDataLocation, "Recom", "SYS")))));
         public Visibility GameDataNotFoundVisibility => !IsGameDataFound ? Visibility.Visible : Visibility.Collapsed;
         public Visibility GameDataFoundVisibility => IsGameDataFound ? Visibility.Visible : Visibility.Collapsed;
         public Visibility ProgressBarVisibility => IsNotExtracting ? Visibility.Collapsed : Visibility.Visible;
@@ -677,7 +678,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         {
                             for (int i = 0; i < 1; i++)
                             {
-                                var outputDir = Path.Combine(gameDataLocation, "recom");
+                                var outputDir = Path.Combine(gameDataLocation, "Recom");
                                 using var hedStream = File.OpenRead(Path.Combine(_pcReleaseLocation, "Image", _pcReleaseLanguage, "Recom.hed"));
                                 using var img = File.OpenRead(Path.Combine(_pcReleaseLocation, "Image", _pcReleaseLanguage, "Recom.pkg"));
 

--- a/OpenKh.Tools.ModsManager/Views/ModDetailsView.xaml
+++ b/OpenKh.Tools.ModsManager/Views/ModDetailsView.xaml
@@ -41,7 +41,7 @@
             </TextBlock>
         </StackPanel>
         <StackPanel Visibility="{Binding LocalVisibility}">
-            <TextBlock Margin="0 0 0 3" TextWrapping="Wrap" FontFamily="Segoe UI Semibold">
+            <TextBlock Margin="0 0 0 3" TextWrapping="Wrap" FontStyle="Italic">
                 This mod is available only locally and it is not linked to any GitHub repository.
             </TextBlock>
         </StackPanel>


### PR DESCRIPTION
Change all instances of "recom" to "Recom" as the other games were named based of their PKGs. Since Recom only has the one PKG Recom with no first, second, etc.
Updated Panacea also to expect Recom.
Updated the setup wizard to not only look for the extracted data folder for Recom and bbs but a folder within so the game needs to be extracted to allow progress.
Fixed changing setup wizard from an emulator setup to a PC setup going to the ISO page after selecting the location of the installed EGS game
Changed local mod text to Segoe with italics instead of semibold