### PR TITLE
Multiply the BoneMatrix count by the same value as when updating groups

### DIFF
--- a/OpenKh.Kh2/Models/ModelSkeletal.cs
+++ b/OpenKh.Kh2/Models/ModelSkeletal.cs
@@ -485,7 +485,7 @@ namespace OpenKh.Kh2.Models
             else
             {
                 uint lastPosition = Groups[Groups.Count - 1].Header.BoneMatrixOffset;
-                lastPosition += (uint)(1 + Groups[Groups.Count - 1].BoneMatrix.Count);
+                lastPosition += (uint)(1 + Groups[Groups.Count - 1].BoneMatrix.Count) * 4;
 
                 uint remainingUpTo16 = (uint)(lastPosition % 16);
                 if (remainingUpTo16 != 0)


### PR DESCRIPTION
Fixes a bug during saving MDLX files which calculates the incorrect offset / ModelHeader size, causing subsequent loads to be corrupted. A x4 multiplier seems to have been forgotten here.

![image](https://github.com/OpenKH/OpenKh/assets/47605427/8ff83fd1-b8bc-42e4-898e-7cf2941d55ff)

In general, this issue does not necessarily occur frequently, because for it to occur your last mesh needs to have more than 4 bones. If it has 4 bones or less, then the multiplication by 4 is within the rounding-margin of 16 bits, which will not trigger the problem.

To reproduce the problem on master, load any MDXL (I recommend P_EX100), save it as an .fbx . Then edit the fbx and remove the two small meshes (crown and necklace) so you're left with the two big meshes. Re-import this .fbx into the main model (keep shadows). Save this new .mdlx (a copy of this mdlx is attached to this issue).

Set a breakpoint / console.log / whatever you use at `stream.Position = ReservedSize + model.ModelHeader.Size` in `ModelSkeletal.cs:202`. and reimport the .mdlx. Observe how `stream.Position` in that state is already ahead of `model.ModelHeader.Size` - this import will likely fail, or alternatively, it might succeed with corrupted shadow data.

![image](https://github.com/OpenKH/OpenKh/assets/47605427/c7d3451b-f7ad-416d-8773-392bc50fe26f)
![image](https://github.com/OpenKH/OpenKh/assets/47605427/9cb4976f-f465-43cc-883e-4d0b268e2833)

This is how the failed import looks like, note the missing model button on the right. Texture is still accessible, though.
![image](https://github.com/OpenKH/OpenKh/assets/47605427/8becf452-38a9-4eee-a11d-702684821371)

Attached is also the same file which is exported from this fixed version. It can be imported without issues.

[P_EX100.broken.mdlx.zip](https://github.com/OpenKH/OpenKh/files/12269965/P_EX100.broken.mdlx.zip)
[P_EX100.good.mdlx.zip](https://github.com/OpenKH/OpenKh/files/12269971/P_EX100.good.mdlx.zip)
