### PR TITLE
Vertex normals, Vif code update and MDLX importer update

### DIFF
--- a/OpenKh.AssimpUtils/Kh2MdlxAssimp.cs
+++ b/OpenKh.AssimpUtils/Kh2MdlxAssimp.cs
@@ -234,6 +234,12 @@ namespace OpenKh.AssimpUtils
                         iMesh.VertexColorChannels[0].Add(new Assimp.Color4D(R, G, B, A));
                     }
 
+                    // NORMALS
+                    if (vertex.Normal != null)
+                    {
+                        iMesh.Normals.Add(new Assimp.Vector3D(vertex.Normal.X, vertex.Normal.Y, vertex.Normal.Z));
+                    }
+
                     currentVertex++;
                 }
 
@@ -304,6 +310,10 @@ namespace OpenKh.AssimpUtils
                     byte B = (byte)(mesh.VertexColorChannels[0][i].B * 255);
                     byte A = (byte)(mesh.VertexColorChannels[0][i].A * 255);
                     vertex.Color = new VifCommon.VertexColor(R, G, B, A);
+                }
+                if(mesh.HasNormals)
+                {
+                    vertex.Normal = new VifCommon.VertexNormal(mesh.Normals[i].X, mesh.Normals[i].Y, mesh.Normals[i].Z);
                 }
 
                 verticesAssimpOrder.Add(vertex);

--- a/OpenKh.Kh2/Models/ModelCommon.cs
+++ b/OpenKh.Kh2/Models/ModelCommon.cs
@@ -183,15 +183,17 @@ namespace OpenKh.Kh2.Models
             public float U { get; set; }
             public float V { get; set; }
             public VifCommon.VertexColor Color { get; set; }
+            public VifCommon.VertexNormal Normal { get; set; }
 
             public UVBVertex() { }
-            public UVBVertex(List<BPosition> BonePositions, float U = 0, float V = 0, Vector3 position = new Vector3(), VifCommon.VertexColor color = null)
+            public UVBVertex(List<BPosition> BonePositions, float U = 0, float V = 0, Vector3 position = new Vector3(), VifCommon.VertexColor color = null, VifCommon.VertexNormal normal = null)
             {
                 this.BPositions = BonePositions;
                 this.U = U;
                 this.V = V;
                 Position = position;
                 Color = color;
+                Normal = normal;
             }
 
             public override string ToString()

--- a/OpenKh.Kh2/Models/ModelSkeletal.cs
+++ b/OpenKh.Kh2/Models/ModelSkeletal.cs
@@ -299,14 +299,14 @@ namespace OpenKh.Kh2.Models
                 OpenKh.Ps2.VpuPacket.VertexIndex index = vpuGroup.Indices[i];
                 UVBVertex vertex = vpuGroup.Vertices[index.Index];
 
-                if(index.Color != null)
-                {
-                    mesh.Vertices.Add(new UVBVertex(vertex.BPositions, index.U, index.V, ModelCommon.getAbsolutePosition(vertex.BPositions, boneMatrices), new VifCommon.VertexColor((byte)index.Color.R, (byte)index.Color.G, (byte)index.Color.B, (byte)index.Color.A)));
-                }
-                else
-                {
-                    mesh.Vertices.Add(new UVBVertex(vertex.BPositions, index.U, index.V, ModelCommon.getAbsolutePosition(vertex.BPositions, boneMatrices)));
-                }
+                UVBVertex completeVertex = new UVBVertex(vertex.BPositions, index.U, index.V, ModelCommon.getAbsolutePosition(vertex.BPositions, boneMatrices));
+
+                if (index.Color != null)
+                    completeVertex.Color = new VifCommon.VertexColor((byte)index.Color.R, (byte)index.Color.G, (byte)index.Color.B, (byte)index.Color.A);
+                if (index.Normal != null)
+                    completeVertex.Normal = new VifCommon.VertexNormal(index.Normal.X, index.Normal.Y, index.Normal.Z);
+
+                mesh.Vertices.Add(completeVertex);
 
                 // Triangles
                 if (index.Function == OpenKh.Ps2.VpuPacket.VertexFunction.DrawTriangle ||
@@ -466,6 +466,15 @@ namespace OpenKh.Kh2.Models
                     for (int j = 0; j < vpuPacket.Indices.Length; j++)
                     {
                         vpuGroup.Indices[previousIndexCount + j].Color = vpuPacket.Colors[j];
+                    }
+                }
+
+                // Normals
+                if (vpuPacket.Indices.Length == vpuPacket.Normals.Length)
+                {
+                    for (int j = 0; j < vpuPacket.Indices.Length; j++)
+                    {
+                        vpuGroup.Indices[previousIndexCount + j].Normal = vpuPacket.Normals[j];
                     }
                 }
 

