### PR TITLE
Adding OpenKh.Tools.Kh2FontImageEditor

### DIFF
--- a/OpenKh.Tools.Kh2FontImageEditor/App.xaml
+++ b/OpenKh.Tools.Kh2FontImageEditor/App.xaml
@@ -1,0 +1,8 @@
+<Application x:Class="OpenKh.Tools.Kh2FontImageEditor.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:OpenKh.Tools.Kh2FontImageEditor">
+    <Application.Resources>
+         
+    </Application.Resources>
+</Application>

--- a/OpenKh.Tools.Kh2FontImageEditor/App.xaml.cs
+++ b/OpenKh.Tools.Kh2FontImageEditor/App.xaml.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.DependencyInjection;
+using OpenKh.Tools.Kh2FontImageEditor.DependencyInjection;
+using OpenKh.Tools.Kh2FontImageEditor.Views;
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace OpenKh.Tools.Kh2FontImageEditor
+{
+    /// <summary>
+    /// Interaction logic for App.xaml
+    /// </summary>
+    public partial class App : Application
+    {
+        private ServiceProvider? _container;
+
+        protected override void OnExit(ExitEventArgs e)
+        {
+            _container?.Dispose();
+
+            base.OnExit(e);
+        }
+
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+
+            var builder = new ServiceCollection();
+            builder.UseKh2FontImageEditor();
+            _container = builder.BuildServiceProvider();
+            ShutdownMode = ShutdownMode.OnMainWindowClose;
+            MainWindow = _container.GetRequiredService<MainWindow>();
+            MainWindow.Show();
+        }
+    }
+}

--- a/OpenKh.Tools.Kh2FontImageEditor/AssemblyInfo.cs
+++ b/OpenKh.Tools.Kh2FontImageEditor/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
+                                     //(used if a resource is not found in the page,
+                                     // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
+                                              //(used if a resource is not found in the page,
+                                              // app, or any theme specific resource dictionaries)
+)]

--- a/OpenKh.Tools.Kh2FontImageEditor/DependencyInjection/UseExtension.cs
+++ b/OpenKh.Tools.Kh2FontImageEditor/DependencyInjection/UseExtension.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.DependencyInjection;
+using OpenKh.Tools.Kh2FontImageEditor.Usecases;
+using OpenKh.Tools.Kh2FontImageEditor.ViewModels;
+using OpenKh.Tools.Kh2FontImageEditor.Views;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenKh.Tools.Kh2FontImageEditor.DependencyInjection
+{
+    internal static class UseExtension
+    {
+        public static void UseKh2FontImageEditor(this ServiceCollection container)
+        {
+            container.AddSingleton<MainWindow>();
+            container.AddSingleton<MainWindowVM>();
+            container.AddSingleton<ShowErrorMessageUsecase>();
+        }
+    }
+}

--- a/OpenKh.Tools.Kh2FontImageEditor/OpenKh.Tools.Kh2FontImageEditor.csproj
+++ b/OpenKh.Tools.Kh2FontImageEditor/OpenKh.Tools.Kh2FontImageEditor.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>WinExe</OutputType>
+        <TargetFramework>net6.0-windows</TargetFramework>
+        <Nullable>enable</Nullable>
+        <UseWPF>true</UseWPF>
+        <AssemblyTitle>Font image editor</AssemblyTitle>
+        <Product>Font image editor - OpenKH</Product>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+        
+        <ProjectReference Include="..\OpenKh.Bbs\OpenKh.Bbs.csproj" />
+        <ProjectReference Include="..\OpenKh.Common\OpenKh.Common.csproj" />
+        <ProjectReference Include="..\OpenKh.Tools.Common.WPF\OpenKh.Tools.Common.Wpf.csproj" />
+        <ProjectReference Include="..\OpenKh.Tools.Common\OpenKh.Tools.Common.csproj" />
+        <ProjectReference Include="..\XeEngine.Tools.Public\Xe.Tools.Wpf\Xe.Tools.Wpf.csproj" />
+        <ProjectReference Include="..\XeEngine.Tools.Public\Xe.Tools\Xe.Tools.csproj" />
+        <ProjectReference Include="..\OpenKh.Command.ImgTool\OpenKh.Command.ImgTool.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/OpenKh.Tools.Kh2FontImageEditor/Usecases/ShowErrorMessageUsecase.cs
+++ b/OpenKh.Tools.Kh2FontImageEditor/Usecases/ShowErrorMessageUsecase.cs
@@ -1,0 +1,18 @@
+using OpenKh.Tools.Common.Wpf;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenKh.Tools.Kh2FontImageEditor.Usecases
+{
+    public class ShowErrorMessageUsecase
+    {
+        public void Show(Exception ex)
+        {
+            new MessageDialog($"There is a critical error:\n\n{ex}")
+                .ShowDialog();
+        }
+    }
+}

