### PR TITLE
Fix png loader of OpenKh.Imaging.PngImage

### DIFF
--- a/OpenKh.Imaging/PngImage.cs
+++ b/OpenKh.Imaging/PngImage.cs
@@ -313,7 +313,8 @@ namespace OpenKh.Imaging
                     clut[4 * y + 1] = PLTE[3 * y + 1];
                     clut[4 * y + 2] = PLTE[3 * y + 2];
                 }
-                if (y + 1 <= tRNS.Length)
+                clut[4 * y + 3] = 255;
+                if (y + 1 <= tRNS?.Length)
                 {
                     clut[4 * y + 3] = tRNS[y];
                 }


### PR DESCRIPTION
Fix png loader of OpenKh.Imaging.PngImage: crash when tRNS (transparency or alpha) chunk is missing on indexed image.

`OpenKh.Tools.ImageViewer` is one of affected tools.

![2023-08-07_09h47_43](https://github.com/OpenKH/OpenKh/assets/5955540/34338a74-f8d9-400c-be5b-70c856740b81)