--- a/OpenKh.Kh2/Models/VIF/DmaVifPacket.cs
+++ b/OpenKh.Kh2/Models/VIF/DmaVifPacket.cs
@@ -27,7 +27,7 @@ namespace OpenKh.Kh2.Models.VIF
             BoneList = new List<int>();
         }
 
-        public void calcHeader(VifPacket vifPacket, bool singleWeightMode = false)
+        public void calcHeader(VifPacket vifPacket, bool singleWeightMode = false, bool hasColors = false, bool hasNormals = false)
         {
             Header.Type = 1;
             Header.VertexColorPtrInc = 0;
@@ -35,17 +35,24 @@ namespace OpenKh.Kh2.Models.VIF
             Header.VertexBufferPointer = 0;
 
             int currentAddress = 0;
-            Header.TriStripNodeOffset = 4;
+            Header.TriStripNodeOffset = hasNormals ? 5 : 4;
             Header.TriStripNodeCount = vifPacket.UvCoords.Count;
 
             currentAddress += Header.TriStripNodeOffset;
             currentAddress += Header.TriStripNodeCount;
 
-            if(vifPacket.Colors != null && vifPacket.Colors.Count > 0)
+            if(hasColors)
             {
                 Header.ColorOffset = currentAddress;
                 Header.ColorCount = vifPacket.Colors.Count;
                 currentAddress += Header.ColorCount;
+            }
+
+            if (hasNormals)
+            {
+                Header.NormalOffset = currentAddress;
+                Header.NormalCount = vifPacket.Normals.Count;
+                currentAddress += Header.NormalCount;
             }
 
             Header.VertexCoordOffset = currentAddress;

--- a/OpenKh.Kh2/Models/VIF/VifCommon.cs
+++ b/OpenKh.Kh2/Models/VIF/VifCommon.cs
@@ -25,6 +25,7 @@ namespace OpenKh.Kh2.Models.VIF
             public UVCoord UvCoord;
             public byte TriFlag;
             public VertexColor Color;
+            public VertexNormal Normal;
             public Vector3 AbsolutePosition;
             public List<BoneRelativePosition> RelativePositions; // WeightGroup
 
@@ -48,6 +49,7 @@ namespace OpenKh.Kh2.Models.VIF
                 vpuSize += (4 * RelativePositions.Count); // Bone matrices
 
                 if(Color != null) vpuSize += 1; // Color
+                if(Normal != null) vpuSize += 1; // Normal
 
                 return vpuSize;
             }
@@ -168,6 +170,20 @@ namespace OpenKh.Kh2.Models.VIF
                 this.G = G;
                 this.B = B;
                 this.A = A;
+            }
+        }
+
+        public class VertexNormal
+        {
+            public float X;
+            public float Y;
+            public float Z;
+
+            public VertexNormal(float x, float y, float z)
+            {
+                this.X = x;
+                this.Y = y;
+                this.Z = z;
             }
         }
 

--- a/OpenKh.Kh2/Models/VIF/VifPacket.cs
+++ b/OpenKh.Kh2/Models/VIF/VifPacket.cs
@@ -18,6 +18,7 @@ namespace OpenKh.Kh2.Models.VIF
         public List<int> BoneCounts;
         public List<List<List<int>>> WeightGroups; // List by weight count (Eg: 1 weight, 2 weights, 3 weights...) - list by entries (Eg: Weight group for vertex 1, WG for vertex 2...) - list of entry's weights (Eg: This weight group has coords 1, 2 & 3)
         public List<VifCommon.VertexColor> Colors;
+        public List<VifCommon.VertexNormal> Normals;
         public Dictionary<int, List<WeightGroup>> WeightGroupsByWeightCount;
 
         public VifPacket()
@@ -30,6 +31,7 @@ namespace OpenKh.Kh2.Models.VIF
             BoneCounts = new List<int>();
             WeightGroups = new List<List<List<int>>>();
             Colors = new List<VifCommon.VertexColor>();
