### PR TITLE
add dinput8.dll hooking support to Panacea

### DIFF
--- a/OpenKh.Research.Panacea/dllmain.cpp
+++ b/OpenKh.Research.Panacea/dllmain.cpp
@@ -10,6 +10,10 @@
 
 typedef BOOL(WINAPI* PFN_MiniDumpWriteDump)(HANDLE hProcess, DWORD ProcessId, HANDLE hFile, MINIDUMP_TYPE DumpType, PMINIDUMP_EXCEPTION_INFORMATION ExceptionParam, PMINIDUMP_USER_STREAM_INFORMATION UserStreamParam, PMINIDUMP_CALLBACK_INFORMATION CallbackParam);
 PFN_MiniDumpWriteDump MiniDumpWriteDumpPtr;
+typedef HRESULT(WINAPI* PFN_DirectInput8Create)(HINSTANCE hinst, DWORD dwVersion, LPCVOID riidltf, LPVOID* ppvOut, LPVOID punkOuter);
+PFN_DirectInput8Create DirectInput8CreatePtr;
+
+
 void HookDbgHelp()
 {
     if (PathFileExists(L"LuaBackend.dll"))
@@ -29,6 +33,25 @@ void HookDbgHelp()
     assert(hModule != nullptr);
 }
 
+void HookDInput8()
+{
+    if (PathFileExists(L"LuaBackend.dll"))
+        LoadLibrary(L"LuaBackend.dll");
+    const char OriginalDllName[] = "\\DINPUT8.dll";
+    char buffer[MAX_PATH];
+
+    auto initialLength = GetSystemDirectoryA(buffer, sizeof(buffer) - sizeof(OriginalDllName) - 1);
+    assert(initialLength > 0);
+
+    strcpy(buffer + initialLength, OriginalDllName);
+
+    auto hModule = LoadLibraryA(buffer);
+    assert(hModule != nullptr);
+
+    DirectInput8CreatePtr = (PFN_DirectInput8Create)GetProcAddress(hModule, "DirectInput8Create");
+    assert(hModule != nullptr);
+}
+
 BOOL APIENTRY DllMain(
     HMODULE hModule,
     DWORD ul_reason_for_call,
@@ -38,6 +61,7 @@ BOOL APIENTRY DllMain(
     {
     case DLL_PROCESS_ATTACH:
         HookDbgHelp();
+        HookDInput8();
         OpenKH::Initialize();
         break;
     case DLL_THREAD_ATTACH:
@@ -49,8 +73,16 @@ BOOL APIENTRY DllMain(
     return TRUE;
 }
 
+
 extern "C" __declspec(dllexport) BOOL WINAPI MiniDumpWriteDump(HANDLE hProcess, DWORD ProcessId, HANDLE hFile, MINIDUMP_TYPE DumpType, PMINIDUMP_EXCEPTION_INFORMATION ExceptionParam, PMINIDUMP_USER_STREAM_INFORMATION UserStreamParam, PMINIDUMP_CALLBACK_INFORMATION CallbackParam)
 {
     if (!MiniDumpWriteDumpPtr) HookDbgHelp();
     return MiniDumpWriteDumpPtr(hProcess, ProcessId, hFile, DumpType, ExceptionParam, UserStreamParam, CallbackParam);
+}
+
+
+extern "C" __declspec(dllexport) HRESULT WINAPI DirectInput8Create(HINSTANCE hinst, DWORD dwVersion, LPCVOID riidltf, LPVOID * ppvOut, LPVOID punkOuter)
+{
+    if (!DirectInput8CreatePtr) HookDInput8();
+    return DirectInput8CreatePtr(hinst, dwVersion, riidltf, ppvOut, punkOuter);
 }


### PR DESCRIPTION
This PR adds the ability for Panacea to hook using 'DINPUT8.dll' as opposed to "DBGHELP.DLL". This method is used by LuaBackend, which is where I got the idea (and code hook information) to add support for this method of hooking.

Hooking this way plays more nicely with WINE, which would otherwise need a copy of 'imagehlp.dll' from a real windows installation to hook with the game due to passthrough conflicts with dbghelp.dll (many WINE dlls reduce code redundancy by forwarding to other DLLs for similar system calls). While this doesn't eliminate all issues with Linux support, it does help with issue #545 

Some testing has been carried out under Windows and Linux through WINE running a GoA seed.

Building in debug mode created a bunch of 'stack corruption' errors; I do not know if this occurs in standard releases of panacea outside of debug mode. Building in release suppresses them, and the DLL seemed to work regardless.

This PR will be left in Draft until some more testing (preferably by people other then me) has been carried out.