### PR TITLE
MdlxEditor - Export Images

### DIFF
--- a/OpenKh.Kh2/ModelTexture.cs
+++ b/OpenKh.Kh2/ModelTexture.cs
@@ -15,15 +15,15 @@ namespace OpenKh.Kh2
     {
         private class Header
         {
-            [Data] public int MagicCode { get; set; }
-            [Data] public int ColorCount { get; set; }
-            [Data] public int TextureInfoCount { get; set; }
-            [Data] public int GsInfoCount { get; set; }
-            [Data] public int Offset1 { get; set; }
-            [Data] public int Texinf1off { get; set; }
-            [Data] public int Texinf2off { get; set; }
-            [Data] public int PictureOffset { get; set; }
-            [Data] public int PaletteOffset { get; set; }
+            [Data] public int MagicCode { get; set; } // shorts type + flag
+            [Data] public int ColorCount { get; set; } // clutDataNum (Color LookUp Table) / Color Palettes
+            [Data] public int TextureInfoCount { get; set; } // pixelDataNum
+            [Data] public int GsInfoCount { get; set; } // textureEnvNum
+            [Data] public int Offset1 { get; set; } // pixelNoOffset
+            [Data] public int Texinf1off { get; set; } // sendPacketOffset
+            [Data] public int Texinf2off { get; set; } // textureEnvPacketOffset
+            [Data] public int PictureOffset { get; set; } // pixelDataOffset
+            [Data] public int PaletteOffset { get; set; } // clutDataOffset
         }
 
         public class Texture : IImageRead

--- a/OpenKh.Tools.Kh2MdlxEditor/Utils/ImageUtils.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/Utils/ImageUtils.cs
@@ -1,13 +1,14 @@
-using OpenKh.Command.ImgTool.Utils;
 using OpenKh.Common;
 using OpenKh.Kh2;
+using OpenKh.Kh2.TextureFooter;
 using OpenKh.Kh2.Utils;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Threading.Tasks;
+using System.Windows.Media.Imaging;
+using static OpenKh.Tools.Kh2MdlxEditor.ViewModels.TexAnim_VM;
 
 namespace OpenKh.Tools.Kh2MdlxEditor.Utils
 {
@@ -37,11 +38,32 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Utils
             }
         }
 
