### PR TITLE
Presets and Lua Script install.

### DIFF
--- a/OpenKh.Research.Panacea/OpenKh.Research.Panacea.vcxproj
+++ b/OpenKh.Research.Panacea/OpenKh.Research.Panacea.vcxproj
@@ -66,6 +66,9 @@
       <EnableUAC>false</EnableUAC>
       <AdditionalDependencies>Shlwapi.lib;Dependencies\bass.lib;Dependencies\bass_vgmstream.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>copy Dependencies\*.dll ..\Debug\</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>

--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -34,7 +34,6 @@ namespace OpenKh.Tools.ModsManager.Services
             public string OpenKhGameEngineLocation { get; internal set; }
             public string Pcsx2Location { get; internal set; }
             public string PcReleaseLocation { get; internal set; }
-            public string PcShortcutLocation { get; internal set; }
             public string PcReleaseLanguage { get; internal set; } = "en";
             public int RegionId { get; internal set; }
             public bool PanaceaInstalled { get; internal set; }
@@ -70,6 +69,7 @@ namespace OpenKh.Tools.ModsManager.Services
         private static string EnabledModsPathBBS = Path.Combine(StoragePath, "mods-BBS.txt");
         private static string EnabledModsPathRECOM = Path.Combine(StoragePath, "mods-ReCoM.txt");
         private static readonly Config _config = Config.Open(ConfigPath);