+            Normals = new List<VifCommon.VertexNormal>();
             WeightGroupsByWeightCount = new Dictionary<int, List<WeightGroup>>();
         }
 
@@ -86,7 +88,8 @@ namespace OpenKh.Kh2.Models.VIF
                 packetLength += VifUtils.getAmountIfGroupedBy(WeightGroups[i].Count * (i + 1), 4);
             }
 
-            packetLength += Colors.Count; // 1 per vertex color; not implemented
+            packetLength += Colors.Count; // 1 per vertex color
+            packetLength += Normals.Count; // 1 per vertex normal
 
             return packetLength;
         }

--- a/OpenKh.Kh2/Models/VIF/VifUtils.cs
+++ b/OpenKh.Kh2/Models/VIF/VifUtils.cs
@@ -53,15 +53,6 @@ namespace OpenKh.Kh2.Models.VIF
 
         public const uint SET_COLUMN = 0x31000000;
 
-        /*public const ulong END_UV = 0xCFCFCFCF20000000;
-        public const ulong END_INDICES = 0x3F3F3F3F20000000;
-        public const ulong END_VERTICES_1 = 0x3F80000031000000;
-        public const ulong END_VERTICES_2 = 0x3F8000003F800000;
-        public const ulong END_VERTICES_3 = 0x200000003F800000;
-        public const uint END_VERTICES_4 = 0x80808080;*/
-        public const ulong END_BONE_DATA = 0x0000000000000000;
-        public const uint DMA_BONE_PARAM0 = 0x01000101;
-
         // VIF CONSTANTS
         public const byte READ_SIZE_16 = 0x6C;
         public const byte READ_SIZE_12 = 0x78;

