### PR TITLE
Fixed Mod Updates being hidden and added ToolTips for 4 buttons on Mod Manager main window

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -37,7 +37,11 @@ namespace OpenKh.Tools.ModsManager.Services
             public string PcReleaseLanguage { get; internal set; } = "en";
             public int RegionId { get; internal set; }
             public bool PanaceaInstalled { get; internal set; }
-            public bool DevView { get; internal set; }
+            public bool ShowConsole { get; internal set; } = false;
+            public bool DebugLog { get; internal set; } = false;
+            public bool EnableCache { get; internal set; } = true;
+            public bool QuickMenu { get; internal set; } = false;
+            public bool DevView { get; internal set; } = false;
             public bool AutoUpdateMods { get; internal set; }
             public bool isEGSVersion { get; internal set; } = true;
             public bool kh1 { get; internal set; }
@@ -264,6 +268,42 @@ namespace OpenKh.Tools.ModsManager.Services
             set
             {
                 _config.PanaceaInstalled = value;
+                _config.Save(ConfigPath);
+            }
+        }
+        public static bool ShowConsole
+        {
+            get => _config.ShowConsole;
+            set
+            {
+                _config.ShowConsole = value;
+                _config.Save(ConfigPath);
+            }
+        }
+        public static bool DebugLog
+        {
+            get => _config.DebugLog;
+            set
+            {
+                _config.DebugLog = value;
+                _config.Save(ConfigPath);
+            }
+        }
+        public static bool EnableCache
+        {
+            get => _config.EnableCache;
+            set
+            {
+                _config.EnableCache = value;
+                _config.Save(ConfigPath);
+            }
+        }
+        public static bool QuickMenu
+        {
+            get => _config.QuickMenu;
+            set
+            {
+                _config.QuickMenu = value;
                 _config.Save(ConfigPath);
             }
         }

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -204,6 +204,8 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         break;
                 }
                 ReloadModsList();
+                if (ModsList.Count > 0)
+                    FetchUpdates();
             }
         }
 
@@ -285,14 +287,16 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         Application.Current.Dispatcher.Invoke(() =>
                         {
                             progressWindow.Close();
+                            if (overwriteMod)
+                            {
+                                var modRemove = ModsList.FirstOrDefault(smod => smod.Title == mod.Metadata.Title);
+                                if (modRemove != null)
+                                    ModsList.RemoveAt(ModsList.IndexOf(modRemove));
+                                overwriteMod = false;
+                            }
                             ModsList.Insert(0, Map(mod));
                             SelectedValue = ModsList[0];
                         });
-                        if (overwriteMod)
-                        {
-                            overwriteMod = false;
-                            ReloadModsList();
-                        }
                     }
                     catch (Exception ex)
                     {
@@ -319,7 +323,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         }
 
                         Directory.Delete(mod.Path, true);
-                        ReloadModsList();
+                        ModsList.RemoveAt(ModsList.IndexOf(SelectedValue));
                     });
                 }
             }, _ => IsModSelected);
@@ -957,6 +961,8 @@ namespace OpenKh.Tools.ModsManager.ViewModels
             {
                 ConfigurationService.EnabledMods = File.ReadAllLines(filename);
                 ReloadModsList();
+                if (ModsList.Count > 0)
+                    FetchUpdates();
             }
             else
             {

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -37,6 +37,10 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         private bool _isBuilding;
         private bool _pc;
         private bool _panaceaInstalled;
+        private bool _panaceaConsoleEnabled;
+        private bool _panaceaDebugLogEnabled;
+        private bool _panaceaCacheEnabled;
+        private bool _panaceaQuickMenuEnabled;
         private bool _devView;
         private bool _autoUpdateMods = false;
         private string _launchGame = "kh2";
@@ -110,6 +114,50 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         public Visibility notPC => !PC ? Visibility.Visible : Visibility.Collapsed;
         public Visibility isPC => PC ? Visibility.Visible : Visibility.Collapsed;
 
+        public bool PanaceaConsoleEnabled
+        {
+            get => _panaceaConsoleEnabled;
+            set
+            {
+                _panaceaConsoleEnabled = value;
+                ConfigurationService.ShowConsole = _panaceaConsoleEnabled;
+                if (_panaceaDebugLogEnabled)
+                    PanaceaDebugLogEnabled = false;
+                OnPropertyChanged(nameof(PanaceaConsoleEnabled));
+                UpdatePanaceaSettings();
+            }
+        }
+        public bool PanaceaDebugLogEnabled
+        {
+            get => _panaceaDebugLogEnabled;
+            set
+            {
+                _panaceaDebugLogEnabled = value;
+                ConfigurationService.DebugLog = _panaceaDebugLogEnabled;
+                OnPropertyChanged(nameof(PanaceaDebugLogEnabled));
+                UpdatePanaceaSettings();
+            }
+        }
+        public bool PanaceaCacheEnabled
+        {
+            get => _panaceaCacheEnabled;
+            set
+            {
+                _panaceaCacheEnabled = value;
+                ConfigurationService.EnableCache = _panaceaCacheEnabled;
+                UpdatePanaceaSettings();
+            }
+        }
+        public bool PanaceaQuickMenuEnabled
+        {
+            get => _panaceaQuickMenuEnabled;
+            set
+            {
+                _panaceaQuickMenuEnabled = value;
+                ConfigurationService.QuickMenu = _panaceaQuickMenuEnabled;
+                UpdatePanaceaSettings();
+            }
+        }
         public bool DevView
         {
             get => _devView;
@@ -232,6 +280,10 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 PC = true;
                 PanaceaInstalled = ConfigurationService.PanaceaInstalled;
                 DevView = ConfigurationService.DevView;
+                _panaceaConsoleEnabled = ConfigurationService.ShowConsole;
+                _panaceaDebugLogEnabled = ConfigurationService.DebugLog;
+                _panaceaCacheEnabled = ConfigurationService.EnableCache;
+                _panaceaQuickMenuEnabled = ConfigurationService.QuickMenu;
             }
             else
                 PC = false;
@@ -931,9 +983,19 @@ namespace OpenKh.Tools.ModsManager.ViewModels
 
                 MessageBox.Show(message, "OpenKh");
             }
