### PR TITLE
Update dotnet.yml

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -52,6 +52,7 @@ jobs:
         path: openkh
 
     - name: "GitHub release latest"
+      if: ${{ github.ref_name == 'master' }}
       uses: "marvinpinto/action-automatic-releases@latest"
       continue-on-error: true # at non master branch this will always fail
       with:
@@ -69,6 +70,6 @@ jobs:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "release2-${{github.run_number}}"
         prerelease: true
-        title: "OpenKh Build ${{github.run_number}}"
+        title: "OpenKh Build ${{github.run_number}} (${{github.ref_name}})"
         files: |
           openkh.zip


### PR DESCRIPTION
Changes to GitHub Actions:

- The `latest` release will be posted only from CI build of `master` branch.
  ![2023-08-02_20h43_38](https://github.com/OpenKH/OpenKh/assets/5955540/062185bf-be92-4452-86fd-0b03e84a08ed)
- Attach the branch name or tag name of the build to the release title, so that users can decide whether the release comes from **official** `master` branch or not.
  ![2023-08-02_20h43_46](https://github.com/OpenKH/OpenKh/assets/5955540/fff9d2e9-90e6-429c-9e6e-7618788bb142)