--- a/OpenKh.Kh2/Models/VIF/VifUtils.cs
+++ b/OpenKh.Kh2/Models/VIF/VifUtils.cs
@@ -7,6 +7,61 @@ namespace OpenKh.Kh2.Models.VIF
 {
     public class VifUtils
     {
+        // VIF CODES
+        public const uint UNPACK = 0x01000101;
+
+        // First number is the amount, second number is the size being read. M indicates using a mask
+        public const byte UNPACK_TYPE_1_32 = 0x60;
+        public const byte UNPACK_TYPE_1_16 = 0x61;
+        public const byte UNPACK_TYPE_1_8 = 0x62;
+        public const byte UNPACK_TYPE_2_32 = 0x64;
+        public const byte UNPACK_TYPE_2_16 = 0x65;
+        public const byte UNPACK_TYPE_2_8 = 0x66;
+        public const byte UNPACK_TYPE_3_32 = 0x68;
+        public const byte UNPACK_TYPE_3_16 = 0x69;
+        public const byte UNPACK_TYPE_3_8 = 0x6A;
+        public const byte UNPACK_TYPE_4_32 = 0x6C;
+        public const byte UNPACK_TYPE_4_16 = 0x6D;
+        public const byte UNPACK_TYPE_4_8 = 0x6E;
+        public const byte UNPACK_TYPE_4_5 = 0x6F; // 5+5+5+1
+        public const byte UNPACK_TYPE_M_1_32 = 0x70;
+        public const byte UNPACK_TYPE_M_1_16 = 0x71;
+        public const byte UNPACK_TYPE_M_1_8 = 0x72;
+        public const byte UNPACK_TYPE_M_2_32 = 0x74;
+        public const byte UNPACK_TYPE_M_2_16 = 0x75;
+        public const byte UNPACK_TYPE_M_2_8 = 0x76;
+        public const byte UNPACK_TYPE_M_3_32 = 0x78;
+        public const byte UNPACK_TYPE_M_3_16 = 0x79;
+        public const byte UNPACK_TYPE_M_3_8 = 0x7A;
+        public const byte UNPACK_TYPE_M_4_32 = 0x7C;
+        public const byte UNPACK_TYPE_M_4_16 = 0x7D;
+        public const byte UNPACK_TYPE_M_4_8 = 0x7E;
+        public const byte UNPACK_TYPE_M_4_5 = 0x7F; // 5+5+5+1
+
+        // Unpack options:
+        // First bit: TOPS is added to starting address (File address + unpack address)
+        // Second bit: Zero extended (If unset sign extended)
+        public const byte UNPACK_OPTIONS_SIGN = 0x80; // 1000
+        public const byte UNPACK_OPTIONS_ZERO = 0xC0; // 1100
+
+        public const uint SET_MASK = 0x20000000;
+        public const uint INDICES_MASK = 0xCFCFCFCF;
+        public const uint FLAGS_MASK = 0x3F3F3F3F;
+        public const uint NORMALS_MASK = 0xC0C0C0C0;
+        public const uint NORMALS_RESERVE_MASK = 0x3F3F3F3F;
+        public const uint COORDS_MASK = 0x80808080;
+
+        public const uint SET_COLUMN = 0x31000000;
+
+        /*public const ulong END_UV = 0xCFCFCFCF20000000;
+        public const ulong END_INDICES = 0x3F3F3F3F20000000;
+        public const ulong END_VERTICES_1 = 0x3F80000031000000;
+        public const ulong END_VERTICES_2 = 0x3F8000003F800000;
+        public const ulong END_VERTICES_3 = 0x200000003F800000;
+        public const uint END_VERTICES_4 = 0x80808080;*/
+        public const ulong END_BONE_DATA = 0x0000000000000000;
+        public const uint DMA_BONE_PARAM0 = 0x01000101;
+
         // VIF CONSTANTS
         public const byte READ_SIZE_16 = 0x6C;
         public const byte READ_SIZE_12 = 0x78;
@@ -14,19 +69,6 @@ namespace OpenKh.Kh2.Models.VIF
         public const byte READ_SIZE_4_2 = 0x6E;
         public const byte READ_SIZE_1 = 0x72;
 
-        public const byte UNIT_SIZE_INT = 0x80;
-        public const byte UNIT_SIZE_BYTE = 0xC0;
-
-        // VIF CODES
-        public const uint  UNPACK = 0x01000101;
-        public const ulong END_UV = 0xCFCFCFCF20000000;
-        public const ulong END_INDICES = 0x3F3F3F3F20000000;
-        public const ulong END_VERTICES_1 = 0x3F80000031000000;
-        public const ulong END_VERTICES_2 = 0x3F8000003F800000;
-        public const ulong END_VERTICES_3 = 0x200000003F800000;
-        public const uint  END_VERTICES_4 = 0x80808080;
-        public const ulong END_BONE_DATA = 0x0000000000000000;
-        public const uint  DMA_BONE_PARAM0 = 0x01000101;
 
         public static bool isSameVector(Vector4 vec1, Vector4 vec2)
         {

--- a/OpenKh.Tools.Kh2MdlxEditor/Utils/MdlxEditorImporter.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/Utils/MdlxEditorImporter.cs
@@ -103,6 +103,10 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Utils
                 model.Groups.Add(group);
 
                 baseAddress += VifProcessor.getGroupSize(group);
+
+                if (VifProcessor.currentApplyNormal)
+                    group.Header.Specular = true;
+                VifProcessor.NextMeshOptions();
             }
 
             foreach (ModelSkeletal.SkeletalGroup group in model.Groups)

--- a/OpenKh.Tools.Kh2MdlxEditor/ViewModels/Importer_VM.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/ViewModels/Importer_VM.cs
@@ -1,17 +1,32 @@
+using OpenKh.AssimpUtils;
 using OpenKh.Kh2.Models.VIF;
 using OpenKh.Tools.Kh2MdlxEditor.Utils;
-using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace OpenKh.Tools.Kh2MdlxEditor.ViewModels
 {
-    public class Importer_VM
+    public class Importer_VM : INotifyPropertyChanged
     {
         public Main2_VM MainVM { get; set; }
+
+        private bool _modelLoaded { get; set; }
+        public bool ModelLoaded
+        {
+            get { return _modelLoaded; }
+            set
+            {
+                _modelLoaded = value;
+                OnPropertyChanged("ModelLoaded");
+            }
+        }
+
+        public string FilePath { get; set; }
+        public Assimp.Scene ExternalModel { get; set; }
+        public ObservableCollection<ImportMeshOptions> MeshOptionsList { get; set; }
+
         public bool KeepShadow { get; set; }
         public byte VertexLimitPerPacket { get; set; }
         public byte MemoryLimitPerPacket { get; set; }
@@ -19,9 +34,106 @@ namespace OpenKh.Tools.Kh2MdlxEditor.ViewModels
         public Importer_VM(Main2_VM mainVM)
         {
             this.MainVM = mainVM;
+            ModelLoaded = false;
+            MeshOptionsList = new ObservableCollection<ImportMeshOptions>();
+
             KeepShadow = false;
             VertexLimitPerPacket = (byte)VifProcessor.VERTEX_LIMIT;
             MemoryLimitPerPacket = (byte)VifProcessor.MEMORY_LIMIT;
+        }
+
+        public class ImportMeshOptions
+        {
+            public int Id { get; set; }
+            public int PolyCount { get; set; }
+            public string Texture { get; set; }
+            public bool HasColors { get; set; }
+            public bool HasNoColors { get; set; }
+            public bool ApplyColors { get; set; }
+            public bool HasNormals { get; set; }
+            public bool HasNoNormals { get; set; }
+            public bool ApplyNormals { get; set; }
+        }
+
+        public void loadModel(string filepath)
+        {
+            ExternalModel = AssimpGeneric.getAssimpSceneFromFile(filepath);
+
+            MeshOptionsList.Clear();
+            foreach (Assimp.Mesh mesh in ExternalModel.Meshes)
+            {
+                ImportMeshOptions meshOptions = new ImportMeshOptions();
+                meshOptions.Id = MeshOptionsList.Count;
+                meshOptions.PolyCount = mesh.FaceCount;
+                meshOptions.Texture = Path.GetFileNameWithoutExtension(ExternalModel.Materials[mesh.MaterialIndex].TextureDiffuse.FilePath);
+                meshOptions.ApplyColors = false;
+                meshOptions.ApplyNormals = false;
+
+                meshOptions.HasNoColors = true;
+                meshOptions.HasNoNormals = true;
+
+                meshOptions.HasColors = true;
+                if (mesh.VertexColorChannels[0].Count > 0)
+                {
+                    foreach (Assimp.Color4D color in mesh.VertexColorChannels[0])
+                    {
+                        if (color == null)
+                        {
+                            meshOptions.HasColors = false;
+                            break;
+                        }
+                    }
+                }
+                else
+                    meshOptions.HasColors = false;
+
+                meshOptions.HasNormals = true;
+                if (mesh.Normals.Count > 0)
+                {
+                    foreach (Assimp.Vector3D normal in mesh.Normals)
+                    {
+                        if (normal == null)
+                        {
+                            meshOptions.HasNormals = false;
+                            break;
+                        }
+                    }
+                }
+                else
+                    meshOptions.HasNormals = false;
+
+                MeshOptionsList.Add(meshOptions);
+            }
+
+            FilePath = filepath;
+            ModelLoaded = true;
+        }
+
+        public void ImportModel()
+        {
+            if (FilePath == null)
+                return;
+
+            MdlxEditorImporter.KEEP_ORIGINAL_SHADOW = KeepShadow;
+            VifProcessor.VERTEX_LIMIT = VertexLimitPerPacket;
+            VifProcessor.MEMORY_LIMIT = MemoryLimitPerPacket;
+
+            List<VifProcessor.MeshOptions> newMeshOptions = new List<VifProcessor.MeshOptions>();
+            foreach(ImportMeshOptions meshOptions in MeshOptionsList)
+            {
+                newMeshOptions.Add(new VifProcessor.MeshOptions(meshOptions.HasColors, meshOptions.ApplyColors, meshOptions.HasNormals, meshOptions.ApplyNormals));
+            }
+
+            VifProcessor.LoadOptions(newMeshOptions);
+
+            MainVM.replaceModel(FilePath);
+        }
+
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        protected void OnPropertyChanged(string name)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
         }
     }
 }

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/Importer_Window.xaml
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/Importer_Window.xaml
@@ -5,9 +5,21 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:OpenKh.Tools.Kh2MdlxEditor.Views"
         mc:Ignorable="d"
-        Title="Import and Replace Mesh" Height="320" Width="460">
-    <StackPanel Margin="10">
+        Title="Import and Replace Mesh" Height="500" Width="500">
+
+    <StackPanel Margin="10" AllowDrop="True" Drop="Drop_LoadModel">
+
+        <StackPanel.Resources>
+            <BooleanToVisibilityConverter x:Key="converter"/>
+        </StackPanel.Resources>
+
+        <!-- Loader -->
+        <Button Margin="10" Click="Button_LoadModel" Width="200">Select model to load</Button>
+
+        <!-- Shadow -->
         <CheckBox Margin="5" IsChecked="{Binding Path=KeepShadow, Mode=TwoWay}">Keep shadow</CheckBox>
+
+        <!-- Limits -->
         <StackPanel Margin="10" Orientation="Horizontal">
             <TextBox Text="{Binding Path=VertexLimitPerPacket}" Width="50"></TextBox>
             <Label>Vertex limit per packet (255 Max)</Label>
@@ -19,7 +31,42 @@
         <Label>The higher the limits the lower the output file's size</Label>
         <Label>If the model is too heavy to process (Eg: Multiweight) lower the memory limit</Label>
         <Label>If the model doesn't load properly ingame (Eg: PS2) lower the vertex limit</Label>
-        <Button Margin="10" Click="Button_Import" Width="200">Select file and Import Mesh</Button>
+
+        <StackPanel Visibility="{Binding Path=ModelLoaded, Converter={StaticResource converter}}">
+
+            <!-- Mesh options -->
+            <DataGrid ItemsSource="{Binding MeshOptionsList}" 
+                      AutoGenerateColumns="False" CanUserAddRows="False" CanUserDeleteRows="False" CanUserReorderColumns="False" CanUserSortColumns="False"
+                      HorizontalAlignment="Center" VerticalAlignment="Center">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Mesh" IsReadOnly="True" Binding="{Binding Id}" />
+                    <DataGridTextColumn Header="Poly count" IsReadOnly="True" Binding="{Binding PolyCount}" />
+                    <DataGridTextColumn Header="Texture" IsReadOnly="True" Binding="{Binding Texture}" />
+
+                    <DataGridTemplateColumn Header="Vertex colors">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <CheckBox IsEnabled="{Binding HasColors}" IsChecked="{Binding Path=ApplyColors, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center"/>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+
+                    <DataGridTemplateColumn Header="Vertex normals">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <CheckBox IsEnabled="{Binding HasNormals}" IsChecked="{Binding ApplyNormals, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center"/>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+
+                </DataGrid.Columns>
+            </DataGrid>
+
+            <!-- Import -->
+            <Button Margin="0 30 0 10" Height="30" Width="70" Click="Button_Import">Import</Button>
+        </StackPanel>
+        
         <Label Name="ErrorMessage"/>
+        
     </StackPanel>
 </Window>

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/Importer_Window.xaml.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/Importer_Window.xaml.cs
@@ -1,7 +1,6 @@
-using OpenKh.Kh2.Models.VIF;
-using OpenKh.Tools.Kh2MdlxEditor.Utils;
 using OpenKh.Tools.Kh2MdlxEditor.ViewModels;
 using System;
+using System.Linq;
 using System.Windows;
 
 namespace OpenKh.Tools.Kh2MdlxEditor.Views
@@ -23,7 +22,7 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
             this.mainWindow = mainWindow;
         }
 
