### PR TITLE
Implement experimental easy mod preferences

### DIFF
--- a/OpenKh.Patcher/EasyPrefProcessor.cs
+++ b/OpenKh.Patcher/EasyPrefProcessor.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenKh.Patcher
+{
+    public class EasyPrefProcessor
+    {
+        public ValueEditor[] ValueEditors { get; }
+
+        public record ValueEditor(
+            string Key,
+            Type ValueType,
+            Func<object, string> ObjectToString,
+            Func<string, object> StringToObject,
+
+            EasyPref EasyPref
+        );
+
+        public EasyPrefProcessor(EasyPref[] easyPrefs)
+        {
+            ValueEditors = easyPrefs
+                .Select(
+                    pref =>
+                    {
+                        Type valueType;
+                        Func<object, string> objectToString = obj => obj?.ToString();
+                        Func<string, object> stringToObject;
+                        switch (pref.ValueType)
+                        {
+                            default:
+                                valueType = typeof(string);
+                                stringToObject = str => str;
+                                break;
+
+                            case "int":
+                                valueType = typeof(int);
+                                stringToObject = str => Convert.ToInt32(str);
+                                break;
+
+                            case "bool":
+                                valueType = typeof(bool);
+                                stringToObject = str => Convert.ToBoolean(str);
+                                break;
+                        }
+
+                        return new ValueEditor(
+                            Key: pref.Key,
+                            ValueType: valueType,
+                            ObjectToString: objectToString,
+                            StringToObject: stringToObject,
+                            EasyPref: pref
+                        );
+                    }
+                )
+                .ToArray();
+        }
+
+        public IDictionary<string, object> GetPrefDictionary(
+            Func<string, object> getter = null
+        )
+        {
+            var dict = new Dictionary<string, object>();
+            foreach (var editor in ValueEditors)
+            {
+                var preferredValue = getter?.Invoke(editor.Key);
+                dict[editor.Key] = (preferredValue != null)
+                    ? Convert.ChangeType(preferredValue, editor.ValueType)
+                    : editor.StringToObject(editor.EasyPref.DefaultValue);
+            }
+
+            return dict;
+        }
+    }
+}

--- a/OpenKh.Patcher/IfProcessor.cs
+++ b/OpenKh.Patcher/IfProcessor.cs
@@ -1,0 +1,44 @@
+using Scriban;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using YamlDotNet.Serialization;
+
+namespace OpenKh.Patcher
+{
+    public class IfProcessor
+    {
+        private static readonly INamingConvention _namingConvention = YamlDotNet.Serialization.NamingConventions.CamelCaseNamingConvention.Instance;
+
+        private readonly TemplateContext _context;
+
+        public IfProcessor(Action<Action<string, object>> registration)
+        {
+            var script = new Scriban.Runtime.ScriptObject();
+
+            registration?.Invoke(
+                (key, value) =>
+                {
+                    script[key] = value;
+                }
+            );
+
+            _context = new TemplateContext(script)
+            {
+                MemberRenamer = memberInfo => _namingConvention.Apply(memberInfo.Name),
+            };
+        }
+
+        public bool EvalIf(string expression)
+        {
+            var result = Template.Evaluate(expression, _context);
+
+            return false
+                || (result is bool boolValue && boolValue)
+                || (result is string stringValue && stringValue == "1")
+                ;
+        }
+    }
+}

--- a/OpenKh.Patcher/Metadata.cs
+++ b/OpenKh.Patcher/Metadata.cs
@@ -20,6 +20,7 @@ namespace OpenKh.Patcher
         public int Specifications { get; set; }
         public List<Dependency> Dependencies { get; set; }
         public List<AssetFile> Assets { get; set; }
+        public List<EasyPref> EasyPrefs { get; set; }
 
         private static readonly IDeserializer deserializer =
             new DeserializerBuilder()
@@ -56,10 +57,20 @@ namespace OpenKh.Patcher
         public string Language { get; set; }
         public bool IsSwizzled { get; set; }
         public int Index { get; set; }
+        public string If { get; set; }
     }
 
     public class Multi
     {
         public string Name { get; set; }
+    }
+
+    public class EasyPref
+    {
+        public string Key { get; set; }
+        public string ValueType { get; set; }
+        public string Category { get; set; }
+        public string Description { get; set; }
+        public string DefaultValue { get; set; }
     }
 }

