### PR TITLE
Restore rename/clarification

### DIFF
--- a/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
@@ -69,13 +69,13 @@
                 <MenuItem Header="Build Only" Command="{Binding BuildCommand}" InputGestureText="Ctrl+B"/>
                 <MenuItem Header="Run Only" Command="{Binding RunCommand}" InputGestureText="Ctrl+F5"/>
                 <MenuItem Header="Stop" Command="{Binding StopRunningInstanceCommand}" Visibility="{Binding notPC}" InputGestureText="Shift+F5"/>
-                <MenuItem Header="Restore" Command="{Binding RestoreCommand}" Visibility="{Binding isPC}" CommandParameter="False" InputGestureText="Ctrl+R"/>
+                <MenuItem Header="Fast Restore" Command="{Binding RestoreCommand}" Visibility="{Binding isPC}" CommandParameter="False" InputGestureText="Ctrl+R"/>
             </MenuItem>
             <MenuItem Header="Patching" Visibility="{Binding PatchVisible}">
                 <MenuItem Header="Build and Patch" Command="{Binding PatchCommand}" CommandParameter="false" InputGestureText="Ctrl+P"/>
                 <MenuItem Header="Build and Fast Patch" Command="{Binding PatchCommand}" CommandParameter="true" InputGestureText="Ctrl+P+F"/>
                 <MenuItem Header="Run Only" Command="{Binding RunCommand}" InputGestureText="Ctrl+F5"/>
-                <MenuItem Header="Restore" Command="{Binding RestoreCommand}" CommandParameter="True" InputGestureText="Ctrl+R"/>
+                <MenuItem Header="Full Restore" Command="{Binding RestoreCommand}" CommandParameter="True" InputGestureText="Ctrl+R"/>
             </MenuItem>
             <MenuItem Header="_Settings">
                 <MenuItem Header="Run _wizard" Command="{Binding WizardCommand}"  InputGestureText="Alt+W"/>


### PR DESCRIPTION
Named Mod Loader Restore to Fast Restore as it does not actually "Restore" the game files to vanilla

Named Patching Restore to Full Restore as it does Restore game files to vanilla

I believe this is a decent naming and sticks to the use of full and fast already but if there is a better naming let me know. Don't think they should be named exactly the same when they don't do the same thing