### PR TITLE
MdlxEditor bones edition

### DIFF
--- a/OpenKh.Kh2/Models/ModelSkeletal.cs
+++ b/OpenKh.Kh2/Models/ModelSkeletal.cs
@@ -3,6 +3,7 @@ using OpenKh.Common.Utils;
 using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
+using System.Reflection;
 using Xe.BinaryMapper;
 using static OpenKh.Kh2.Models.ModelCommon;
 
@@ -271,6 +272,14 @@ namespace OpenKh.Kh2.Models
 
             // Generates the mesh
             return GetSkeletalMeshFromVpuGroup(vpuGroup, boneMatrices);
+        }
+
+        public void recalculateMeshes()
+        {
+            foreach (SkeletalGroup group in Groups)
+            {
+                group.Mesh = getMeshFromGroup(group, GetBoneMatrices(Bones));
+            }
         }
 
         //----------------------------

--- a/OpenKh.Tools.Kh2MdlxEditor/ViewModels/ModelBones_VM.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/ViewModels/ModelBones_VM.cs
@@ -1,0 +1,14 @@
+using OpenKh.Kh2.Models;
+
+namespace OpenKh.Tools.Kh2MdlxEditor.ViewModels
+{
+    public class ModelBones_VM
+    {
+        public ModelSkeletal ModelFile { get; set; }
+        public ModelBones_VM() { }
+        public ModelBones_VM(ModelSkeletal modelFile)
+        {
+            ModelFile = modelFile;
+        }
+    }
+}

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/Main2_Window.xaml
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/Main2_Window.xaml
@@ -36,7 +36,7 @@
             <!-- Side menu -->
             <StackPanel Grid.Column="1" Background="#2d2d2d">
                 <!-- Model -->
-                <Image x:Name="sideModel" Visibility="Collapsed" Height="50" Source="../Assets/IconModelW.png" MouseLeftButtonUp="Side_Model"></Image>
+                <Image x:Name="sideModel" Visibility="Collapsed" Height="50" Source="../Assets/IconModelW.png" MouseLeftButtonUp="Side_Model" MouseRightButtonUp="Side_ModelBones"></Image>
                 <!-- Texture -->
                 <Image x:Name="sideTexture" Visibility="Collapsed" Height="50" Source="../Assets/IconTextureW.png" MouseLeftButtonUp="Side_Texture"></Image>
                 <!-- Collision -->

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/Main2_Window.xaml.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/Main2_Window.xaml.cs
@@ -79,6 +79,10 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
         {
             reloadModelControl();
         }
+        private void Side_ModelBones(object sender, EventArgs e)
+        {
+            contentFrame.Content = new ModelBones_Control(mainVM.ModelFile);
+        }
         private void Side_Texture(object sender, EventArgs e)
         {
             contentFrame.Content = new TextureFile_Control(mainVM.TextureFile);

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/ModelBones_Control.xaml
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/ModelBones_Control.xaml
@@ -1,0 +1,34 @@
+<UserControl x:Class="OpenKh.Tools.Kh2MdlxEditor.Views.ModelBones_Control"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:OpenKh.Tools.Kh2MdlxEditor.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    
+    <DataGrid Name="DataTable"
+                AutoGenerateColumns="False"
+                ItemsSource="{Binding ModelFile.Bones}"
+                CanUserAddRows="True">
+        <DataGrid.Columns>
+            <DataGridTextColumn Binding="{Binding Path=Index}" Header="Index" />
+            <DataGridTextColumn Binding="{Binding Path=SiblingIndex}" Header="SiblingIndex" />
+            <DataGridTextColumn Binding="{Binding Path=ParentIndex}" Header="ParentIndex" />
+            <DataGridTextColumn Binding="{Binding Path=ChildIndex}" Header="ChildIndex" />
+            <DataGridTextColumn Binding="{Binding Path=ScaleX}" Header="ScaleX" />
+            <DataGridTextColumn Binding="{Binding Path=ScaleY}" Header="ScaleY" />
+            <DataGridTextColumn Binding="{Binding Path=ScaleZ}" Header="ScaleZ" />
+            <DataGridTextColumn Binding="{Binding Path=ScaleW}" Header="ScaleW" />
+            <DataGridTextColumn Binding="{Binding Path=RotationX}" Header="RotationX" />
+            <DataGridTextColumn Binding="{Binding Path=RotationY}" Header="RotationY" />
+            <DataGridTextColumn Binding="{Binding Path=RotationZ}" Header="RotationZ" />
+            <DataGridTextColumn Binding="{Binding Path=RotationW}" Header="RotationW" />
+            <DataGridTextColumn Binding="{Binding Path=TranslationX}" Header="TranslationX" />
+            <DataGridTextColumn Binding="{Binding Path=TranslationY}" Header="TranslationY" />
+            <DataGridTextColumn Binding="{Binding Path=TranslationZ}" Header="TranslationZ" />
+            <DataGridTextColumn Binding="{Binding Path=TranslationW}" Header="TranslationW" />
+        </DataGrid.Columns>
+    </DataGrid>
+    
+</UserControl>

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/ModelBones_Control.xaml
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/ModelBones_Control.xaml
@@ -28,6 +28,7 @@
             <DataGridTextColumn Binding="{Binding Path=TranslationY}" Header="TranslationY" />
             <DataGridTextColumn Binding="{Binding Path=TranslationZ}" Header="TranslationZ" />
             <DataGridTextColumn Binding="{Binding Path=TranslationW}" Header="TranslationW" />
+            <DataGridTextColumn Binding="{Binding Path=Flags}" Header="Flags" />
         </DataGrid.Columns>
     </DataGrid>
     

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/ModelBones_Control.xaml.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/ModelBones_Control.xaml.cs
@@ -1,0 +1,22 @@
+using OpenKh.Kh2.Models;
+using OpenKh.Tools.Kh2MdlxEditor.ViewModels;
+using System.Windows.Controls;
+
+namespace OpenKh.Tools.Kh2MdlxEditor.Views
+{
+    public partial class ModelBones_Control : UserControl
+    {
+        ModelBones_VM ThisVM { get; set; }
+
+        public ModelBones_Control()
+        {
+            InitializeComponent();
+        }
+        public ModelBones_Control(ModelSkeletal modelFile)
+        {
+            InitializeComponent();
+            ThisVM = new ModelBones_VM(modelFile);
+            DataContext = ThisVM;
+        }
+    }
+}

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/Model_Control.xaml.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/Model_Control.xaml.cs
@@ -20,6 +20,10 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
         public Model_Control(ModelSkeletal modelFile, ModelTexture textureFile, ModelCollision? collisionFile = null)
         {
             InitializeComponent();
+
+            // Recalc meshes
+            modelFile.recalculateMeshes();
+
             modelControlModel = new Model_VM(modelFile, textureFile, collisionFile);
             DataContext = modelControlModel;
             List<GeometryModel3D> geometry = new List<GeometryModel3D>();


### PR DESCRIPTION
Adds a page to edit the bones. This includes editing their translation as well as adding new bones if wanted (Beware of mset bone count)
Opened by right clicking the model icon (sphere)

![ModelBones](https://github.com/OpenKH/OpenKh/assets/20492864/672c408e-cc0e-48ad-b4c6-482e98c2cce2)

Note: The Flags column is added just in case it's needed, I haven't bothered with implementing its decoding/encoding. The bitmap goes like this:
terminate
below
enableBias
reserved [19]
undefined [10]