--- a/OpenKh.Tools.Kh2FontImageEditor/UserControls/ImagerTablet.xaml
+++ b/OpenKh.Tools.Kh2FontImageEditor/UserControls/ImagerTablet.xaml
@@ -1,0 +1,21 @@
+<UserControl x:Class="OpenKh.Tools.Kh2FontImageEditor.UserControls.ImagerTablet"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:OpenKh.Tools.Kh2FontImageEditor.UserControls"
+             mc:Ignorable="d" 
+             x:Name="self"
+             d:DesignHeight="450" d:DesignWidth="450">
+    <DockPanel>
+        <ToolBar DockPanel.Dock="Top">
+            <Label Content="{Binding Caption,ElementName=self}" />
+            <Separator />
+            <Button Content="Import" Command="{Binding ImportCommand,ElementName=self}" CommandParameter="{Binding ImportCommandParameter,ElementName=self}" />
+            <Button Content="Export" Command="{Binding ExportCommand,ElementName=self}" CommandParameter="{Binding ExportCommandParameter,ElementName=self}" />
+        </ToolBar>
+        <Border Background="Black">
+            <Image Source="{Binding Image,ElementName=self}" />
+        </Border>
+    </DockPanel>
+</UserControl>

--- a/OpenKh.Tools.Kh2FontImageEditor/UserControls/ImagerTablet.xaml.cs
+++ b/OpenKh.Tools.Kh2FontImageEditor/UserControls/ImagerTablet.xaml.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace OpenKh.Tools.Kh2FontImageEditor.UserControls
+{
+    /// <summary>
+    /// Interaction logic for ImagerTablet.xaml
+    /// </summary>
+    public partial class ImagerTablet : UserControl
+    {
+        public ImagerTablet()
+        {
+            InitializeComponent();
+        }
+
+        #region Caption
+        public static readonly DependencyProperty CaptionProperty = DependencyProperty.Register(
+            "Caption",
+            typeof(string),
+            typeof(ImagerTablet)
+        );
+
+        public string? Caption
+        {
+            get => (string?)GetValue(CaptionProperty);
+            set => SetValue(CaptionProperty, value);
+        }
+        #endregion
+
+        #region Image
+        public static readonly DependencyProperty ImageProperty = DependencyProperty.Register(
+            "Image",
+            typeof(ImageSource),
+            typeof(ImagerTablet)
+        );
+
+        public ImageSource? Image
+        {
+            get => (ImageSource?)GetValue(ImageProperty);
+            set => SetValue(ImageProperty, value);
+        }
+        #endregion
+
+        #region ImportCommand
+        public static readonly DependencyProperty ImportCommandProperty = DependencyProperty.Register(
+            "ImportCommand",
+            typeof(ICommand),
+            typeof(ImagerTablet)
+        );
+
+        public ICommand? ImportCommand
+        {
+            get => (ICommand?)GetValue(ImportCommandProperty);
+            set => SetValue(ImportCommandProperty, value);
+        }
+        #endregion
+
+        #region ExportCommand
+        public static readonly DependencyProperty ExportCommandProperty = DependencyProperty.Register(
+            "ExportCommand",
+            typeof(ICommand),
+            typeof(ImagerTablet)
+        );
+
+        public ICommand? ExportCommand
+        {
+            get => (ICommand?)GetValue(ExportCommandProperty);
+            set => SetValue(ExportCommandProperty, value);
+        }
+        #endregion
+
+        #region ImportCommandParameter
+        public static readonly DependencyProperty ImportCommandParameterProperty = DependencyProperty.Register(
+            "ImportCommandParameter",
+            typeof(object),
+            typeof(ImagerTablet)
+        );
+
+        public object? ImportCommandParameter
+        {
+            get => (object?)GetValue(ImportCommandParameterProperty);
+            set => SetValue(ImportCommandParameterProperty, value);
+        }
+        #endregion
+
+        #region ExportCommandParameter
+        public static readonly DependencyProperty ExportCommandParameterProperty = DependencyProperty.Register(
+            "ExportCommandParameter",
+            typeof(object),
+            typeof(ImagerTablet)
+        );
+
+        public object? ExportCommandParameter
+        {
+            get => (object?)GetValue(ExportCommandParameterProperty);
+            set => SetValue(ExportCommandParameterProperty, value);
+        }
+        #endregion   
+    }
+}