--- a/OpenKh.Patcher/OpenKh.Patcher.csproj
+++ b/OpenKh.Patcher/OpenKh.Patcher.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="YamlDotNet" Version="12.3.1" />
+    <PackageReference Include="Scriban" Version="5.5.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenKh.Patcher/OpenKh.Patcher.csproj
+++ b/OpenKh.Patcher/OpenKh.Patcher.csproj
@@ -5,9 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="YamlDotNet" Version="12.3.1" />
-    <PackageReference Include="Scriban" Version="5.5.2" />
     <PackageReference Include="YamlDotNet" Version="13.0.0" />
+    <PackageReference Include="Scriban" Version="5.5.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -79,7 +79,7 @@ namespace OpenKh.Patcher
             "Recom",
         };
 
-        public void Patch(string originalAssets, string outputDir, Metadata metadata, string modBasePath, int platform = 1, bool fastMode = false, IDictionary<string, string> packageMap = null, string LaunchGame = null)
+        public void Patch(string originalAssets, string outputDir, Metadata metadata, string modBasePath, int platform = 1, bool fastMode = false, IDictionary<string, string> packageMap = null, string LaunchGame = null, Func<string, bool> evalAssetIf = null)
         {
             
             var context = new Context(metadata, originalAssets, modBasePath, outputDir);
@@ -91,7 +91,13 @@ namespace OpenKh.Patcher
                 if (metadata.Game != null && GamesList.Contains(metadata.Game.ToLower()) && metadata.Game.ToLower() != LaunchGame.ToLower())
                     return;
 
-                metadata.Assets.AsParallel().ForAll(assetFile =>
+                evalAssetIf ??= any => true;
+
+                var allowedAssets = metadata.Assets
+                    .Where(asset => evalAssetIf(asset.If))
+                    .ToArray();
+
+                allowedAssets.AsParallel().ForAll(assetFile =>
                 {
                     var names = new List<string>();
                     names.Add(assetFile.Name);

--- a/OpenKh.Tools.ModsManager/Services/PreferenceWrapperService.cs
+++ b/OpenKh.Tools.ModsManager/Services/PreferenceWrapperService.cs
@@ -1,0 +1,182 @@
+using OpenKh.Patcher;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenKh.Tools.ModsManager.Services
+{
+    internal class PreferenceWrapperService
+    {
+        internal object GetWrappedObject(
+            IDictionary<string, object> dict,
+            EasyPrefProcessor.ValueEditor[] editors
+        )
+        {
+            return new WrappedObject(
+                dict: dict,
+                getProps: () =>
+                {
+                    return new PropertyDescriptorCollection(
+                        editors
+                            .Select(
+                                editor =>
+                                {
+                                    return new WrappedProperty(
+                                        name: editor.Key,
+                                        type: editor.ValueType,
+                                        attrs: new Attribute[]
+                                        {
+                                            new DescriptionAttribute(editor.EasyPref.Description),
+                                            new CategoryAttribute(editor.EasyPref.Category),
+                                        },
+                                        getter: (target) =>
+                                        {
+                                            var localDict = ((WrappedObject)target).Dict;
+                                            localDict.TryGetValue(editor.Key, out object value);
+                                            return value;
+                                        },
+                                        setter: (target, value) =>
+                                        {
+                                            var localDict = ((WrappedObject)target).Dict;
+                                            localDict[editor.Key] = value;
+                                        }
+                                    );
+                                }
+                            )
+                            .ToArray()
+                    );
+                }
+            );
+        }
+
+        internal class WrappedProperty : PropertyDescriptor
+        {
+            private readonly Type _type;
+            private readonly Func<object, object> _getter;
+            private readonly Action<object, object> _setter;
+
+            public WrappedProperty(
+                string name,
+                Type type,
+                Attribute[] attrs,
+                Func<object, object> getter,
+                Action<object, object> setter
+            ) : base(name, attrs)
+            {
+                _type = type;
+                _getter = getter;
+                _setter = setter;
+            }
+
+            public override Type ComponentType => typeof(WrappedObject);
+
+            public override bool IsReadOnly => false;
+
+            public override Type PropertyType => _type;
+
+            public override bool CanResetValue(object component)
+            {
+                return false;
+            }
+
+            public override object GetValue(object component)
+            {
+                return _getter(component);
+            }
+
+            public override void ResetValue(object component)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void SetValue(object component, object value)
+            {
+                _setter(component, value);
+            }
+
+            public override bool ShouldSerializeValue(object component)
+            {
+                return false;
+            }
+        }
+
+        internal class WrappedObject : ICustomTypeDescriptor
+        {
+            internal IDictionary<string, object> Dict { get; }
+
+            private readonly Func<PropertyDescriptorCollection> _getProps;
+
+            public WrappedObject(
+                IDictionary<string, object> dict,
+                Func<PropertyDescriptorCollection> getProps
+            )
+            {
+                Dict = dict;
+                _getProps = getProps;
+            }
+
+            public AttributeCollection GetAttributes()
+            {
+                return new AttributeCollection();
+            }
+
+            public string GetClassName()
+            {
+                return "Wrapper";
+            }
+
+            public string GetComponentName()
+            {
+                return "Wrapper";
+            }
+
+            public TypeConverter GetConverter()
+            {
+                return new TypeConverter();
+            }
+
+            public EventDescriptor GetDefaultEvent()
+            {
+                throw new NotImplementedException();
+            }
+
+            public PropertyDescriptor GetDefaultProperty()
+            {
+                throw new NotImplementedException();
+            }
+
+            public object GetEditor(Type editorBaseType)
+            {
+                throw new NotImplementedException();
+            }
+
+            public EventDescriptorCollection GetEvents()
+            {
+                throw new NotImplementedException();
+            }
+
+            public EventDescriptorCollection GetEvents(Attribute[] attributes)
+            {
+                throw new NotImplementedException();
+            }
+
+            public PropertyDescriptorCollection GetProperties()
+            {
+                return _getProps();
+            }
+
+            public PropertyDescriptorCollection GetProperties(Attribute[] attributes)
+            {
+                throw new NotImplementedException();
+            }
+
+            public object GetPropertyOwner(PropertyDescriptor pd)
+            {
+                return this;
+            }
+        }
+    }
+}

--- a/OpenKh.Tools.ModsManager/ViewModels/ModViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/ModViewModel.cs
@@ -1,3 +1,4 @@
+using OpenKh.Patcher;
 using OpenKh.Tools.ModsManager.Models;
 using OpenKh.Tools.ModsManager.Services;
 using OpenKh.Tools.ModsManager.Views;
@@ -124,6 +125,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         public string SourceUrl => $"https://github.com/{Source}";
         public string ReportBugUrl => $"https://github.com/{Source}/issues";
         public string FilesToPatch => string.Join('\n', GetFilesToPatch());
+        public EasyPref[] EasyPrefs => _model?.Metadata?.EasyPrefs?.ToArray();
 
         public string Description => _model.Metadata.Description;
 

--- a/OpenKh.Tools.ModsManager/Views/EditModEasyPrefsWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/EditModEasyPrefsWindow.xaml
@@ -1,0 +1,19 @@
+<Window x:Class="OpenKh.Tools.ModsManager.Views.EditModEasyPrefsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:OpenKh.Tools.ModsManager.Views"
+        WindowStartupLocation="CenterOwner"
+        Title="Edit mod easy preferences"
+        Height="400" Width="400"
+        xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+        >
+    <Grid>
+        <xctk:PropertyGrid
+            x:Name="Editor"
+            x:FieldModifier="internal"
+            Margin="3"
+            />
+    </Grid>
+</Window>

--- a/OpenKh.Tools.ModsManager/Views/EditModEasyPrefsWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/EditModEasyPrefsWindow.xaml
@@ -14,6 +14,8 @@
             x:Name="Editor"
             x:FieldModifier="internal"
             Margin="3"
+            SelectedObjectTypeName="{Binding PropertyGridCaption}"
+            SelectedObject="{Binding PropertyGridSelectedObject}"
             />
     </Grid>
 </Window>

--- a/OpenKh.Tools.ModsManager/Views/EditModEasyPrefsWindow.xaml.cs
+++ b/OpenKh.Tools.ModsManager/Views/EditModEasyPrefsWindow.xaml.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace OpenKh.Tools.ModsManager.Views
+{
+    /// <summary>
+    /// Interaction logic for EditModPrefWindow.xaml
+    /// </summary>
+    public partial class EditModEasyPrefsWindow : Window
+    {
+        public EditModEasyPrefsWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/OpenKh.Tools.ModsManager/Views/EditModEasyPrefsWindow.xaml.cs
+++ b/OpenKh.Tools.ModsManager/Views/EditModEasyPrefsWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -22,6 +23,35 @@ namespace OpenKh.Tools.ModsManager.Views
         public EditModEasyPrefsWindow()
         {
             InitializeComponent();
+        }
+
+        public TViewModel ViewModel
+        {
+            get => (TViewModel)DataContext;
+            set => DataContext = value;
+        }
+
+        public record TViewModel(
+            Action OnSave,
+            string PropertyGridCaption,
+            object PropertyGridSelectedObject
+        );
+
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            switch (MessageBox.Show(this, "Save changes?", "ModsManager", MessageBoxButton.YesNoCancel))
+            {
+                case MessageBoxResult.Yes:
+                    ViewModel?.OnSave?.Invoke();
+                    DialogResult = true;
+                    break;
+                case MessageBoxResult.No:
+                    DialogResult = false;
+                    break;
+                default:
+                    e.Cancel = true;
+                    break;
+            }
         }
     }
 }

--- a/OpenKh.Tools.ModsManager/Views/ModManagerView.xaml
+++ b/OpenKh.Tools.ModsManager/Views/ModManagerView.xaml
@@ -83,6 +83,9 @@
                 <Button Grid.Row="2" Margin="0 3 0 3" Command="{Binding AddModCommand}">
                     <Image Source="{StaticResource Add_16x}"/>
                 </Button>
+                <Button Grid.Row="2" Margin="0 3 0 3" Command="{Binding EditModPrefCommand}">
+                    <Image Source="{StaticResource EditWindow_16x}"/>
+                </Button>
                 <Button Grid.Row="2" Margin="0 3 0 3" Command="{Binding RemoveModCommand}">
                     <Image Source="{StaticResource Remove_color_16x}"/>
                 </Button>


### PR DESCRIPTION
Adding support of simple preferences (easyPrefs) for every mod.
(This pr is still not tested so much)

Ideally [JSON Schema](https://json-schema.org/) will be better to define preference store for a mod.
However this kind of UI costs not quite a few to implement on WPF.
If we can use modern HTML+JavaScript+CSS technologies, using [json-editor/json-editor: JSON Schema Based Editor](https://github.com/json-editor/json-editor) were good selection.
Thus in this time, I suggest simplified version `easyPrefs` instead.

`mod.yml`

```yml
easyPrefs:
  - key: lang
    valueType: string
    description: |
      Optionally you can select lang from the following codes:
      - en
      - fr
    defaultValue: en
    category: Language Category
  - key: feature1
    valueType: bool
    description: Install feature one
    category: Install
  - key: feature2
    valueType: bool
    description: Install feature two
    category: Install


assets:
  - name: msg/us/fontimage.bar
    method: copy
    source:
    - name: msg/fontimage.bar
    if: easyPrefs.lang == "en"
```

The value of `key` is case sensitive. `key: lang` defines `lang` and it is accessed by `if: easyPrefs.lang == "en"`

Currently `valueType` should be one from the following list.

- `int`
- `bool`
- `text` or `string`

The expression on `if` is evaluated by [scriban](https://github.com/scriban/scriban).
Scriban is a kind of text template engine.
If we implement `if` feature in this time, in the future, it may want to implement some kind of text substitution like `- name: msg/fontimage-{{lang}}.bar`.
Thus I have selected Scriban this time.

The supported and visible objects and properties should be added in `ModsService.cs`.

```cs
                var ifProcessor = new IfProcessor(
                    register =>
                    {
                        register("easyPrefs", easyPrefs);
                        register("config",
                            new
                            {
                                LaunchGame = ConfigurationService.LaunchGame,
                                GameEdition = _gameList[ConfigurationService.GameEdition],
                                Language = _langList[ConfigurationService.RegionId],
                            }
                        );
                    }
                );
```

The casing (naming convention) is very important.
- _entries_ of IDictionary or such, no name conversion occurs. `easyPrefs` meets this.
- _properties_ of Objects, name conversion occurs using `YamlDotNet.Serialization.NamingConventions.CamelCaseNamingConvention` inside scriban context.

Adding edit easy mod preference button.

![2023-02-01_04h29_34](https://user-images.githubusercontent.com/5955540/215864549-deb7134b-d32d-4f0d-a09a-cdf4693965a6.png)

Prompt when it has no easyPrefs, instead of app crash.

![2023-02-02_21h28_34](https://user-images.githubusercontent.com/5955540/216325197-53e7fb10-eff1-47ac-81c2-a538ee18cd2f.png)


Basic per mod preference editor. This [PropertyGrid](https://github.com/xceedsoftware/wpftoolkit/wiki/PropertyGrid).

![2023-02-02_21h25_27](https://user-images.githubusercontent.com/5955540/216324612-a0364415-67b6-4c80-bb87-f6a189320d37.png)

Confirm save change on close.

![2023-02-02_21h26_31](https://user-images.githubusercontent.com/5955540/216324826-f3ac6d72-6503-447e-95a5-43828831f57f.png)

- Yes → save and close
- No → discard and close
- Cancel → won't do neither save/discard and won't close

`mods-easy-prefs.yml` stores all mod's easy preference items.

```yml
easyPrefItems:
- modName: OpenKH/languagepack-en
  key: lang
  value: en
- modName: OpenKH/languagepack-en
  key: feature1
  value: True
- modName: OpenKH/languagepack-en
  key: feature2
  value: False
```
