### PR TITLE
Implement Texture and Mesh Order Switching

### DIFF
--- a/OpenKh.Kh2/ModelTexture.cs
+++ b/OpenKh.Kh2/ModelTexture.cs
@@ -817,6 +817,14 @@ namespace OpenKh.Kh2
             }
         }
 
+        public void SwapTextures(int index, int swapIndex)
+        {
+            (Images[index], Images[swapIndex]) = (Images[swapIndex], Images[index]);
+            (_textureTransfer[index], _textureTransfer[swapIndex]) =
+                (_textureTransfer[swapIndex], _textureTransfer[index]);
+            (_gsInfo[index], _gsInfo[swapIndex]) = (_gsInfo[swapIndex], _gsInfo[index]);
+        }
+        
         private static void AddOffset(Stream stream, int fileOffset, int delta)
         {
             var buff = new byte[4];

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/Importer_Window.xaml
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/Importer_Window.xaml
@@ -5,7 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:OpenKh.Tools.Kh2MdlxEditor.Views"
         mc:Ignorable="d"
-        Title="Import and Replace Mesh" Height="320" Width="460">
+        Title="Import and Replace Mesh" Height="320" Width="460"
+        Closing="Importer_WindowClose_StoreValues">
     <StackPanel Margin="10">
         <CheckBox Margin="5" IsChecked="{Binding Path=KeepShadow, Mode=TwoWay}">Keep shadow</CheckBox>
         <StackPanel Margin="10" Orientation="Horizontal">

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/Importer_Window.xaml.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/Importer_Window.xaml.cs
@@ -2,6 +2,7 @@ using OpenKh.Kh2.Models.VIF;
 using OpenKh.Tools.Kh2MdlxEditor.Utils;
 using OpenKh.Tools.Kh2MdlxEditor.ViewModels;
 using System;
+using System.ComponentModel;
 using System.Windows;
 
 namespace OpenKh.Tools.Kh2MdlxEditor.Views
@@ -54,6 +55,14 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
                 }
                     
             }
