### PR TITLE
Revert "Try to fix #877"

### DIFF
--- a/OpenKh.Tools.LayoutEditor/Dialogs/SpriteEditDialog.cs
+++ b/OpenKh.Tools.LayoutEditor/Dialogs/SpriteEditDialog.cs
@@ -59,14 +59,11 @@ namespace OpenKh.Tools.LayoutEditor.Dialogs
                 DrawCropAtlasTexture();
             }
 
-            if (ImGui.Button("Add Sprite"))
+            if (ImGui.Button("+"))
                 _spriteModels.Add(new SpriteModel(new Kh2.Sequence.Sprite(), _spriteDrawing, _atlasTexture, _textureBinder, _settings));
             ImGui.SameLine();
-            if (ImGui.Button("Remove Sprite"))
-            {
-                _selectedSpriteModel -= 1;
-                _spriteModels.RemoveAt(_selectedSpriteModel + 1);
-            }
+            if (ImGui.Button("-"))
+                _spriteModels.RemoveAt(_selectedSpriteModel);
 
             ForChild("AtlasTexture", _atlasTexture.Width, _atlasTexture.Height, false,
                 () =>


### PR DESCRIPTION
Reverts OpenKH/OpenKh#878

The problem (#877) is just reversed now. If you delete the very first sprite (sprite 0) in a layout/sequence file, the program cannot move its index down by 1, and thus crashes. This must be addressed as well now.
Edit: This was my mistake merging. I did not think to test this until the near-instant after I accepted the hotfix.