### PR TITLE
MDLX builder vertex colors

### DIFF
--- a/OpenKh.AssimpUtils/Kh2MdlxAssimp.cs
+++ b/OpenKh.AssimpUtils/Kh2MdlxAssimp.cs
@@ -224,6 +224,16 @@ namespace OpenKh.AssimpUtils
                         bone.VertexWeights.Add(new Assimp.VertexWeight(currentVertex, weight));
                     }
 
+                    // COLORS
+                    if(vertex.Color != null)
+                    {
+                        float R = vertex.Color.R / 255f;
+                        float G = vertex.Color.G / 255f;
+                        float B = vertex.Color.B / 255f;
+                        float A = vertex.Color.A / 255f;
+                        iMesh.VertexColorChannels[0].Add(new Assimp.Color4D(R, G, B, A));
+                    }
+
                     currentVertex++;
                 }
 
@@ -287,6 +297,14 @@ namespace OpenKh.AssimpUtils
                 short u = (short)(mesh.TextureCoordinateChannels[0][i].X * 4096.0f);
                 short v = (short)((1 - mesh.TextureCoordinateChannels[0][i].Y) * 4096.0f);
                 vertex.UvCoord = new VifCommon.UVCoord(u, v);
+                if (mesh.HasVertexColors(0))
+                {
+                    byte R = (byte)(mesh.VertexColorChannels[0][i].R * 255);
+                    byte G = (byte)(mesh.VertexColorChannels[0][i].G * 255);
+                    byte B = (byte)(mesh.VertexColorChannels[0][i].B * 255);
+                    byte A = (byte)(mesh.VertexColorChannels[0][i].A * 255);
+                    vertex.Color = new VifCommon.VertexColor(R, G, B, A);
+                }
 
                 verticesAssimpOrder.Add(vertex);
             }

--- a/OpenKh.Kh2/Models/ModelCommon.cs
+++ b/OpenKh.Kh2/Models/ModelCommon.cs
@@ -1,3 +1,4 @@
+using OpenKh.Kh2.Models.VIF;
 using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
@@ -181,14 +182,16 @@ namespace OpenKh.Kh2.Models
             public List<BPosition> BPositions { get; set; } // Positions relative to bones
             public float U { get; set; }
             public float V { get; set; }
+            public VifCommon.VertexColor Color { get; set; }
 
             public UVBVertex() { }
-            public UVBVertex(List<BPosition> BonePositions, float U = 0, float V = 0, Vector3 position = new Vector3())
+            public UVBVertex(List<BPosition> BonePositions, float U = 0, float V = 0, Vector3 position = new Vector3(), VifCommon.VertexColor color = null)
             {
                 this.BPositions = BonePositions;
                 this.U = U;
                 this.V = V;
                 Position = position;
+                Color = color;
             }
 
             public override string ToString()

--- a/OpenKh.Kh2/Models/ModelSkeletal.cs
+++ b/OpenKh.Kh2/Models/ModelSkeletal.cs
@@ -1,5 +1,6 @@
 using OpenKh.Common;
 using OpenKh.Common.Utils;
+using OpenKh.Kh2.Models.VIF;
 using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
@@ -236,11 +237,11 @@ namespace OpenKh.Kh2.Models
                 using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
                 {
                     writer.Write(group.BoneMatrix.Count);
-                    foreach (int boneIndex in group.BoneMatrix)
-                    {
+                foreach (int boneIndex in group.BoneMatrix)
+                {
                         writer.Write(boneIndex);
-                    }
                 }
+            }
             }
 
             ModelCommon.alignStreamToByte(stream, 16);
@@ -297,7 +298,15 @@ namespace OpenKh.Kh2.Models
                 // Vertices
                 OpenKh.Ps2.VpuPacket.VertexIndex index = vpuGroup.Indices[i];
                 UVBVertex vertex = vpuGroup.Vertices[index.Index];
-                mesh.Vertices.Add(new UVBVertex(vertex.BPositions, index.U, index.V, ModelCommon.getAbsolutePosition(vertex.BPositions, boneMatrices)));
+
+                if(index.Color != null)
+                {
+                    mesh.Vertices.Add(new UVBVertex(vertex.BPositions, index.U, index.V, ModelCommon.getAbsolutePosition(vertex.BPositions, boneMatrices), new VifCommon.VertexColor((byte)index.Color.R, (byte)index.Color.G, (byte)index.Color.B, (byte)index.Color.A)));
+                }
+                else
+                {
+                    mesh.Vertices.Add(new UVBVertex(vertex.BPositions, index.U, index.V, ModelCommon.getAbsolutePosition(vertex.BPositions, boneMatrices)));
+                }
 
                 // Triangles
                 if (index.Function == OpenKh.Ps2.VpuPacket.VertexFunction.DrawTriangle ||
@@ -440,6 +449,7 @@ namespace OpenKh.Kh2.Models
                 }
 
                 // VPU INDICES (Vertices with spacial position + UV)
