### PR TITLE
Mod Manager update for new panacea 

### DIFF
--- a/OpenKh.Research.Panacea/OpenKh.Research.Panacea.vcxproj
+++ b/OpenKh.Research.Panacea/OpenKh.Research.Panacea.vcxproj
@@ -86,6 +86,9 @@
       <EnableUAC>false</EnableUAC>
       <AdditionalDependencies>Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>copy Dependencies\*.dll ..\Release\</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp" />

--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -388,8 +388,50 @@ namespace OpenKh.Tools.ModsManager.ViewModels
             InstallPanaceaCommand = new RelayCommand(_ =>
             {
                 if (File.Exists(PanaceaSourceLocation))
+                {               
                     // Again, do not bother in debug mode
                     File.Copy(PanaceaSourceLocation, PanaceaDestinationLocation, true);
+                    try
+                    {   
+                        File.Copy(Path.Combine(AppContext.BaseDirectory, "avcodec-vgmstream-59.dll"), Path.Combine(PcReleaseLocation, "avcodec-vgmstream-59.dll"), true);
+                        File.Copy(Path.Combine(AppContext.BaseDirectory, "avformat-vgmstream-59.dll"), Path.Combine(PcReleaseLocation, "avformat-vgmstream-59.dll"), true);
+                        File.Copy(Path.Combine(AppContext.BaseDirectory, "avutil-vgmstream-57.dll"), Path.Combine(PcReleaseLocation, "avutil-vgmstream-57.dll"), true);
+                        File.Copy(Path.Combine(AppContext.BaseDirectory, "bass.dll"), Path.Combine(PcReleaseLocation, "bass.dll"), true);
+                        File.Copy(Path.Combine(AppContext.BaseDirectory, "bass_vgmstream.dll"), Path.Combine(PcReleaseLocation, "bass_vgmstream.dll"), true);
+                        File.Copy(Path.Combine(AppContext.BaseDirectory, "libatrac9.dll"), Path.Combine(PcReleaseLocation, "libatrac9.dll"), true);
+                        File.Copy(Path.Combine(AppContext.BaseDirectory, "libcelt-0061.dll"), Path.Combine(PcReleaseLocation, "libcelt-0061.dll"), true);
+                        File.Copy(Path.Combine(AppContext.BaseDirectory, "libcelt-0110.dll"), Path.Combine(PcReleaseLocation, "libcelt-0110.dll"), true);
+                        File.Copy(Path.Combine(AppContext.BaseDirectory, "libg719_decode.dll"), Path.Combine(PcReleaseLocation, "libg719_decode.dll"), true);
+                        File.Copy(Path.Combine(AppContext.BaseDirectory, "libmpg123-0.dll"), Path.Combine(PcReleaseLocation, "libmpg123-0.dll"), true);
+                        File.Copy(Path.Combine(AppContext.BaseDirectory, "libspeex-1.dll"), Path.Combine(PcReleaseLocation, "libspeex-1.dll"), true);
+                        File.Copy(Path.Combine(AppContext.BaseDirectory, "libvorbis.dll"), Path.Combine(PcReleaseLocation, "libvorbis.dll"), true);
+                        File.Copy(Path.Combine(AppContext.BaseDirectory, "swresample-vgmstream-4.dll"), Path.Combine(PcReleaseLocation, "swresample-vgmstream-4.dll"), true);
+                    }
+                    catch (Exception e) 
+                    {
+                        MessageBox.Show(
+                            $"Missing panacea dependencies. Unable to fully install panacea.",
+                            "Extraction error",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Error);
+                        File.Delete(PanaceaDestinationLocation);
+                        File.Delete(Path.Combine(PcReleaseLocation, "avcodec-vgmstream-59.dll"));
+                        File.Delete(Path.Combine(PcReleaseLocation, "avformat-vgmstream-59.dll"));
+                        File.Delete(Path.Combine(PcReleaseLocation, "avutil-vgmstream-57.dll"));
+                        File.Delete(Path.Combine(PcReleaseLocation, "bass.dll"));
+                        File.Delete(Path.Combine(PcReleaseLocation, "bass_vgmstream.dll"));
+                        File.Delete(Path.Combine(PcReleaseLocation, "libatrac9.dll"));
+                        File.Delete(Path.Combine(PcReleaseLocation, "libcelt-0061.dll"));
+                        File.Delete(Path.Combine(PcReleaseLocation, "libcelt-0110.dll"));
+                        File.Delete(Path.Combine(PcReleaseLocation, "libg719_decode.dll"));
+                        File.Delete(Path.Combine(PcReleaseLocation, "libmpg123-0.dll"));
+                        File.Delete(Path.Combine(PcReleaseLocation, "libspeex-1.dll"));
+                        File.Delete(Path.Combine(PcReleaseLocation, "libvorbis.dll"));
+                        File.Delete(Path.Combine(PcReleaseLocation, "swresample-vgmstream-4.dll"));
+                        PanaceaInstalled = false;
+                        return;
+                    }
+                }
                 OnPropertyChanged(nameof(IsLastPanaceaVersionInstalled));
                 OnPropertyChanged(nameof(PanaceaInstalledVisibility));
                 OnPropertyChanged(nameof(PanaceaNotInstalledVisibility));
@@ -398,7 +440,22 @@ namespace OpenKh.Tools.ModsManager.ViewModels
             RemovePanaceaCommand = new RelayCommand(_ =>
             {
                 if (File.Exists(PanaceaDestinationLocation))
+                {
                     File.Delete(PanaceaDestinationLocation);
+                    File.Delete(Path.Combine(PcReleaseLocation, "avcodec-vgmstream-59.dll"));
+                    File.Delete(Path.Combine(PcReleaseLocation, "avformat-vgmstream-59.dll"));
+                    File.Delete(Path.Combine(PcReleaseLocation, "avutil-vgmstream-57.dll"));
+                    File.Delete(Path.Combine(PcReleaseLocation, "bass.dll"));
+                    File.Delete(Path.Combine(PcReleaseLocation, "bass_vgmstream.dll"));
+                    File.Delete(Path.Combine(PcReleaseLocation, "libatrac9.dll"));
+                    File.Delete(Path.Combine(PcReleaseLocation, "libcelt-0061.dll"));
+                    File.Delete(Path.Combine(PcReleaseLocation, "libcelt-0110.dll"));
+                    File.Delete(Path.Combine(PcReleaseLocation, "libg719_decode.dll"));
+                    File.Delete(Path.Combine(PcReleaseLocation, "libmpg123-0.dll"));
+                    File.Delete(Path.Combine(PcReleaseLocation, "libspeex-1.dll"));
+                    File.Delete(Path.Combine(PcReleaseLocation, "libvorbis.dll"));
+                    File.Delete(Path.Combine(PcReleaseLocation, "swresample-vgmstream-4.dll"));
+                }
                 OnPropertyChanged(nameof(IsLastPanaceaVersionInstalled));
                 OnPropertyChanged(nameof(PanaceaInstalledVisibility));
                 OnPropertyChanged(nameof(PanaceaNotInstalledVisibility));


### PR DESCRIPTION
with error handling to prevent a partial panacea install causing the game to crash.

If Panacea is missing files it will remove Panacea and any partially installed dlls and you will be unable to use the mod loader. Otherwise install works normally. Checksum is still only calculated for Panacea not these dlls.
![image](https://github.com/OpenKH/OpenKh/assets/47014056/24d750d2-ac26-49bb-ada4-978492885fa8)

this adds an additional 13 dlls that Panacea needs to the game install folder. The remove command will remove all 13 + Panacea dlls