### PR TITLE
Revert "Bump ImGui.NET from 1.78.0 to 1.89.2"

### DIFF
--- a/OpenKh.Tools.BbsMapStudio/OpenKh.Tools.BbsMapStudio.csproj
+++ b/OpenKh.Tools.BbsMapStudio/OpenKh.Tools.BbsMapStudio.csproj
@@ -23,7 +23,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ImGui.NET" Version="1.89.2" />
+		<PackageReference Include="ImGui.NET" Version="1.78.0" />
 		<PackageReference Include="MonoGame.Content.Builder" Version="3.7.0.9" />
 		<PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.0.7" />
 		<PackageReference Include="AssimpNet" Version="5.0.0-beta1" />

--- a/OpenKh.Tools.Common.CustomImGui/OpenKh.Tools.Common.CustomImGui.csproj
+++ b/OpenKh.Tools.Common.CustomImGui/OpenKh.Tools.Common.CustomImGui.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ImGui.NET" Version="1.89.2" />
+    <PackageReference Include="ImGui.NET" Version="1.78.0" />
     <PackageReference Include="MonoGame.Content.Builder" Version="3.7.0.9" />
     <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.0.7" />
   </ItemGroup>

--- a/OpenKh.Tools.Kh2MapStudio/OpenKh.Tools.Kh2MapStudio.csproj
+++ b/OpenKh.Tools.Kh2MapStudio/OpenKh.Tools.Kh2MapStudio.csproj
@@ -23,7 +23,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ImGui.NET" Version="1.89.2" />
+		<PackageReference Include="ImGui.NET" Version="1.78.0" />
 		<PackageReference Include="MonoGame.Content.Builder" Version="3.7.0.9" />
 		<PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.0.7" />
 		<PackageReference Include="AssimpNet" Version="5.0.0-beta1" />

--- a/OpenKh.Tools.LayoutEditor/OpenKh.Tools.LayoutEditor.csproj
+++ b/OpenKh.Tools.LayoutEditor/OpenKh.Tools.LayoutEditor.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ImGui.NET" Version="1.89.2" />
+    <PackageReference Include="ImGui.NET" Version="1.78.0" />
     <PackageReference Include="MonoGame.Content.Builder" Version="3.7.0.9" />
     <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.0.7" />
   </ItemGroup>


### PR DESCRIPTION
Reverts OpenKH/OpenKh#739
It seemed like the problems were solved as it said it was able to build but in fact it skipped building the layout editor as the three errors still exists so this needs to be reverted. My bad