--- a/OpenKh.Tools.Kh2FontImageEditor/ViewModels/MainWindowVM.cs
+++ b/OpenKh.Tools.Kh2FontImageEditor/ViewModels/MainWindowVM.cs
@@ -1,0 +1,240 @@
+using OpenKh.Common;
+using OpenKh.Imaging;
+using OpenKh.Kh2;
+using OpenKh.Kh2.Contextes;
+using OpenKh.Tools.Common.Imaging;
+using OpenKh.Tools.Common.Wpf;
+using OpenKh.Tools.Kh2FontImageEditor.Usecases;
+using OpenKh.Tools.Kh2FontImageEditor.UserControls;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using System.Windows.Media;
+using Xe.Tools;
+using Xe.Tools.Wpf.Commands;
+using Xe.Tools.Wpf.Dialogs;
+
+namespace OpenKh.Tools.Kh2FontImageEditor.ViewModels
+{
+    public class MainWindowVM : BaseNotifyPropertyChanged
+    {
+        public MainWindowVM(
+            ShowErrorMessageUsecase showErrorMessageUsecase
+        )
+        {
+            OpenCommand = new RelayCommand(
+                _ =>
+                {
+                    try
+                    {
+                        FileDialog.OnOpen(fileName =>
+                        {
+                            LoadFontImage(fileName);
+                            _lastOpenedFile = fileName;
+                        }, OpenFontImageFilters);
+                    }
+                    catch (Exception ex)
+                    {
+                        showErrorMessageUsecase.Show(ex);
+                    }
+                }
+            );
+            SaveCommand = new RelayCommand(
+                _ =>
+                {
+                    try
+                    {
+                        FileDialog.OnSave(fileName =>
+                        {
+                            SaveFontImage(fileName);
+                            _lastOpenedFile = fileName;
+                        }, OpenFontImageFilters, defaultFileName: _lastOpenedFile);
+                    }
+                    catch (Exception ex)
+                    {
+                        showErrorMessageUsecase.Show(ex);
+                    }
+                }
+            );
+            SaveAsCommand = new RelayCommand(
+                _ =>
+                {
+                    try
+                    {
+                        FileDialog.OnSave(fileName =>
+                        {
+                            SaveFontImage(fileName);
+                            _lastOpenedFile = fileName;
+                        }, OpenFontImageFilters, defaultFileName: _lastOpenedFile);
+                    }
+                    catch (Exception ex)
+                    {
+                        showErrorMessageUsecase.Show(ex);
+                    }
+                }
+            );
+
+            System1 = new ImagerModel("System1", it => it.ImageSystem, (it, one) => it.ImageSystem = one);
+            System2 = new ImagerModel("System2", it => it.ImageSystem2, (it, one) => it.ImageSystem2 = one);
+            Event1 = new ImagerModel("Event1", it => it.ImageEvent, (it, one) => it.ImageEvent = one);
+            Event2 = new ImagerModel("Event2", it => it.ImageEvent2, (it, one) => it.ImageEvent2 = one);
+            Icon = new ImagerModel("Icon", it => it.ImageIcon, (it, one) => it.ImageIcon = one);
+
+            ImagerImportCommand = new RelayCommand(
+                imager =>
+                {
+                    try
+                    {
+                        DoImport((ImagerModel)imager!);
+                    }
+                    catch (Exception ex)
+                    {
+                        showErrorMessageUsecase.Show(ex);
+                    }
+                }
+            );
+            ImagerExportCommand = new RelayCommand(
+                imager =>
+                {
+                    try
+                    {
+                        DoExport((ImagerModel)imager!);
+                    }
+                    catch (Exception ex)
+                    {
+                        showErrorMessageUsecase.Show(ex);
+                    }
+                }
+            );
+            AboutCommand = new RelayCommand(
+                _ =>
+                {
+                    new AboutDialog(Assembly.GetExecutingAssembly()).ShowDialog();
+                }
+            );
+        }
+
+        private void SaveFontImage(string fileName)
+        {
+            if (_fontContext == null)
+            {
+                return;
+            }
+
+            var work = new MemoryStream();
+            Bar.Write(work, _fontContext.WriteFontImage());
+            File.WriteAllBytes(fileName, work.ToArray());
+        }
+
+        private void DoExport(ImagerModel imager)
+        {
+            if (_fontContext == null)
+            {
+                return;
+            }
+
+            FileDialog.OnSave(fileName =>
+            {
+                var temp = new MemoryStream();
+                Png.Write(temp, imager.GetImage(_fontContext!)); //TODO use PngImage
+                File.WriteAllBytes(fileName, temp.ToArray());
+            }, OpenPngFilters, defaultFileName: $"{imager.Caption}.png");
+        }
+
+        private void DoImport(ImagerModel imager)
+        {
+            if (_fontContext == null)
+            {
+                return;
+            }
+
+            FileDialog.OnOpen(fileName =>
+            {
+                DoImport(imager, File.OpenRead(fileName).Using(it => PngImage.Read(it)));
+            }, OpenPngFilters, defaultFileName: $"{imager.Caption}.png");
+        }
+
+        private void DoImport(ImagerModel imager, PngImage pngImage)
+        {
+            imager.Image = pngImage.GetBimapSource();
+            imager.SetImage(_fontContext!, pngImage);
+        }
+
+        private void LoadFontImage(string fileName)
+        {
+            _fontContext = new FontContext();
+            _fontContext.Read(File.OpenRead(fileName).Using(stream => Bar.Read(stream)));
+
+            System1.Image = _fontContext.ImageSystem.GetBimapSource();
+            System2.Image = _fontContext.ImageSystem2.GetBimapSource();
+            Event1.Image = _fontContext.ImageEvent.GetBimapSource();
+            Event2.Image = _fontContext.ImageEvent2.GetBimapSource();
+            Icon.Image = _fontContext.ImageIcon.GetBimapSource();
+        }
+
+        private FontContext? _fontContext = new FontContext();
+        private string? _lastOpenedFile = null;
+
+        public ICommand OpenCommand { get; }
+        public ICommand SaveCommand { get; }
+        public ICommand SaveAsCommand { get; }
+        public ICommand AboutCommand { get; }
+
+        public ICommand ImagerImportCommand { get; }
+        public ICommand ImagerExportCommand { get; }
+
+        public ImagerModel System1 { get; }
+        public ImagerModel System2 { get; }
+        public ImagerModel Event1 { get; }
+        public ImagerModel Event2 { get; }
+        public ImagerModel Icon { get; }
+
+        public class ImagerModel : BaseNotifyPropertyChanged
+        {
+            public ImagerModel(string caption, Func<FontContext, IImageRead> getImage, Action<FontContext, IImageRead> setImage)
+            {
+                Caption = caption;
+                GetImage = getImage;
+                SetImage = setImage;
+            }
+
+            public string Caption { get; }
+            internal Func<FontContext, IImageRead> GetImage { get; }
+            internal Action<FontContext, IImageRead> SetImage { get; }
+
+            #region Image
+            private ImageSource? _image;
+            public ImageSource? Image
+            {
+                get => _image;
+                set
+                {
+                    if (_image != value)
+                    {
+                        _image = value;
+                        OnPropertyChanged();
+                    }
+                }
+            }
+            #endregion
+
+        }
+
+        private static readonly List<FileDialogFilter> OpenFontImageFilters = FileDialogFilterComposer
+            .Compose()
+            .AddPatterns("fontimage.bar", new string[] { "fontimage.bar" }.AsEnumerable())
+            .ToList()
+            .AddAllFiles();
+
+        private static readonly List<FileDialogFilter> OpenPngFilters = FileDialogFilterComposer
+            .Compose()
+            .AddExtensions("png", "png")
+            .ToList()
+            .AddAllFiles();
+    }
+}