-        private void Button_Import(object sender, EventArgs e)
+        private void Button_LoadModel(object sender, EventArgs e)
         {
             System.Windows.Forms.OpenFileDialog sfd;
             sfd = new System.Windows.Forms.OpenFileDialog();
@@ -35,25 +34,60 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
                 {
                     try
                     {
-                        ErrorMessage.Content = "Loading...";
-                        MdlxEditorImporter.KEEP_ORIGINAL_SHADOW = importerVM.KeepShadow;
-                        VifProcessor.VERTEX_LIMIT = importerVM.VertexLimitPerPacket;
-                        VifProcessor.MEMORY_LIMIT = importerVM.MemoryLimitPerPacket;
-                        importerVM.MainVM.replaceModel(sfd.FileName);
-                        ErrorMessage.Content = "Finished";
-                        if(mainWindow != null)
-                        {
-                            mainWindow.reloadModelControl();
-                        }
-                        this.Close();
+                        loadModel(sfd.FileName);
                     }
                     catch (Exception exception)
                     {
                         ErrorMessage.Content = "Error: " + exception.Message;
                     }
                 }
-                    
+
             }
+        }
+
+        private void Drop_LoadModel(object sender, DragEventArgs e)
+        {
+            try
+            {
+                if (e.Data.GetDataPresent(DataFormats.FileDrop))
+                {
+                    string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+                    string firstFile = files?.FirstOrDefault();
+
+                    if (firstFile.ToLower().EndsWith(".fbx") || firstFile.ToLower().EndsWith(".dae"))
+                    {
+                        loadModel(firstFile);
+                    }
+                }
+            }
+            catch (Exception exception)
+            {
+                ErrorMessage.Content = "Error opening file: " + exception.Message;
+            }
+        }
+
+        private void Button_Import(object sender, EventArgs e)
+        {
+            try
+            {
+                ErrorMessage.Content = "Loading...";
+                importerVM.ImportModel();
+                ErrorMessage.Content = "Finished";
+                if (mainWindow != null)
+                {
+                    mainWindow.reloadModelControl();
+                }
+                this.Close();
+            }
+            catch (Exception exception)
+            {
+                ErrorMessage.Content = "Error: " + exception.Message;
+            }
+        }
+
+        private void loadModel(string filepath)
+        {
+            importerVM.loadModel(filepath);
         }
     }
 }

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/Main2_Window.xaml
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/Main2_Window.xaml
@@ -12,7 +12,9 @@
         <!-- Top navbar -->
         <Menu DockPanel.Dock="Top">
             <MenuItem Header="File">
