### PR TITLE
Allow `dotnet publish` to emit success/error code correctly

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -75,6 +75,7 @@ Get-CSProjects "OpenKh.Game*" | ForEach-Object {
 
 # Publish solution
 dotnet publish $solution --configuration $configuration --verbosity $verbosity --output $output /p:DebugType=None /p:DebugSymbols=false
+Test-Success $LASTEXITCODE
 
 # Remove the temporary solution after the solution is published
 Remove-Item $solution -ErrorAction Ignore


### PR DESCRIPTION
Currently build error of OpenKh tools are treated as _successful_, and then GitHub Actions recognize `.NET / build (pull_request)` pipeline succeeded.

![2023-02-10_19h29_14](https://user-images.githubusercontent.com/5955540/218069276-8ba8097c-e4cc-4313-ab18-bd6433f74f74.png)

This behavior is wrong.
The build error should make `.NET / build (pull_request)` pipeline failure.
As a result, it prevents admins from merging broken commits accidentally.

In this pr, allow `dotnet publish` to emit success/error code correctly.

`Error: Process completed with exit code 1.` will be logged at end of the build step log, if there is a build error.

![2023-02-10_19h26_06](https://user-images.githubusercontent.com/5955540/218068499-ffeae283-ac48-48b1-b594-9f0ea0dddc3e.png)
