### PR TITLE
Fix updater errors of OpenKh.Tools.ModsManager

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/OpenkhUpdateCheckerService.cs
+++ b/OpenKh.Tools.ModsManager/Services/OpenkhUpdateCheckerService.cs
@@ -49,18 +49,15 @@ namespace OpenKh.Tools.ModsManager.Services
 
                 var localReleaseTagFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "openkh-release");
                 var localReleaseTag = File.Exists(localReleaseTagFile)
-                    ? File.ReadAllText(localReleaseTagFile)
+                    ? File.ReadAllLines(localReleaseTagFile).First()
                     : "(Unknown version)";
 
-                if (localReleaseTag != remoteReleaseTag)
-                {
-                    return new CheckResult(
-                        HasUpdate: true,
-                        CurrentVersion: localReleaseTag,
-                        NewVersion: remoteReleaseTag,
-                        DownloadZipUrl: latestAsset.Asset.BrowserDownloadUrl
-                    );
-                }
+                return new CheckResult(
+                    HasUpdate: localReleaseTag != remoteReleaseTag,
+                    CurrentVersion: localReleaseTag,
+                    NewVersion: remoteReleaseTag,
+                    DownloadZipUrl: latestAsset.Asset.BrowserDownloadUrl
+                );
             }
 
             return new CheckResult(

--- a/OpenKh.Tools.ModsManager/Services/OpenkhUpdateProceederService.cs
+++ b/OpenKh.Tools.ModsManager/Services/OpenkhUpdateProceederService.cs
@@ -48,7 +48,7 @@ namespace OpenKh.Tools.ModsManager.Services
                 tempBatFile: tempBatFile,
                 copyFrom: Path.Combine(tempZipDir, "openkh"),
                 copyTo: copyTo,
-                execAfter: $"start {Path.Combine(copyTo, "OpenKh.Tools.ModsManager.exe")}" // no enclosing double-quotes!
+                execAfter: $"start \"\" \"{Path.Combine(copyTo, "OpenKh.Tools.ModsManager.exe")}\""
             );
 
             Process.Start(

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -889,6 +889,12 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     Window?.Close();
                 }
             }
+            else
+            {
+                var message = $"The latest version '{checkResult.CurrentVersion}' is already installed!";
+
+                MessageBox.Show(message, "OpenKh");
+            }
         }
     }
 }


### PR DESCRIPTION
- Use first line of `openkh-release` instead of entire file. Because the local release tag file `openkh-release` is suffixed by `\n`.

```sh
$ hexdump.exe -C openkh-release
00000000  72 65 6c 65 61 73 65 32  2d 34 33 36 0a           |release2-436.|
0000000d
```

- Fix that ModsManager cannot be re-launched after update if full path of `OpenKh.Tools.ModsManager.exe` contains at least one space.

- Display "The latest version '{checkResult.CurrentVersion}' is already installed!" when update is not required.

![2023-02-23_01h10_34](https://user-images.githubusercontent.com/5955540/220687785-9f9a5838-79c2-47e7-abfc-8161d8f85de0.png)
