### PR TITLE
When installing a mod only reload mods list if you are overwriting an old mod of the same name

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/ModsService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ModsService.cs
@@ -3,6 +3,7 @@ using OpenKh.Common;
 using OpenKh.Patcher;
 using OpenKh.Tools.ModsManager.Exceptions;
 using OpenKh.Tools.ModsManager.Models;
+using OpenKh.Tools.ModsManager.ViewModels;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -136,6 +137,7 @@ namespace OpenKh.Tools.ModsManager.Services
                 switch (errorMessage)
                 {
                     case MessageBoxResult.Yes:
+                        MainViewModel.overwriteMod = true;
                         Directory.Delete(modPath, true);
                         break;
                     case MessageBoxResult.No:
@@ -279,6 +281,7 @@ namespace OpenKh.Tools.ModsManager.Services
                     case MessageBoxResult.Yes:
                         Handle(() =>
                         {
+                            MainViewModel.overwriteMod = true;
                             foreach (var filePath in Directory.GetFiles(modPath, "*", SearchOption.AllDirectories))
                             {
                                 var attributes = File.GetAttributes(filePath);

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -61,6 +61,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         private const string ORIGINAL_FILES_FOLDER_NAME = "original";
         private const string REMASTERED_FILES_FOLDER_NAME = "remastered";
 
+        public static bool overwriteMod = false;
         public string Title => ApplicationName;
         public string CurrentVersion => ApplicationVersion;
         public ObservableCollection<ModViewModel> ModsList { get; set; }
@@ -285,7 +286,11 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                             ModsList.Insert(0, Map(mod));
                             SelectedValue = ModsList[0];
                         });
-                        ReloadModsList();
+                        if (overwriteMod)
+                        {
+                            overwriteMod = false;
+                            ReloadModsList();
+                        }
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
With my recent PR to allow users to overwrite a mod if they try to install the mod again (for purposes of overwriting a partial installation or adding a new rando seed) it would always call `ReloadModsList()` making it so if you were installing a mod for the first time it would get kicked to the bottom of active mods. This fixes that to only reload mods list when overwriting an old mod so the user can easily enable and move the mod in priority without needing to scroll to the bottom of their list and find the mod they installed.