+        public static ModelTexture.Texture imgdToTexture(Imgd imgdFile)
+        {
+            Imgd[] imgdArray = new Imgd[1];
+            imgdArray[0] = imgdFile;
+            ModelTexture modTex = new ModelTexture(imgdArray);
+            // The only method for loading the textures is reading the whole binary again
+            Stream buffer = new MemoryStream();
+            modTex.Write(buffer);
+            modTex = ModelTexture.Read(buffer);
+
+            return modTex.Images[0];
+        }
+
+        public static ModelTexture.Texture pngToTexture(string filePath)
+        {
+            return imgdToTexture(pngToImgd(filePath));
+        }
+        public static BitmapSource getBitmapSource(TextureAnimation texAnim, byte[] clutPalette)
+        {
+            return GetBimapSource(ToBgra32(texAnim.SpriteImage, clutPalette), texAnim.SpriteWidth, texAnim.SpriteHeight * texAnim.NumSpritesInImageData);
+        }
+
         // OLD VERSION USING THE CONSOLE COMMAND VVV
 
         public static Imgd pngToImgd_Old(string filePath)
         {
-
             if (filePath.EndsWith(".imd"))
             {
                 return ImageResizer.NormalizeImageSize(File.OpenRead(filePath).Using(s => Imgd.Read(s)));

--- a/OpenKh.Tools.Kh2MdlxEditor/ViewModels/Main2_VM.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/ViewModels/Main2_VM.cs
@@ -89,6 +89,7 @@ namespace OpenKh.Tools.Kh2MdlxEditor.ViewModels
                         ModelFile.Write(barEntry.Stream);
                         break;
                     case Bar.EntryType.ModelTexture:
+                        barEntry.Stream = new MemoryStream();
                         TextureFile.Write(barEntry.Stream);
                         break;
                     case Bar.EntryType.ModelCollision:

--- a/OpenKh.Tools.Kh2MdlxEditor/ViewModels/TextureFile_VM.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/ViewModels/TextureFile_VM.cs
@@ -1,15 +1,31 @@
 using OpenKh.Kh2;
+using OpenKh.Tools.Kh2MdlxEditor.Utils;
+using System.Collections.ObjectModel;
+using System.Windows;
 
 namespace OpenKh.Tools.Kh2MdlxEditor.ViewModels
 {
     internal class TextureFile_VM
     {
         public ModelTexture textureData { get; set; }
+        public ObservableCollection<ModelTexture.Texture> textures { get; set; }
 
         public TextureFile_VM() { }
         public TextureFile_VM(ModelTexture textureFile)
         {
             textureData = textureFile;
+            textures = new ObservableCollection<ModelTexture.Texture>(textureData.Images);
+        }
+
+        public void removeTextureAt(int index)
+        {
+            textures.RemoveAt(index);
+            textureData.Images.RemoveAt(index);
+        }
+        public void addTexture(string filename)
+        {
+            textures.Add(ImageUtils.pngToTexture(filename));
+            textureData.Images.Add(ImageUtils.pngToTexture(filename));
         }
     }
 }

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/TextureFile_Control.xaml
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/TextureFile_Control.xaml
@@ -36,10 +36,18 @@
             <!-- Texture list -->
             <DockPanel Grid.Row="0" LastChildFill="True">
                 <Label DockPanel.Dock="Top" Foreground="White" HorizontalAlignment="Center">Textures</Label>
-                <ListView ItemsSource="{Binding textureData.Images}" DisplayMemberPath="Size">
+                <ListView Name="LV_Textures" ItemsSource="{Binding textureData.Images}" DisplayMemberPath="Size">
+                    <ListView.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem Header="Export as PNG" Click="Texture_Export"/>
+                            <MenuItem Header="Remove texture" Click="Texture_Remove" Visibility="Collapsed"/>
+                            <MenuItem Header="Add texture" Click="Texture_Add" Visibility="Collapsed"/>
+                        </ContextMenu>
+                    </ListView.ContextMenu>
                     <ListView.ItemContainerStyle>
                         <Style TargetType="ListViewItem">
                             <EventSetter Event="MouseLeftButtonUp" Handler="ListViewItem_OpenTexture"/>
+                            <EventSetter Event="MouseRightButtonUp" Handler="ListViewItem_OpenTexture"/>
                         </Style>
                     </ListView.ItemContainerStyle>
                 </ListView>
@@ -48,7 +56,12 @@
             <!-- Texture animation list -->
             <DockPanel Grid.Row="1" LastChildFill="True">
                 <Label DockPanel.Dock="Top" Foreground="White" HorizontalAlignment="Center">Texture animations</Label>
-                <ListView Grid.Row="1" ItemsSource="{Binding textureData.TextureFooterData.TextureAnimationList}" DisplayMemberPath="TextureIndex">
+                <ListView Grid.Row="1" Name="LV_Animations" ItemsSource="{Binding textureData.TextureFooterData.TextureAnimationList}" DisplayMemberPath="TextureIndex">
+                    <ListView.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem Header="Export as PNG" Click="Animation_Export"/>
+                        </ContextMenu>
+                    </ListView.ContextMenu>
                     <ListView.ItemContainerStyle>
                         <Style TargetType="ListViewItem">
                             <EventSetter Event="MouseLeftButtonUp" Handler="ListViewItem_OpenTexAnim"/>

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/TextureFile_Control.xaml.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/TextureFile_Control.xaml.cs
@@ -1,8 +1,15 @@
+using OpenKh.AssimpUtils;
 using OpenKh.Kh2;
 using OpenKh.Kh2.TextureFooter;
+using OpenKh.Tools.Common.Wpf;
+using OpenKh.Tools.Kh2MdlxEditor.Utils;
 using OpenKh.Tools.Kh2MdlxEditor.ViewModels;
+using System;
+using System.IO;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media.Imaging;
 
 namespace OpenKh.Tools.Kh2MdlxEditor.Views
 {
@@ -21,6 +28,11 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
         {
             InitializeComponent();
             textureFileControlModel = new TextureFile_VM(textureFile);
+            reloadContents();
+        }
+
+        public void reloadContents()
+        {
             DataContext = textureFileControlModel;
 
             if (textureFileControlModel.textureData.Images != null && textureFileControlModel.textureData.Images.Count > 0)
@@ -31,7 +43,8 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
             {
                 TextureAnimation texAnimFirst = textureFileControlModel.textureData.TextureFooterData.TextureAnimationList[0];
                 byte[] clutPalette = null;
-                if (texAnimFirst.TextureIndex < textureFileControlModel.textureData.Images.Count) {
+                if (texAnimFirst.TextureIndex < textureFileControlModel.textureData.Images.Count)
+                {
                     clutPalette = textureFileControlModel.textureData.Images[texAnimFirst.TextureIndex].GetClut();
                 }
                 contentFrameAnimation.Content = new TexAnim_Control(texAnimFirst, clutPalette);
@@ -52,6 +65,70 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
                 clutPalette = textureFileControlModel.textureData.Images[texAnimSelected.TextureIndex].GetClut();
             }
             contentFrameAnimation.Content = new TexAnim_Control(texAnimSelected, clutPalette);
+        }
+        public void Texture_Export(object sender, RoutedEventArgs e)
+        {
+            if(LV_Textures.SelectedItem != null)
+            {
+                BitmapSource bitmapImage = (LV_Textures.SelectedItem as ModelTexture.Texture).GetBimapSource();
+
+                System.Windows.Forms.SaveFileDialog sfd;
+                sfd = new System.Windows.Forms.SaveFileDialog();
+                sfd.Title = "Export image as PNG";
+                sfd.FileName = "Texture.png";
+                sfd.ShowDialog();
+                if (sfd.FileName != "")
+                {
+                    MemoryStream memStream = new MemoryStream();
+                    AssimpGeneric.ExportBitmapSourceAsPng(bitmapImage, sfd.FileName);
+                }
+            }
+        }
+        // Works for the textures, but the textures are outputted from the actual data, so it only works visually on the tool
+        public void Texture_Remove(object sender, RoutedEventArgs e)
+        {
+            if (LV_Textures.SelectedItem != null)
+            {
+                //textureFileControlModel.textureData.Images.RemoveAt(LV_Textures.SelectedIndex);
+                textureFileControlModel.removeTextureAt(LV_Textures.SelectedIndex);
+                reloadContents();
+            }
+        }
+        // Works for the textures, but the textures are outputted from the actual data, so it only works visually on the tool
+        public void Texture_Add(object sender, RoutedEventArgs e)
+        {
+            System.Windows.Forms.OpenFileDialog sfd;
+            sfd = new System.Windows.Forms.OpenFileDialog();
+            sfd.Title = "Select PNG image";
+            sfd.ShowDialog();
+            if (sfd.FileName != "")
+            {
+                if (sfd.FileName.ToLower().EndsWith(".png"))
+                {
+                    textureFileControlModel.addTexture(sfd.FileName);
+                    reloadContents();
+                }
+            }
+        }
+        public void Animation_Export(object sender, RoutedEventArgs e)
+        {
+            if (LV_Animations.SelectedItem != null)
+            {
+                TextureAnimation texAnim = LV_Animations.SelectedItem as TextureAnimation;
+
+                BitmapSource bitmapImage = ImageUtils.getBitmapSource(texAnim, textureFileControlModel.textureData.Images[texAnim.TextureIndex].GetClut());
+
+                System.Windows.Forms.SaveFileDialog sfd;
+                sfd = new System.Windows.Forms.SaveFileDialog();
+                sfd.Title = "Export image as PNG";
+                sfd.FileName = "Texture.png";
+                sfd.ShowDialog();
+                if (sfd.FileName != "")
+                {
+                    MemoryStream memStream = new MemoryStream();
+                    AssimpGeneric.ExportBitmapSourceAsPng(bitmapImage, sfd.FileName);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Images shown in the MDLX Editor can now be exported.

![export](https://user-images.githubusercontent.com/20492864/219956788-79be4885-aefd-463c-878a-e587d7cff79b.png)

There's code (Written but hidden in the view) for adding/removing textures, however the textures are created from the data. Since the actual data remains the same, the output file will remain the same. This'll only work if the textures are changed in the actual data, for which there's no code as of now.