--- a/OpenKh.Tools.Kh2FontImageEditor/Views/MainWindow.xaml
+++ b/OpenKh.Tools.Kh2FontImageEditor/Views/MainWindow.xaml
@@ -1,0 +1,50 @@
+<Window x:Class="OpenKh.Tools.Kh2FontImageEditor.Views.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:OpenKh.Tools.Kh2FontImageEditor"
+        xmlns:UserControls="clr-namespace:OpenKh.Tools.Kh2FontImageEditor.UserControls"
+        mc:Ignorable="d"
+        WindowStartupLocation="CenterScreen"
+        Title="Kh2FontImageEditor" Height="388" Width="885">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <Menu Grid.Row="0">
+            <MenuItem Header="_File">
+                <MenuItem Header="_Open" Command="{Binding OpenCommand}"/>
+                <MenuItem Header="_Save" Command="{Binding SaveCommand}"/>
+                <MenuItem Header="Save _as..." Command="{Binding SaveAsCommand}"/>
+                <Separator/>
+                <MenuItem Header="E_xit" Command="{Binding ExitCommand}"/>
+            </MenuItem>
+            <MenuItem Header="_Help">
+                <MenuItem Header="_About" Command="{Binding AboutCommand}"/>
+            </MenuItem>
+        </Menu>
+
+        <StatusBar Grid.Row="2">
+        </StatusBar>
+
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <UserControls:ImagerTablet Grid.Column="0" Caption="{Binding System1.Caption}" Image="{Binding System1.Image}" ImportCommand="{Binding ImagerImportCommand}" ExportCommand="{Binding ImagerExportCommand}" ImportCommandParameter="{Binding System1}" ExportCommandParameter="{Binding System1}" />
+            <UserControls:ImagerTablet Grid.Column="1" Caption="{Binding System2.Caption}" Image="{Binding System2.Image}" ImportCommand="{Binding ImagerImportCommand}" ExportCommand="{Binding ImagerExportCommand}" ImportCommandParameter="{Binding System2}" ExportCommandParameter="{Binding System2}" />
+            <UserControls:ImagerTablet Grid.Column="2" Caption="{Binding Event1.Caption}" Image="{Binding Event1.Image}" ImportCommand="{Binding ImagerImportCommand}" ExportCommand="{Binding ImagerExportCommand}" ImportCommandParameter="{Binding Event1}" ExportCommandParameter="{Binding Event1}" />
+            <UserControls:ImagerTablet Grid.Column="3" Caption="{Binding Event2.Caption}" Image="{Binding Event2.Image}" ImportCommand="{Binding ImagerImportCommand}" ExportCommand="{Binding ImagerExportCommand}" ImportCommandParameter="{Binding Event2}" ExportCommandParameter="{Binding Event2}" />
+            <UserControls:ImagerTablet Grid.Column="4" Caption="{Binding Icon.Caption}" Image="{Binding Icon.Image}" ImportCommand="{Binding ImagerImportCommand}" ExportCommand="{Binding ImagerExportCommand}" ImportCommandParameter="{Binding Icon}" ExportCommandParameter="{Binding Icon}" />
+
+        </Grid>
+    </Grid>
+</Window>