+        }        
+        
+        public void UpdatePanaceaSettings()
+        {
+            string panaceaSettings = Path.Combine(ConfigurationService.PcReleaseLocation, "panacea_settings.txt");
+            if (panaceaSettings != null)
+            {
+                string textToWrite = $"mod_path={ConfigurationService.GameModPath}\r\nshow_console={_panaceaConsoleEnabled}\r\n" +
+                    $"debug_log={_panaceaDebugLogEnabled}\r\nenable_cache={_panaceaCacheEnabled}\r\nquick_menu={_panaceaQuickMenuEnabled}";
+                File.WriteAllText(panaceaSettings, textToWrite);
+            }
         }
-        
-        
+
         // PRESETS
         public void SavePreset(string presetName)
         {

--- a/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
@@ -82,8 +82,14 @@
             </MenuItem>
             <MenuItem Header="_Settings">
                 <MenuItem Header="Run _wizard" Command="{Binding WizardCommand}"  InputGestureText="Alt+W"/>
-                <MenuItem Header="Auto Update Mods" IsCheckable="True" ToolTip="When enabled Mod Manager will automatically update all mods on startup." IsChecked="{Binding AutoUpdateMods}"/>
+                <MenuItem Header="Auto Update Mods" IsCheckable="True" ToolTip="When enabled Mod Manager will automatically update all mods on startup." IsChecked="{Binding AutoUpdateMods}" StaysOpenOnClick="True"/>
                 <MenuItem Header="Check for update" Command="{Binding CheckOpenkhUpdateCommand}"/>
+                <MenuItem Header="Panacea Settings" Visibility="{Binding ModLoader}">
+                    <MenuItem Header="Enable Console" IsCheckable="True" IsChecked="{Binding PanaceaConsoleEnabled}" StaysOpenOnClick="True"/>
+                    <MenuItem Header="Enable Debug Log" IsCheckable="True" IsChecked="{Binding PanaceaDebugLogEnabled}" IsEnabled="{Binding PanaceaConsoleEnabled}" StaysOpenOnClick="True"/>
+                    <MenuItem Header="Enable Cache" IsCheckable="True" IsChecked="{Binding PanaceaCacheEnabled}" StaysOpenOnClick="True"/>
+                    <MenuItem Header="Enable Quick Menu" IsCheckable="True" IsChecked="{Binding PanaceaQuickMenuEnabled}" StaysOpenOnClick="True"/>
+                </MenuItem>
             </MenuItem>
             <MenuItem Header="_Info">
                 <MenuItem IsEnabled="False">
@@ -128,7 +134,7 @@
                         <Image Source="{StaticResource WebURL_16x}"/>
                     </MenuItem.Icon>
                 </MenuItem>
-                <MenuItem Header="Dev View" IsCheckable="True" IsChecked="{Binding DevView}"/>
+                <MenuItem Header="Dev View" IsCheckable="True" IsChecked="{Binding DevView}" StaysOpenOnClick="True"/>
             </MenuItem>
             <MenuItem Header="Presets" Command="{Binding OpenPresetMenuCommand}"/>
             <MenuItem Header="PC Version" Focusable="False" IsHitTestVisible="False" Visibility="{Binding isPC}"/>

--- a/OpenKh.Tools.ModsManager/Views/ModManagerView.xaml
+++ b/OpenKh.Tools.ModsManager/Views/ModManagerView.xaml
@@ -74,16 +74,16 @@
         </ListBox>
         <Grid Grid.Column="1">
             <StackPanel VerticalAlignment="Center">
-                <Button Grid.Row="0" Margin="0 3 0 3" Command="{Binding MoveUp}">
+                <Button Grid.Row="0" Margin="0 3 0 3" Command="{Binding MoveUp}" ToolTip="Moves selected mod up increasing its priority.">
                     <Image Source="{StaticResource AddRowToAbove_16x}"/>
                 </Button>
-                <Button Grid.Row="4" Margin="0 3 0 3" Command="{Binding MoveDown}">
+                <Button Grid.Row="4" Margin="0 3 0 3" Command="{Binding MoveDown}" ToolTip="Moves selected mod down decreasing its priority.">
                     <Image Source="{StaticResource AddRowToBelow_16x}"/>
                 </Button>
-                <Button Grid.Row="2" Margin="0 3 0 3" Command="{Binding AddModCommand}">
+                <Button Grid.Row="2" Margin="0 3 0 3" Command="{Binding AddModCommand}" ToolTip="Install a new mod.">
                     <Image Source="{StaticResource Add_16x}"/>
                 </Button>
-                <Button Grid.Row="2" Margin="0 3 0 3" Command="{Binding RemoveModCommand}">
+                <Button Grid.Row="2" Margin="0 3 0 3" Command="{Binding RemoveModCommand}" ToolTip="Delete selected mod.">
                     <Image Source="{StaticResource Remove_color_16x}"/>
                 </Button>
             </StackPanel>


### PR DESCRIPTION
ToolTips for the MoveUp, MoveDown, AddModCommand, and RemoveModCommand.
Changed instances of ReloadModsList() to only do whats needed when possible. If not possible FetchUpdates after ReloadModsList() so the updates do not get hidden until a Mod Manager restart.