### PR TITLE
Workaround to avoid that wrong preview sprite is shown on Sprite editor in OpenKh.Tools.LayoutEditor

### DIFF
--- a/OpenKh.Tools.LayoutEditor/Dialogs/SpriteEditDialog.cs
+++ b/OpenKh.Tools.LayoutEditor/Dialogs/SpriteEditDialog.cs
@@ -58,6 +58,7 @@ namespace OpenKh.Tools.LayoutEditor.Dialogs
                 DrawCropAtlasTexture();
             }
 
+            ImGui.Image(_cropAtlasTextureId, Vector2.Zero);
             ImGui.Image(_cropAtlasTextureId, new Vector2(_atlasTexture.Width, _atlasTexture.Height));
 
             var source = new int[]
@@ -109,6 +110,7 @@ namespace OpenKh.Tools.LayoutEditor.Dialogs
             }
 
             SpriteModel.Draw(0, 0);
+            ImGui.Image(SpriteModel.TextureId, Vector2.Zero);
             ImGui.Image(SpriteModel.TextureId, SuggestSpriteSize());
         }
 

--- a/OpenKh.Tools.LayoutEditor/Dialogs/SpriteEditDialog.cs
+++ b/OpenKh.Tools.LayoutEditor/Dialogs/SpriteEditDialog.cs
@@ -1,6 +1,7 @@
 using ImGuiNET;
 using OpenKh.Engine.Extensions;
 using OpenKh.Engine.Renders;
+using static OpenKh.Tools.Common.CustomImGui.ImGuiEx;
 using OpenKh.Tools.LayoutEditor.Interfaces;
 using OpenKh.Tools.LayoutEditor.Models;
 using System;
@@ -58,8 +59,12 @@ namespace OpenKh.Tools.LayoutEditor.Dialogs
                 DrawCropAtlasTexture();
             }
 
-            ImGui.Image(_cropAtlasTextureId, Vector2.Zero);
-            ImGui.Image(_cropAtlasTextureId, new Vector2(_atlasTexture.Width, _atlasTexture.Height));
+            ForChild("AtlasTexture", _atlasTexture.Width, _atlasTexture.Height, false,
+                () =>
+                {
+                    ImGui.Image(_cropAtlasTextureId, new Vector2(_atlasTexture.Width, _atlasTexture.Height));
+                }
+            );
 
             var source = new int[]
             {
@@ -110,8 +115,13 @@ namespace OpenKh.Tools.LayoutEditor.Dialogs
             }
 
             SpriteModel.Draw(0, 0);
-            ImGui.Image(SpriteModel.TextureId, Vector2.Zero);
-            ImGui.Image(SpriteModel.TextureId, SuggestSpriteSize());
+            var spriteSize = SuggestSpriteSize();
+            ForChild("Sprite", spriteSize.X, spriteSize.Y, false,
+                () =>
+                {
+                    ImGui.Image(SpriteModel.TextureId, spriteSize);
+                }
+            );
         }
 
         private void DrawCropAtlasTexture()


### PR DESCRIPTION
When it was broken:

- 434ed0b4cef899e85c2f9124c878b859f05993b2 Good
- e5ac7c1563c439ce648be8199ae5c9e2e1cc6b76 Broken

At 434ed0b4cef899e85c2f9124c878b859f05993b2:

![2023-07-26_18h11_24](https://github.com/OpenKH/OpenKh/assets/5955540/b5f4623a-a4e8-4231-b727-7b7305662589)

At latest:

![2023-07-26_18h10_38](https://github.com/OpenKH/OpenKh/assets/5955540/e1355369-0384-42da-854a-1c9bc8d1b511)

With this workaround:

![2023-07-26_20h08_08](https://github.com/OpenKH/OpenKh/assets/5955540/c7685c68-2366-4367-98d9-f8669b8d6e44)