+                int previousIndexCount = vpuGroup.Indices.Count;
                 foreach (OpenKh.Ps2.VpuPacket.VertexIndex vertexIndex in vpuPacket.Indices)
                 {
                     OpenKh.Ps2.VpuPacket.VertexIndex newVertexIndex = new OpenKh.Ps2.VpuPacket.VertexIndex();
@@ -448,6 +458,15 @@ namespace OpenKh.Kh2.Models
                     newVertexIndex.U = vertexIndex.U;
                     newVertexIndex.V = vertexIndex.V;
                     vpuGroup.Indices.Add(newVertexIndex);
+                }
+
+                // Colors
+                if(vpuPacket.Indices.Length == vpuPacket.Colors.Length)
+                {
+                    for (int j = 0; j < vpuPacket.Indices.Length; j++)
+                    {
+                        vpuGroup.Indices[previousIndexCount + j].Color = vpuPacket.Colors[j];
+                    }
                 }
 
                 indexCount = vpuGroup.Vertices.Count;

--- a/OpenKh.Kh2/Models/VIF/DmaVifPacket.cs
+++ b/OpenKh.Kh2/Models/VIF/DmaVifPacket.cs
@@ -40,6 +40,14 @@ namespace OpenKh.Kh2.Models.VIF
 
             currentAddress += Header.TriStripNodeOffset;
             currentAddress += Header.TriStripNodeCount;
+
+            if(vifPacket.Colors != null && vifPacket.Colors.Count > 0)
+            {
+                Header.ColorOffset = currentAddress;
+                Header.ColorCount = vifPacket.Colors.Count;
+                currentAddress += Header.ColorCount;
+            }
+
             Header.VertexCoordOffset = currentAddress;
             //Header.VertexCoordCount = vifPacket.PositionCoordsVector.Count;
             Header.VertexCoordCount = vifPacket.PositionCoords.Count;

--- a/OpenKh.Kh2/Models/VIF/VifPacket.cs
+++ b/OpenKh.Kh2/Models/VIF/VifPacket.cs
@@ -17,6 +17,7 @@ namespace OpenKh.Kh2.Models.VIF
         public List<int> BoneList;
         public List<int> BoneCounts;
         public List<List<List<int>>> WeightGroups; // List by weight count (Eg: 1 weight, 2 weights, 3 weights...) - list by entries (Eg: Weight group for vertex 1, WG for vertex 2...) - list of entry's weights (Eg: This weight group has coords 1, 2 & 3)
+        public List<VifCommon.VertexColor> Colors;
         public Dictionary<int, List<WeightGroup>> WeightGroupsByWeightCount;
 
         public VifPacket()
@@ -28,6 +29,7 @@ namespace OpenKh.Kh2.Models.VIF
             BoneList = new List<int>();
             BoneCounts = new List<int>();
             WeightGroups = new List<List<List<int>>>();
+            Colors = new List<VifCommon.VertexColor>();
             WeightGroupsByWeightCount = new Dictionary<int, List<WeightGroup>>();
         }
 
@@ -84,7 +86,7 @@ namespace OpenKh.Kh2.Models.VIF
                 packetLength += VifUtils.getAmountIfGroupedBy(WeightGroups[i].Count * (i + 1), 4);
             }
 
-            //packetLength += colorCount; // 1 per vertex color; not implemented
+            packetLength += Colors.Count; // 1 per vertex color; not implemented
 
             return packetLength;
         }

--- a/OpenKh.Kh2/Models/VIF/VifProcessor.cs
+++ b/OpenKh.Kh2/Models/VIF/VifProcessor.cs
@@ -1,3 +1,4 @@
+using OpenKh.Common;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -176,6 +177,8 @@ namespace OpenKh.Kh2.Models.VIF
 
                         currentPacket.WeightGroups[vertex.RelativePositions.Count - 1].Add(weights);
                     }
+
+                    currentPacket.Colors.Add(vertex.Color);
                 }
 
                 currentPacket.generateBoneData();
@@ -275,6 +278,27 @@ namespace OpenKh.Kh2.Models.VIF
                 }
             }
             ModelCommon.alignStreamToByte(binStream, 4);
+
+            // COLORS
+            if (vifPacket.Colors.Count > 0)
+            {
+                using (var writer = new BinaryWriter(binStream, Encoding.UTF8, true))
+                {
+                    writer.Write(VifUtils.UNPACK);
+                    writer.Write((byte)packet.Header.ColorOffset);
+                    writer.Write(VifUtils.UNIT_SIZE_BYTE);
+                    writer.Write((byte)vifPacket.Colors.Count);
+                    writer.Write(VifUtils.READ_SIZE_4_2);
+                    foreach (VifCommon.VertexColor color in vifPacket.Colors)
+                    {
+                        binStream.Write(color.R);
+                        binStream.Write(color.G);
+                        binStream.Write(color.B);
+                        binStream.Write(color.A);
+                    }
+                }
+                ModelCommon.alignStreamToByte(binStream, 4);
+            }
 
             using (var writer = new BinaryWriter(binStream, System.Text.Encoding.UTF8, true))
             {

--- a/OpenKh.Ps2/VpuPacket.cs
+++ b/OpenKh.Ps2/VpuPacket.cs
@@ -52,6 +52,7 @@ namespace OpenKh.Ps2
             [Data] public int V { get; set; }
             [Data] public int Index { get; set; }
             [Data] public VertexFunction Function { get; set; }
+            public VertexColor Color { get; set; }
 
             public override string ToString() =>
                 $"{U / 4096.0f:F}, {V / 4096.0f:F}, {Index:X}, {Function}";


### PR DESCRIPTION
Adds vertex color support to the MDLX builder.

![image](https://github.com/OpenKH/OpenKh/assets/20492864/79caf570-1ff6-429e-9509-3881a05da8b8)