-                <MenuItem Header="Save As..." Click="Menu_SaveFile"/>
+                <MenuItem Header="Open" Click="Menu_Open"/>
+                <MenuItem Header="Save" Click="Menu_OverwriteFile"/>
+                <MenuItem Header="Save As" Click="Menu_SaveFile"/>
                 <MenuItem Header="Export model">
                     <MenuItem Header="FBX" Click="Menu_ExportAsFbx"/>
                     <MenuItem Header="DAE (Collada)" Visibility="Collapsed" Click="Menu_ExportAsDae"/>

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/Main2_Window.xaml.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/Main2_Window.xaml.cs
@@ -1,14 +1,13 @@
+using Microsoft.Win32;
 using OpenKh.AssimpUtils;
 using OpenKh.Kh2;
 using OpenKh.Tools.Common.Wpf;
-using OpenKh.Tools.Kh2MdlxEditor.Utils;
 using OpenKh.Tools.Kh2MdlxEditor.ViewModels;
 using System;
 using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 
 namespace OpenKh.Tools.Kh2MdlxEditor.Views
 {
@@ -54,9 +53,26 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
             {
             }
         }
+        private void Menu_Open(object sender, EventArgs e)
+        {
+            OpenFileDialog openFileDialog = new OpenFileDialog();
+            openFileDialog.Multiselect = false;
+            if (openFileDialog.ShowDialog() == true && openFileDialog.FileNames != null && openFileDialog.FileNames.Length > 0)
+            {
+                string filePath = openFileDialog.FileNames[0];
+                if (filePath.ToLower().EndsWith(".mdlx"))
+                {
+                    loadFile(filePath);
+                }
+            }
+        }
         private void Menu_SaveFile(object sender, EventArgs e)
         {
-            saveFile();
+            SaveFile();
+        }
+        private void Menu_OverwriteFile(object sender, EventArgs e)
+        {
+            OverwriteFile();
         }
 
         private void Menu_ExportAsFbx(object sender, EventArgs e)