--- a/OpenKh.Tools.Kh2FontImageEditor/Views/MainWindow.xaml.cs
+++ b/OpenKh.Tools.Kh2FontImageEditor/Views/MainWindow.xaml.cs
@@ -1,0 +1,32 @@
+using OpenKh.Tools.Kh2FontImageEditor.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace OpenKh.Tools.Kh2FontImageEditor.Views
+{
+    /// <summary>
+    /// Interaction logic for MainWindow.xaml
+    /// </summary>
+    public partial class MainWindow : Window
+    {
+        public MainWindow(
+            MainWindowVM vm
+        )
+        {
+            InitializeComponent();
+            DataContext = vm;
+        }
+    }
+}

--- a/OpenKh.sln
+++ b/OpenKh.sln
@@ -212,6 +212,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenKh.Command.Txa", "OpenK
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Simple3DViewport", "Simple3DViewport\Simple3DViewport\Simple3DViewport.csproj", "{CA7DCF50-324E-4C36-B476-49940EBA393A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenKh.Tools.Kh2FontImageEditor", "OpenKh.Tools.Kh2FontImageEditor\OpenKh.Tools.Kh2FontImageEditor.csproj", "{97E01F25-D6FB-45F0-9FD7-7A88F95F88D0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		.NET Debug|x64 = .NET Debug|x64
@@ -848,6 +850,14 @@ Global
 		{CA7DCF50-324E-4C36-B476-49940EBA393A}.Debug|x64.Build.0 = Debug|Any CPU
 		{CA7DCF50-324E-4C36-B476-49940EBA393A}.Release|x64.ActiveCfg = Release|Any CPU
 		{CA7DCF50-324E-4C36-B476-49940EBA393A}.Release|x64.Build.0 = Release|Any CPU
+		{97E01F25-D6FB-45F0-9FD7-7A88F95F88D0}..NET Debug|x64.ActiveCfg = Debug|Any CPU
+		{97E01F25-D6FB-45F0-9FD7-7A88F95F88D0}..NET Debug|x64.Build.0 = Debug|Any CPU
+		{97E01F25-D6FB-45F0-9FD7-7A88F95F88D0}..NET Release|x64.ActiveCfg = Release|Any CPU
+		{97E01F25-D6FB-45F0-9FD7-7A88F95F88D0}..NET Release|x64.Build.0 = Release|Any CPU
+		{97E01F25-D6FB-45F0-9FD7-7A88F95F88D0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{97E01F25-D6FB-45F0-9FD7-7A88F95F88D0}.Debug|x64.Build.0 = Debug|Any CPU
+		{97E01F25-D6FB-45F0-9FD7-7A88F95F88D0}.Release|x64.ActiveCfg = Release|Any CPU
+		{97E01F25-D6FB-45F0-9FD7-7A88F95F88D0}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -936,6 +946,7 @@ Global
 		{F0A7BD0D-C717-45D5-9544-4C3AECC3740F} = {9C52D787-9819-4B89-989B-EEA6FEB20731}
 		{1D074EA4-9964-43EC-9389-7E60C2545C13} = {0FB7CD6A-EE31-467D-A590-267DCD028618}
 		{EAD6D51F-5106-4E11-A4E4-104A18C0235B} = {9C52D787-9819-4B89-989B-EEA6FEB20731}
+		{97E01F25-D6FB-45F0-9FD7-7A88F95F88D0} = {402B2669-D594-4DFA-965B-02A92626ADC6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1DF3960B-4FE5-4E56-92D4-2FC0A912E823}


### PR DESCRIPTION
![2023-08-07_16h13_36](https://github.com/OpenKH/OpenKh/assets/5955540/11ea2aed-1c1f-4175-85ec-8ef15adac653)

![2023-08-07_16h13_44](https://github.com/OpenKH/OpenKh/assets/5955540/a052bf54-9db4-4996-b9c8-a0892821f71d)

![2023-08-07_16h13_53](https://github.com/OpenKH/OpenKh/assets/5955540/2b7263e2-341d-4a64-8cc8-bdae988bd159)

The one big problem is that color palette of `Icon` image.
This is an `Indexed8` image so we can edit the palette too.
But the _alpha channel_ (Ps2 alpha) of the palette has irregular rule that we had not before.
0 to 128 is mapped to 0 to 255 (0.0 to 1.0) in PC.
129 to 255 is what for? This is for brighter alpha color blending (1.0 to 2.0).
We need good sense and good idea and valid data format to support this overkill usage of alpha channel of color palette for import and export purpose.
