### PR TITLE
Fix a swapping problem of R and B channels on OpenKh.Engine.MonoGame

### DIFF
--- a/OpenKh.Engine.MonoGame/MonoSpriteDrawing.cs
+++ b/OpenKh.Engine.MonoGame/MonoSpriteDrawing.cs
@@ -180,7 +180,7 @@ namespace OpenKh.Engine.MonoGame
         {
             var size = image.Size;
             var texture = new RenderTarget2D(_graphicsDevice, size.Width, size.Height);
-            texture.SetData(image.AsBgra8888());
+            texture.SetData(image.AsRgba8888());
 
             return new CSpriteTexture(texture);
         }


### PR DESCRIPTION
Before:

![2023-07-26_20h42_54](https://github.com/OpenKH/OpenKh/assets/5955540/cbe7de83-6ab9-4d89-adda-059201aaf7be)

After:

![2023-07-26_20h42_29](https://github.com/OpenKH/OpenKh/assets/5955540/85ba806e-02ac-4bf8-b687-6857d49730d9)

---

`SurfaceFormat` that RenderTarget2D uses in default is `Color`.

https://github.com/MonoGame/MonoGame/blob/b21463b419e55b4c898030fc22bee77dabb11210/MonoGame.Framework/Graphics/RenderTarget2D.cs#L65-L66

https://docs.monogame.net/api/Microsoft.Xna.Framework.Graphics.SurfaceFormat.html

> Color	
> Unsigned 32-bit ARGB pixel format for store 8 bits per channel.

I'm not sure whether this means that the byte order is `AA RR GG BB` or not.

Fix #825 


