### PR TITLE
Various changes.

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/OpenkhUpdateProceederService.cs
+++ b/OpenKh.Tools.ModsManager/Services/OpenkhUpdateProceederService.cs
@@ -40,6 +40,7 @@ namespace OpenKh.Tools.ModsManager.Services
                 zip.ExtractToDirectory(tempZipDir);
             }
 
+            File.Delete(tempZipFile);
             var tempBatFile = Path.Combine(Path.GetTempPath(), $"openkh-{tempId}.bat");
 
             var copyTo = AppDomain.CurrentDomain.BaseDirectory;
@@ -84,8 +85,11 @@ namespace OpenKh.Tools.ModsManager.Services
         private async Task CreateBatchFileAsync(string tempBatFile, string copyFrom, string copyTo, string execAfter)
         {
             var bat = new StringWriter();
+            bat.WriteLine($"taskkill /im OpenKh.Tools.ModsManager.exe");
             bat.WriteLine($"xcopy /d /e \"{copyFrom}\" \"{copyTo}\" || pause");
             bat.WriteLine($"{execAfter}");
+            bat.WriteLine($"rd /s /q \"{copyFrom}\"");
+            bat.WriteLine($"del %0");
             await File.WriteAllTextAsync(tempBatFile, bat.ToString(), Encoding.Default);
         }
     }

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -425,7 +425,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
             OpenPresetMenuCommand = new RelayCommand(_ =>
             {
                 PresetsWindow view = new PresetsWindow(this);
-                view.Show();
+                view.ShowDialog();
             });
 
             OpenLinkCommand = new RelayCommand(url => Process.Start(new ProcessStartInfo(url as string)

--- a/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
@@ -83,6 +83,7 @@
             <MenuItem Header="_Settings">
                 <MenuItem Header="Run _wizard" Command="{Binding WizardCommand}"  InputGestureText="Alt+W"/>
                 <MenuItem Header="Auto Update Mods" IsCheckable="True" ToolTip="When enabled Mod Manager will automatically update all mods on startup." IsChecked="{Binding AutoUpdateMods}"/>
+                <MenuItem Header="Check for update" Command="{Binding CheckOpenkhUpdateCommand}"/>
             </MenuItem>
             <MenuItem Header="_Info">
                 <MenuItem IsEnabled="False">
@@ -128,7 +129,6 @@
                     </MenuItem.Icon>
                 </MenuItem>
                 <MenuItem Header="Dev View" IsCheckable="True" IsChecked="{Binding DevView}"/>
-                <MenuItem Header="Check for update" Command="{Binding CheckOpenkhUpdateCommand}"/>
             </MenuItem>
             <MenuItem Header="Presets" Command="{Binding OpenPresetMenuCommand}"/>
             <MenuItem Header="PC Version" Focusable="False" IsHitTestVisible="False" Visibility="{Binding isPC}"/>


### PR DESCRIPTION
Delete the downloaded zip for the update from temp AppData after extracting it. 
Add more lines to the .bat. Sometimes window?.close() fails to close Mod Manager because window is null so the bat will try also before doing anything. If MM is alreaddy closed the bat just continues to execute as normal. After starting the updated MM deletes the extracted openkh download then itself. 
Preset window changed to ShowDialog() so you cannot mess with the main window while the preset window is open. 
Moved Check for update to the settings tab.
![image](https://github.com/OpenKH/OpenKh/assets/47014056/76505c70-9c19-4da0-851e-db597911d829)
