### PR TITLE
UV mapping fix

### DIFF
--- a/OpenKh.Tools.Kh2MdlxEditor/Utils/Viewport3DUtils.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/Utils/Viewport3DUtils.cs
@@ -61,7 +61,7 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Utils
             PointCollection myTextureCoordinatesCollection = new PointCollection();
             foreach (ModelCommon.UVBVertex vertex in group.Mesh.Vertices)
             {
-                myTextureCoordinatesCollection.Add(new Point(vertex.U, vertex.V));
+                myTextureCoordinatesCollection.Add(new Point(vertex.U / 4096.0f, vertex.V / 4096.0f));
             }
             myMeshGeometry3D.TextureCoordinates = myTextureCoordinatesCollection;
 
@@ -98,6 +98,12 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Utils
             }
 
             myGeometryModel.Material = myMaterial;
+
+            // Magic vertices so that the UV mapping goes from 0 to 1 instead of scaling to maximum existing
+            myPositionCollection.Add(new Point3D(0, 0, 0));
+            myPositionCollection.Add(new Point3D(0, 0, 0));
+            myTextureCoordinatesCollection.Add(new Point(0, 0));
+            myTextureCoordinatesCollection.Add(new Point(1, 1));
 
             return myGeometryModel;
         }

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/Viewport_Control.xaml.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/Viewport_Control.xaml.cs
@@ -154,7 +154,7 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
             phi -= rX * 0.01;
             length *= 1.0 - 0.1 * rZ;
 
-            theta = Math.Clamp(theta, 0.0001, Math.PI - 0001);
+            theta = Math.Clamp(theta, 0.0001, Math.PI - 0.0001);
 
             vector.X = length * Math.Sin(theta) * Math.Cos(phi);
             vector.Z = -length * Math.Sin(theta) * Math.Sin(phi);

--- a/OpenKh.Tools.Kh2ObjectEditor/Utils/ViewportHelper.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Utils/ViewportHelper.cs
@@ -122,7 +122,7 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Utils
             PointCollection myTextureCoordinatesCollection = new PointCollection();
             foreach (ModelCommon.UVBVertex vertex in group.Mesh.Vertices)
             {
-                myTextureCoordinatesCollection.Add(new Point(vertex.U, vertex.V));
+                myTextureCoordinatesCollection.Add(new Point(vertex.U / 4096.0f, vertex.V / 4096.0f));
             }
             myMeshGeometry3D.TextureCoordinates = myTextureCoordinatesCollection;
 
@@ -159,6 +159,12 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Utils
             }
 
             myGeometryModel.Material = myMaterial;
+
+            // Magic vertices so that the UV mapping goes from 0 to 1 instead of scaling to maximum existing
+            myPositionCollection.Add(new Point3D(0, 0, 0));
+            myPositionCollection.Add(new Point3D(0, 0, 0));
+            myTextureCoordinatesCollection.Add(new Point(0, 0));
+            myTextureCoordinatesCollection.Add(new Point(1, 1));
 
             return myGeometryModel;
         }


### PR DESCRIPTION
In WPF texture UVs (Which go from 0 to 1) take 1 as the highest value in the mapping list, meaning meshes that don't have UVs that go from 0 to 1 would render incorrectly (Thanks WPF)
Whenever the model is rendered in WPF a couple of dummy vertices are added with UVs 0,0 and 1,1 so the mapping scales correctly, which fixes the issue. Now all models should be rendered accurately.

![image](https://github.com/OpenKH/OpenKh/assets/20492864/06080310-596c-45f4-aacd-58e0c2939913)

![image](https://github.com/OpenKH/OpenKh/assets/20492864/b115c673-3321-44cb-ba9d-6ca8bb3b9c93)