### PR TITLE
Fix sklt listpatching.

### DIFF
--- a/OpenKh.Kh2/SystemData/Sklt.cs
+++ b/OpenKh.Kh2/SystemData/Sklt.cs
@@ -7,8 +7,8 @@ namespace OpenKh.Kh2.SystemData
     public class Sklt
     {
         [Data] public uint CharacterId { get; set; }
-        [Data] public ushort Bone1 { get; set; }
-        [Data] public ushort Bone2 { get; set; }
+        [Data] public short Bone1 { get; set; }
+        [Data] public short Bone2 { get; set; }
 
         public static List<Sklt> Read(Stream stream) => BaseTable<Sklt>.Read(stream);
         public static void Write(Stream stream, IEnumerable<Sklt> entries) =>


### PR DESCRIPTION
Game files use -1 when a character doesnt use a Bone 1 or 2 to hold a weapon so Bone 1 and 2 need to be shorts not ushorts