+        }
+
+        private void Importer_WindowClose_StoreValues(object? sender, CancelEventArgs e)
+        {
+            // keeps track of the values of the importer window without having to execute the import
+            MdlxEditorImporter.KEEP_ORIGINAL_SHADOW = importerVM.KeepShadow;
+            VifProcessor.VERTEX_LIMIT = importerVM.VertexLimitPerPacket;
+            VifProcessor.MEMORY_LIMIT = importerVM.MemoryLimitPerPacket;
         }
     }
 }

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/Main2_Window.xaml.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/Main2_Window.xaml.cs
@@ -81,7 +81,7 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
         }
         private void Side_Texture(object sender, EventArgs e)
         {
-            contentFrame.Content = new TextureFile_Control(mainVM.TextureFile);
+            contentFrame.Content = new TextureFile_Control(mainVM.TextureFile, mainVM.ModelFile);
         }
         private void Side_Collision(object sender, EventArgs e)
         {
@@ -99,7 +99,7 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
         public void loadFile(string filePath)
         {
             contentFrame.Content = null;
-            mainVM = (filePath != null) ? new Main2_VM(filePath) : new Main2_VM();
+            mainVM = (filePath != null) ? new Main2_VM(this, filePath) : new Main2_VM(this);
             DataContext = mainVM;
 
             if(mainVM.ModelFile != null)
@@ -186,7 +186,7 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
         {
             if (mainVM.ModelFile != null)
             {
-                contentFrame.Content = new Model_Control(mainVM.ModelFile, mainVM.TextureFile, mainVM.CollisionFile);
+                contentFrame.Content = new Model_Control(mainVM);
             }
         }
     }

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/Main_Window.xaml.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/Main_Window.xaml.cs
@@ -120,7 +120,8 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
                     contentFrame.Content = new ModelFile_Control(mainWiewModel.ModelFile);
                     break;
                 case Bar.EntryType.ModelTexture:
-                    contentFrame.Content = new TextureFile_Control(mainWiewModel.TextureFile);
+                    // TODO the second parameter should be the texture file, but it's not available here. 
+                    contentFrame.Content = new TextureFile_Control(mainWiewModel.TextureFile, null);
                     break;
                 case Bar.EntryType.ModelCollision:
                     contentFrame.Content = new Collision_Control(mainWiewModel.CollisionFile);

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/Model_Control.xaml
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/Model_Control.xaml
@@ -39,12 +39,13 @@
         <Grid Grid.Column="2" Background="#202020">
             <Grid.RowDefinitions>
                 <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="2" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             
             <!-- Meshes -->
-            <ListView Grid.Row="0" ItemsSource="{Binding Groups}" Background="#1d1d1d" Foreground="White">
+            <ListView Name="LV_Meshes" Grid.Row="0" ItemsSource="{Binding Groups}" Background="#1d1d1d" Foreground="White">
                 <ListView.Resources>
                     <Style TargetType="GridViewColumnHeader">
                         <Setter Property="Visibility" Value="Collapsed" />
@@ -84,9 +85,20 @@
                 </ListView.View>
             </ListView>
             
-            <GridSplitter Grid.Row="1" VerticalAlignment="Stretch" />
+            <DockPanel Grid.Row="1">
+                <!-- Buttons to reorder the meshes -->
+                <Button DockPanel.Dock="Right" Margin="5" HorizontalAlignment="Right" Width="40" Height="25" Click="Mesh_MoveDown"
+                        ToolTip="Move the selected mesh up. This uses an fbx export and import behind the scenes, make sure the settings in `File > Import > Replace Mesh...` are correct." >
+                    \/
+                </Button>
+                <Button DockPanel.Dock="Right" Margin="5" HorizontalAlignment="Right" Width="40" Height="25" Click="Mesh_MoveUp" 
+                        ToolTip="Move the selected mesh down. This uses an fbx export and import behind the scenes, make sure the settings in `File > Import > Replace Mesh...` are correct." >
+                    /\
+                </Button>
+            </DockPanel>
+            <GridSplitter Grid.Row="2" VerticalAlignment="Stretch"/>
 
-            <ContentControl Grid.Row="2" Background="#2d2d2d" x:Name="meshPropertiesFrame"/>
+            <ContentControl Grid.Row="3" Background="#2d2d2d" x:Name="meshPropertiesFrame"/>
             
         </Grid>
         

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/Model_Control.xaml.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/Model_Control.xaml.cs
@@ -1,26 +1,28 @@
-using OpenKh.Kh2;
-using OpenKh.Kh2.Models;
-using OpenKh.Tools.Kh2MdlxEditor.Utils;
-using OpenKh.Tools.Kh2MdlxEditor.ViewModels;
 using System.Collections.Generic;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media.Media3D;
+using OpenKh.Tools.Kh2MdlxEditor.Utils;
+using OpenKh.Tools.Kh2MdlxEditor.ViewModels;
 
 namespace OpenKh.Tools.Kh2MdlxEditor.Views
 {
     public partial class Model_Control : UserControl
     {
+        Main2_VM mainVM { get; set; }
         Model_VM modelControlModel { get; set; }
 
         public Model_Control()
         {
             InitializeComponent();
         }
-        public Model_Control(ModelSkeletal modelFile, ModelTexture textureFile, ModelCollision? collisionFile = null)
+        public Model_Control(Main2_VM mainVm)
         {
+            this.mainVM = mainVm;
+
             InitializeComponent();
-            modelControlModel = new Model_VM(modelFile, textureFile, collisionFile);
+            modelControlModel = new Model_VM(mainVm.ModelFile, mainVm.TextureFile, mainVm.CollisionFile);
             DataContext = modelControlModel;
             List<GeometryModel3D> geometry = new List<GeometryModel3D>();
             geometry.AddRange(Viewport3DUtils.getGeometryFromModel(modelControlModel.ModelFile, modelControlModel.TextureFile));
@@ -43,6 +45,44 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
             group.Selected_VM = !group.Selected_VM;
             drawSelectedGroups();
         }
+
+        public void Mesh_MoveUp(object sender, RoutedEventArgs e)
+        {
+            if (LV_Meshes.SelectedItem == null) return;
+
+            MoveCurrentMeshBy(-1);
+        }
+        
+        public void Mesh_MoveDown(object sender, RoutedEventArgs e)
+        {
+            if (LV_Meshes.SelectedItem == null) return;
+
+            MoveCurrentMeshBy(1);
+        }
+
+        private void MoveCurrentMeshBy(int offset)
+        {
+            // calculate index with a wraparound values
+            var swapIndex = ((LV_Meshes.SelectedIndex + offset + LV_Meshes.Items.Count) % LV_Meshes.Items.Count); ;
+            SwapGroups(LV_Meshes.SelectedIndex, swapIndex);
+            
+            mainVM.reloadModelFromFbx();
+            
+        }
+
+        private void SwapGroups(int index, int swapIndex)
+        {
+            var viewModelGroups = modelControlModel.Groups;
+            (viewModelGroups[index], viewModelGroups[swapIndex])  = (viewModelGroups[swapIndex], viewModelGroups[index]);
+
+            var modelSkeletal = mainVM.ModelFile;
+            var skeletalGroups = modelSkeletal.Groups;
+            (skeletalGroups[index], skeletalGroups[swapIndex]) = (skeletalGroups[swapIndex], skeletalGroups[index]);
+
+            // var shadowGroups = modelSkeletal.Shadow.Groups;
+            // (shadowGroups[index], shadowGroups[swapIndex])  = (shadowGroups[swapIndex], shadowGroups[index]);
+        }
+        
         public void drawSelectedGroups()
         {
             List<GeometryModel3D> geometry = new List<GeometryModel3D>();

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/TextureFile_Control.xaml
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/TextureFile_Control.xaml
@@ -30,6 +30,7 @@
         <Grid Grid.Column="3" Background="#222222">
             <Grid.RowDefinitions>
                 <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             
@@ -51,10 +52,20 @@
                         </Style>
                     </ListView.ItemContainerStyle>
                 </ListView>
+                
+            </DockPanel>
+            <DockPanel Grid.Row="1">
+                <!-- Buttons to move the texture up and down -->
+                <Button DockPanel.Dock="Right" Margin="5" HorizontalAlignment="Right" Width="40" Height="25" Click="Texture_MoveDown" ToolTip="Move the active texture up">
+                    \/
+                </Button>
+                <Button DockPanel.Dock="Right" Margin="5" HorizontalAlignment="Right" Width="40" Height="25" Click="Texture_MoveUp" ToolTip="Move the active texture down">
+                    /\
+                </Button>
             </DockPanel>
 
             <!-- Texture animation list -->
-            <DockPanel Grid.Row="1" LastChildFill="True">
+            <DockPanel Grid.Row="2" LastChildFill="True">
                 <Label DockPanel.Dock="Top" Foreground="White" HorizontalAlignment="Center">Texture animations</Label>
                 <ListView Grid.Row="1" Name="LV_Animations" ItemsSource="{Binding textureData.TextureFooterData.TextureAnimationList}" DisplayMemberPath="TextureIndex">
                     <ListView.ContextMenu>

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/TextureFile_Control.xaml.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/TextureFile_Control.xaml.cs
@@ -10,6 +10,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media.Imaging;
+using OpenKh.Kh2.Models;
 
 namespace OpenKh.Tools.Kh2MdlxEditor.Views
 {
@@ -19,15 +20,19 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
     public partial class TextureFile_Control : UserControl
     {
         TextureFile_VM textureFileControlModel { get; set; }
+        
+        // this is used for the Move Texture Up/Down operator, as it needs to update indexes in other places.
+        ModelSkeletal modelFile { get; set; }
 
         public TextureFile_Control()
         {
             InitializeComponent();
         }
-        public TextureFile_Control(ModelTexture textureFile)
+        public TextureFile_Control(ModelTexture textureFile, ModelSkeletal modelFile)
         {
             InitializeComponent();
             textureFileControlModel = new TextureFile_VM(textureFile);
+            this.modelFile = modelFile;
             reloadContents();
         }
 
@@ -39,9 +44,17 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
             {
                 contentFrameTexture.Content = new Texture_Control(textureFileControlModel.textureData.Images[0]);
             }
-            if (textureFileControlModel.textureData.TextureFooterData != null && textureFileControlModel.textureData.TextureFooterData.TextureAnimationList.Count > 0)
+
+            ReloadAnimationContent();
+        }
+        
+        private void ReloadAnimationContent()
+        {
+            if (textureFileControlModel.textureData.TextureFooterData != null 
+                && textureFileControlModel.textureData.TextureFooterData.TextureAnimationList.Count > 0)
             {
-                TextureAnimation texAnimFirst = textureFileControlModel.textureData.TextureFooterData.TextureAnimationList[0];
+                var index = LV_Animations.SelectedItem != null ? LV_Animations.SelectedIndex : 0;
+                TextureAnimation texAnimFirst = textureFileControlModel.textureData.TextureFooterData.TextureAnimationList[index];
                 byte[] clutPalette = null;
                 if (texAnimFirst.TextureIndex < textureFileControlModel.textureData.Images.Count)
                 {
@@ -49,7 +62,9 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
                 }
                 contentFrameAnimation.Content = new TexAnim_Control(texAnimFirst, clutPalette);
             }
+
         }
+
 
         public void ListViewItem_OpenTexture(object sender, MouseButtonEventArgs e)
         {
@@ -66,6 +81,63 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
             }
             contentFrameAnimation.Content = new TexAnim_Control(texAnimSelected, clutPalette);
         }
+        
+        public void Texture_MoveUp(object sender, RoutedEventArgs e)
+        {
+            if (LV_Textures.SelectedItem == null) return; 
+
+            MoveCurrentTextureBy(-1);
+        }
+
+        public void Texture_MoveDown(object sender, RoutedEventArgs e)
+        {
+            if (LV_Textures.SelectedItem == null) return; 
+
+            MoveCurrentTextureBy(1);
+        }
+
+        private void MoveCurrentTextureBy(int offset)
+        {
+            var textureData = (DataContext as TextureFile_VM).textureData;
+            
+            // calculate index with a wraparound
+            var swapIndex = ((LV_Textures.SelectedIndex + offset + LV_Textures.Items.Count) % LV_Textures.Items.Count); ;
+            textureData.SwapTextures(LV_Textures.SelectedIndex, swapIndex);
+            UpdateTextureReferences((ushort) LV_Textures.SelectedIndex, (ushort) swapIndex);
+
+            LV_Textures.Items.Refresh();
+            LV_Animations.Items.Refresh();
+            ReloadAnimationContent();
+        }
+        
+        private void UpdateTextureReferences(ushort textureIndex, ushort swapTextureIndex)
+        {
+            foreach (var modelFileGroup in modelFile.Groups)
+            {
+                var itemIndex = modelFileGroup.Header.TextureIndex;
+                if (itemIndex == textureIndex)
+                {
+                    modelFileGroup.Header.TextureIndex = swapTextureIndex;
+                } else if (itemIndex == swapTextureIndex)
+                {
+                    modelFileGroup.Header.TextureIndex = textureIndex;
+                }
+            }
+
+            var textureAnimations = textureFileControlModel.textureData.TextureFooterData.TextureAnimationList;
+            foreach (var textureAnimation in textureAnimations)
+            {
+                var itemIndex  = textureAnimation.TextureIndex;
+                if (itemIndex  == textureIndex)
+                {
+                    textureAnimation.TextureIndex = swapTextureIndex;
+                } else if (itemIndex  == swapTextureIndex)
+                {
+                    textureAnimation.TextureIndex = textureIndex;
+                }
+            }
+        }
+
         public void Texture_Export(object sender, RoutedEventArgs e)
         {
             if(LV_Textures.SelectedItem != null)


### PR DESCRIPTION
Allows the user to change the order of meshes and textures (but not texture animations) of an mdlx file. Keeps Texture & Texture Animation associations in order, so that the .tim file stays valid (as far as my testing could tell).

Foreword: It's been ages since I wrote C#, and I never have written much WPF to begin with.

![image](https://github.com/OpenKH/OpenKh/assets/47605427/446f2826-a93f-4c35-8c3c-e1bf27120a3d)
![image](https://github.com/OpenKH/OpenKh/assets/47605427/f6fc943b-bc14-417c-81fd-c162c3adc63c)

For Textures, switching order is as simple as changing the order of the `TextureModel` and adjusting a couple indexes.

For Meshes, this is more complicated. For some reason I don't quite understand, messing with the `Mesh` order causes the file to become corrupt when saved as MDLX - the file cannot be opened in other viewers or used in the game (the game crashes). 

Luckily, when we export the modified mdlx as fbx and reimport the same fbx, the model is now exportable as a valid mdlx. So internally, we do exactly that when switching the order. We do have to take a middle step and store it in an temporary file, because apparently during the export process the `scene` still gets modified in a way necessary to make it not corrupted. 

In the future if we figure out why the mdlx is corrupt when the mesh order is changed, we can get rid of this ugly process.

I'm a bit strapped for time, so I just reused the settings menu of the Import Window right now, but if anybody has better ideas how to do this, feel free to suggest or implement.