@@ -123,7 +139,7 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
         }
 
         // Saves the file
-        public void saveFile()
+        public void SaveFile()
         {
             mainVM.buildBarFile();
 
@@ -138,6 +154,13 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
                 Bar.Write(memStream, mainVM.BarFile);
                 File.WriteAllBytes(sfd.FileName, memStream.ToArray());
             }
+        }
+        public void OverwriteFile()
+        {
+            mainVM.buildBarFile();
+            MemoryStream memStream = new MemoryStream();
+            Bar.Write(memStream, mainVM.BarFile);
+            File.WriteAllBytes(mainVM.FilePath, memStream.ToArray());
         }
 
 


### PR DESCRIPTION
Behold! The last MDLX importer update! (I hope)

* The VIF code has been updated and it now should reflect the data more accurately.  This seems to have fixed an issue with the previous importer release.
* The importer now supports vertex normals.
* Vertex colors and normals can be selected to be applied per mesh.
* New buttons have been added to open a file by selecting it instead of drag & dropping and to save over the opened MDLX.
* If I have to touch this again I'm gonna jump out the window.

![image](https://github.com/OpenKH/OpenKh/assets/20492864/a259fb85-5310-4054-b0f0-5e68243bb037)

When importing, the user can either select the file or drag and drop it. Once the file is loaded the list of meshes will appear. For those meshes that have colors or normals, their checkbox will be able to be checked to import the colors or normals. Once everything's set, clicking in Import will finish the process.

Exmaple of a model with normals and colors applied:

![image](https://github.com/OpenKH/OpenKh/assets/20492864/a23f31ee-3fe1-4fa8-9cbf-8820365511d5)