+        public static string PresetPath = Path.Combine(StoragePath, "presets");
 
         static ConfigurationService()
         {
@@ -82,7 +82,9 @@ namespace OpenKh.Tools.ModsManager.Services
                 Directory.CreateDirectory(Path.Combine(modsPath, "bbs"));
             if (!Directory.Exists(Path.Combine(modsPath, "Recom")))
                 Directory.CreateDirectory(Path.Combine(modsPath, "Recom"));
-           
+            if (!Directory.Exists(PresetPath))
+                Directory.CreateDirectory(PresetPath);
+
 
             Task.Run(async () =>
             {
@@ -232,15 +234,6 @@ namespace OpenKh.Tools.ModsManager.Services
             set
             {
                 _config.PcReleaseLocation = value;
-                _config.Save(ConfigPath);
-            }
-        }
-        public static string PcShortcutLocation
-        {
-            get => _config.PcShortcutLocation;
-            set
-            {
-                _config.PcShortcutLocation = value;
                 _config.Save(ConfigPath);
             }
         }

--- a/OpenKh.Tools.ModsManager/Views/InstallModView.xaml
+++ b/OpenKh.Tools.ModsManager/Views/InstallModView.xaml
@@ -9,7 +9,7 @@
         WindowStartupLocation="CenterScreen"
         ResizeMode="NoResize"
          FocusManager.FocusedElement="{Binding ElementName=txtSourceModUrl}"
-        Title="Install a new mod..." Height="160" Width="300" SizeToContent="Height">
+        Title="Install a new mod or Lua Script..." Height="160" Width="300" SizeToContent="Height">
     <Window.InputBindings>
         <KeyBinding Key="Esc" Command="{Binding CloseCommand}"/>
     </Window.InputBindings>
@@ -30,8 +30,8 @@
                 <TextBox Name="txtSourceModUrl" Background="Transparent" Text="{Binding RepositoryName, UpdateSourceTrigger=PropertyChanged}" KeyUp="txtSourceModUrl_KeyUp" />
             </Grid>
 
-            <TextBlock Margin="0 0 0 3">Or install it from a Mod Archive</TextBlock>
-            <Button Margin="0 0 0 5" Click="InstallZip_Click">Select and install Mod Archive</Button>
+            <TextBlock Margin="0 0 0 3">Install a Mod Archive or Lua Script</TextBlock>
+            <Button Margin="0 0 0 5" Click="InstallLocalFile_Click">Select and install Mod Archive or Lua Script</Button>
         </StackPanel>
 
         <Grid Grid.Row="2">

--- a/OpenKh.Tools.ModsManager/Views/InstallModView.xaml.cs
+++ b/OpenKh.Tools.ModsManager/Views/InstallModView.xaml.cs
@@ -13,11 +13,12 @@ namespace OpenKh.Tools.ModsManager.Views
     {
         private static readonly IEnumerable<FileDialogFilter> _zipFilter = FileDialogFilterComposer
             .Compose()
-            .AddExtensions("Mod archive", "zip", "kh2pcpatch", "kh1pcpatch", "compcpatch", "bbspcpatch");
+            .AddExtensions("Mod archive", "zip", "kh2pcpatch", "kh1pcpatch", "compcpatch", "bbspcpatch", "lua");
 
         public RelayCommand CloseCommand { get; }
         public string RepositoryName { get; set; }
         public bool IsZipFile { get; private set; }
+        public bool IsLuaFile { get; private set; } = false;
 
         public InstallModView()
         {
@@ -53,14 +54,25 @@ namespace OpenKh.Tools.ModsManager.Views
             Close();
         }
 
-        private void InstallZip_Click(object sender, RoutedEventArgs e)
+        private void InstallLocalFile_Click(object sender, RoutedEventArgs e)
         {
             FileDialog.OnOpen(fileName =>
             {
-                IsZipFile = true;
-                RepositoryName = fileName;
-                DialogResult = true;
-                Close();
+                if (!fileName.Contains(".lua"))
+                {
+                    IsZipFile = true;
+                    RepositoryName = fileName;
+                    DialogResult = true;
+                    Close();
+                }
+                else
+                {
+                    IsZipFile = false;
+                    IsLuaFile = true;
+                    RepositoryName = fileName;
+                    DialogResult = true;
+                    Close();
+                }
             }, _zipFilter);
         }
 

--- a/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
@@ -130,6 +130,7 @@
                 <MenuItem Header="Dev View" IsCheckable="True" IsChecked="{Binding DevView}"/>
                 <MenuItem Header="Check for update" Command="{Binding CheckOpenkhUpdateCommand}"/>
             </MenuItem>
+            <MenuItem Header="Presets" Command="{Binding OpenPresetMenuCommand}"/>
             <MenuItem Header="PC Version" Focusable="False" IsHitTestVisible="False" Visibility="{Binding isPC}"/>
             <MenuItem Header="Emulator" Focusable="False" IsHitTestVisible="False" Visibility="{Binding notPC}"/>
         </Menu>

--- a/OpenKh.Tools.ModsManager/Views/MainWindow.xaml.cs
+++ b/OpenKh.Tools.ModsManager/Views/MainWindow.xaml.cs
@@ -1,5 +1,4 @@
 using OpenKh.Tools.ModsManager.ViewModels;
-using SharpDX.Direct2D1;
 using System;
 using System.Windows;
 

--- a/OpenKh.Tools.ModsManager/Views/PresetsWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/PresetsWindow.xaml
@@ -1,0 +1,61 @@
+<Window x:Class="OpenKh.Tools.ModsManager.Views.PresetsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:OpenKh.Tools.ModsManager.Views"
+        xmlns:ctrls="clr-namespace:System.Windows.Controls"
+        mc:Ignorable="d"
+        WindowStartupLocation="CenterScreen"
+        ResizeMode="NoResize"
+         FocusManager.FocusedElement="{Binding ElementName=txtSourceModUrl}"
+        Title="Presets" Height="300" Width="300" SizeToContent="Height">
+    
+    <Window.InputBindings>
+        <KeyBinding Key="Esc" Command="{Binding CloseCommand}"/>
+    </Window.InputBindings>
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+    </Window.Resources>
+
+    <!-- Preset List -->
+    <DockPanel Margin="10">
+
+        <!-- Add new preset -->
+        <StackPanel DockPanel.Dock="Bottom">
+            <TextBlock Margin="0 0 0 3">Name Preset</TextBlock>
+            <Grid Margin="0 0 0 5" Background="White">
+                <TextBlock Margin="5,1" MinWidth="50" Text="Enter New Preset Name" 
+                   Foreground="Gray" Visibility="{Binding ElementName=txtSourceModUrl, Path=Text.IsEmpty, Converter={StaticResource BooleanToVisibilityConverter}}" IsHitTestVisible="False"/>
+                <TextBox Name="txtSourceModUrl" Background="Transparent" Text="{Binding PresetName, UpdateSourceTrigger=PropertyChanged}" KeyUp="txtSourceModUrl_KeyUp" />
+            </Grid>
+            <Button Click="Save_Click">Save</Button>
+        </StackPanel>
+
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="100"/>
+            </Grid.ColumnDefinitions>
+            <ScrollViewer Grid.Column="0" MinHeight="200">
+                <ListView Name="List_Presets" ItemsSource="{Binding Path=MainVm.PresetList}">
+                    <ListView.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock VerticalAlignment="Center" Text="{Binding}"/>
+                                <!--<Button Margin="5 0 0 0" Click="Button_ApplyPreset">Apply</Button>
+                                <Button Margin="5 0 0 0" Click="Button_RemovePreset">Remove</Button>-->
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+            </ScrollViewer>
+
+            <StackPanel Grid.Column="1" Margin="10">
+                <Button Click="Button_ApplyPreset" Margin="0 10">Apply</Button>
+                <Button Click="Button_RemovePreset">Remove</Button>
+            </StackPanel>
+        </Grid>
+        
+    </DockPanel>
+</Window>

--- a/OpenKh.Tools.ModsManager/Views/PresetsWindow.xaml.cs
+++ b/OpenKh.Tools.ModsManager/Views/PresetsWindow.xaml.cs
@@ -1,0 +1,66 @@
+using OpenKh.Tools.ModsManager.ViewModels;
+using System.Windows;
+using System.Windows.Controls;
+using Xe.Tools.Wpf.Commands;
+
+namespace OpenKh.Tools.ModsManager.Views
+{
+    public partial class PresetsWindow : Window
+    {
+        public MainViewModel MainVm { get; set; }
+        public RelayCommand CloseCommand { get; }
+        public string PresetName { get; set; }
+
+        public PresetsWindow()
+        {
+            InitializeComponent();
+            DataContext = this;
+
+            CloseCommand = new RelayCommand(_ => Close());
+        }
+        public PresetsWindow(MainViewModel mvm)
+        {
+            MainVm = mvm;
+            InitializeComponent();
+            DataContext = this;
+
+            CloseCommand = new RelayCommand(_ => Close());
+        }
+
+        private void Save_Click(object sender, RoutedEventArgs e)
+        {
+            MainVm.SavePreset(txtSourceModUrl.Text);
+        }
+
+        private void txtSourceModUrl_KeyUp(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.Enter)
+                Save_Click(sender, e);
+
+            e.Handled = true;
+        }
+
+        private void Button_ApplyPreset(object sender, RoutedEventArgs e)
+        {
+            if (List_Presets.SelectedItem == null)
+                return;
+
+            string presetName = (string)List_Presets.SelectedItem;
+            MainVm.LoadPreset(presetName);
+            Close();
+        }
+
+        private void Button_RemovePreset(object sender, RoutedEventArgs e)
+        {
+            if (List_Presets.SelectedItem == null)
+                return;
+            string presetName = (string)List_Presets.SelectedItem;
+            MessageBoxResult messageBoxResult = MessageBox.Show($"Do you want to remove {presetName} preset.", "Delete Confirmation", MessageBoxButton.YesNo);
+            if (messageBoxResult == MessageBoxResult.Yes)
+            {                
+                MainVm.RemovePreset(presetName);
+            }
+                
+        }
+    }
+}


### PR DESCRIPTION
Took everything from Lua Engine PR into its own. I believe this is better to have in main and once Lua Engine is ready it will be merged by itself. will copy relevant info from mention PR below.

Add Presets and Lua Script install.
~~When saving a new preset you will need to restart mod manager for the preset to show under Load Presets.~~ If you save a preset with the same name as one that already exists it will override the previous preset. If you try to include characters in the name that windows does not let be in a filename it will automatically be replaced by +.

Taken from osdanovas PR to my fork.
Changes the presets to its own menu. Backend remains mostly the same.
![266825917-7eaac0ef-ba31-428d-9c83-8c068b5a1a1f](https://github.com/OpenKH/OpenKh/assets/47014056/46ea0b7c-0af0-475c-b24d-1df2d415f2ac)

Can also install a Lua Script directly into mod manager as an easy way to enable or disable them.
![image](https://github.com/OpenKH/OpenKh/assets/47014056/7ffd80f4-26ff-429f-b94d-11235213cd77)
When you install a script it will generate a mod.yml based on MetaData in the Lua or using defaults. The script will be copied to be in `mod/"chosen game"/scripts`. Without Lua Engine this is mostly useful for KH2Rando. But anyone with Lua Backend installed and configured to load scripts from `mod/"chosen game"/scripts` as the KH2Rando seed gen configuration does for the user can use this.