### PR TITLE
Gives user the option to overwrite old mod install.

### DIFF
--- a/OpenKh.Tools.ModsManager/Exceptions/Exceptions.cs
+++ b/OpenKh.Tools.ModsManager/Exceptions/Exceptions.cs
@@ -7,7 +7,7 @@ namespace OpenKh.Tools.ModsManager.Exceptions
         public string ModName { get; }
 
         public ModAlreadyExistsExceptions(string modName) :
-            base($"A mod with the name '{modName}' already exists. The installation will now stop.")
+            base($"The previous install of '{modName}' will not be overwritten. The installation will now stop.")
         {
             ModName = modName;
         }

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -285,6 +285,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                             ModsList.Insert(0, Map(mod));
                             SelectedValue = ModsList[0];
                         });
+                        ReloadModsList();
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
In case it partially installed or has been edited and they want to install fresh. They do not have to remove the mod then install can just reinstall. Very helpful if a partial mod install happened because sometimes the mod didn't show up in mod manager so you had to go into the `mods` folder and delete it.

Zip
![image](https://github.com/OpenKH/OpenKh/assets/47014056/8efb3f80-2700-46c2-a9fb-bff06a1a6bbf)
GitHub
![image](https://github.com/OpenKH/OpenKh/assets/47014056/e663726a-1c8d-4797-b898-94d33f69a0b8)
No Click
![image](https://github.com/OpenKH/OpenKh/assets/47014056/f827ecaa-0f75-4f30-bc13-ef233c7277d4)

Yes proceeds like normal after deleting the old mod install.
