### PR TITLE
Documentation of KH2 SCDs & 12soundinfo.bar.

### DIFF
--- a/OpenKh.Tools.Kh2MsetEditor/ViewModels/Transfer_VM.cs
+++ b/OpenKh.Tools.Kh2MsetEditor/ViewModels/Transfer_VM.cs
@@ -234,6 +234,21 @@ namespace OpenKh.Tools.Kh2MsetEditor.ViewModels
                     //fromAnb.MotionFile.BoneFCurves.RemoveAt(i);
                 }
             }
+            
+            // EXPRESSION NODES - Related to IK Data. Must be updated, or else IK-bones will behave weirdly.
+            for (int i = fromAnb.MotionFile.ExpressionNodes.Count - 1; i >= 0; i--)
+            {
+                Motion.ExpressionNode expressionnodes = fromAnb.MotionFile.ExpressionNodes[i];
+
+                if (boneTransfers[expressionnodes.ExpressionId] != 65535) //"NULL" in this context is "FF FF".
+                {
+                    expressionnodes.ExpressionId = (short)boneTransfers[expressionnodes.ExpressionId];
+                }
+                else
+                {
+                    //fromAnb.MotionFile.BoneFCurves.RemoveAt(i);
+                }
+            }
 
             // IK HELPERS
             for (int i = fromAnb.MotionFile.IKHelpers.Count - 1; i >= 0; i--)

--- a/OpenKh.Tools.Kh2MsetEditor/ViewModels/Transfer_VM.cs
+++ b/OpenKh.Tools.Kh2MsetEditor/ViewModels/Transfer_VM.cs
@@ -234,21 +234,6 @@ namespace OpenKh.Tools.Kh2MsetEditor.ViewModels
                     //fromAnb.MotionFile.BoneFCurves.RemoveAt(i);
                 }
             }
-            
-            // EXPRESSION NODES - Related to IK Data. Must be updated, or else IK-bones will behave weirdly.
-            for (int i = fromAnb.MotionFile.ExpressionNodes.Count - 1; i >= 0; i--)
-            {
-                Motion.ExpressionNode expressionnodes = fromAnb.MotionFile.ExpressionNodes[i];
-
-                if (boneTransfers[expressionnodes.ExpressionId] != 65535) //"NULL" in this context is "FF FF".
-                {
-                    expressionnodes.ExpressionId = (short)boneTransfers[expressionnodes.ExpressionId];
-                }
-                else
-                {
-                    //fromAnb.MotionFile.BoneFCurves.RemoveAt(i);
-                }
-            }
 
             // IK HELPERS
             for (int i = fromAnb.MotionFile.IKHelpers.Count - 1; i >= 0; i--)

--- a/docs/kh2/file-type.md
+++ b/docs/kh2/file-type.md
@@ -32,6 +32,7 @@
 | VAS                             | Streamed music or voice (stereo audio)
 | VSB                             | A sub-type of BAR; contains VAG
 | WD                              | Instruments for BGM files; unused in the PC release.
+| [SCD](file/type/scd.md)         | Audio container, exclusive to the HD Remaster.
 | a.fm                            | A sub-type of BAR; usually used in conjunction with MDLX
 | a.fr                            | French localized a.fm
 | a.gr                            | German localized a.fm

--- a/docs/kh2/file/type/12soundinfo.md
+++ b/docs/kh2/file/type/12soundinfo.md
@@ -3,14 +3,14 @@
 This file is responsible for defining various environmental sound effects related to maps in [Kingdom Hearts II](../../index.md)
 It is a [BAR](bar.md) file and each subfile represents a different [World](/docs/kh2/worlds.md).
 
-###Structure
+### Structure
 
 | Amount | Description |
 |--------|---------------|
 | 1 	   | Sound Info Entry Count
 | Count  | Sound Info Entries
 
-###Sound Info Entry
+### Sound Info Entry
 | Offset | Variable Type | Description |
 |--------|---------------|-------------|
 | 0 	 | uint16 | Reverb

--- a/docs/kh2/file/type/12soundinfo.md
+++ b/docs/kh2/file/type/12soundinfo.md
@@ -1,0 +1,29 @@
+# [Kingdom Hearts II](../../index.md) - 12soundinfo.bar
+
+This file is responsible for defining various environmental sound effects related to maps in [Kingdom Hearts II](../../index.md)
+It is a [BAR](bar.md) file and each subfile represents a different [World](/docs/kh2/worlds.md).
+
+###Structure
+
+| Amount | Description |
+|--------|---------------|
+| 1 	   | Sound Info Entry Count
+| Count  | Sound Info Entries
+
+###Sound Info Entry
+| Offset | Variable Type | Description |
+|--------|---------------|-------------|
+| 0 	 | uint16 | Reverb
+| 2 	 | uint16 | 3DRate
+| 4 	 | uint16 | WAV for Environment
+| 6 	 | uint16 | SEB for Environment
+| 8 	 | uint16 | NUMBER for Environment
+| 10 	 | uint16 | SPOT for Environment
+| 12 	 | uint16 | WAV for Footstep
+| 14 	 | uint16 | SORA Footstep Sound Container
+| 16 	 | uint16 | DONALD Footstep Sound Container
+| 18 	 | uint16 | GOOFY Footstep Sound Container
+| 20 	 | uint16 | WORLD_FRIEND Footstep Sound Container
+| 22 	 | uint16 | OTHER Footstep Sound Container
+
+

--- a/docs/kh2/file/type/scd.md
+++ b/docs/kh2/file/type/scd.md
@@ -46,9 +46,9 @@ This is referred to here as a Sound Mapping Table. </br>
 | 0x3     | uint8    | Unknown
 | 0x4     | uint16   | Unknown
 | 0x6     | uint16   | Unknown
-| 0x8     | float    | Unknown
+| 0x8     | float    | Volume to play at
 | 0xC     | int32    | Sound Effect: Index in Game
-| 0x10    | int16    | Sound Effect: Index in SCD
+| 0x10    | int16    | Sound Effect: Index in SCD?
 | 0x12    | int16    | Sound Effect: Index in SCD
 
 This table has entries of two different sizes, 0x10 and 0x14. </br>
@@ -59,8 +59,18 @@ Otherwise, entries that are 0x14 long are used where the last 4 bytes are used t
 
 
 ## Table 0
-First entry seems to be 0x58 long.
-All entries after seem to be 0x62 long.
+First entry seems to be 0x58 long. </br>
+All entries after seem to be 0x62 long. </br>
+
+## Sound Entry Table
+| Offset | Type  | Description
+|--------|-------|------------
+| 0x0     | Unknown[0x4F]   | Unknown
+| 0x50    | uint32   | Audio Length (in ms)
+| 0x54    | uint32   | Unknown
+
+Most data seems to be identical here, except for 0x50. </br>
+That int determines how long to play the sound effect for in-game, before cutting the audio off. </br>
 
 ## Stream (pointed to by SoundEntry Table)
 | Offset | Type  | Description

--- a/docs/kh2/file/type/scd.md
+++ b/docs/kh2/file/type/scd.md
@@ -1,0 +1,79 @@
+# [Kingdom Hearts II](../../index.md)
+# SCD Format
+
+SCD stands for *Sound Container Data*.
+
+This file is a container for many related sounds.
+
+## Header
+
+| Offset | Type  | Description
+|--------|-------|------------
+| 0x0     | char[8]   | File identifier, always `SEDBSSCF`. which stands for `Sound Environment DataBase ? ? ? ?`
+| 0x8     | uint32  | File version, always `3`.
+| 0xC     | uint8   | Endianness (0 = LE, 1 = BE)
+| 0xD     | uint8   | SSCF version. Always `0x400`.
+| 0xE     | uint16  | Header Size
+| 0x10    | uint32  | Total File Size
+| 0x14    | uint32[7]  | Padding
+
+## Table Offset Header
+
+| Offset | Type  | Description
+|--------|-------|------------
+| 0x0     | uint16   | Table 0 Offset Size
+| 0x2     | uint16   | Size of Sound Entry Offset Table; this corresponds to the number of sounds within the SCD.
+| 0x4     | uint16   | Table 2 Offset Size
+| 0x6     | uint16   | Unknown
+| 0x8     | int32    | Offset to Table 0
+| 0xC     | int32    | Sound Entry Table Offset
+| 0x10    | int32    | Offset to Table 2
+| 0x14    | int32    | Unknown
+| 0x18    | int32    | Unknown Offset; must be the same offset as the first offset found in Table 2.
+| 0x1C    | int32    | Padding
+
+Immediately after Table Offset Header is another table of offsets, not pointed to in the header. </br>
+This table of offsets points to offsets that map sounds in the SCD to ID numbers used by the game.</br>
+The size of this table seems to be determined by Table 0 Offset Size.</br>
+This is referred to here as a Sound Mapping Table. </br>
+
+## Sound Mapping Table
+| Offset | Type  | Description
+|--------|-------|------------
+| 0x0     | uint8    | Unknown; seems to be set to 1 if a sound effect is mapped, and 0 if not?
+| 0x1     | uint8    | Unknown; seems to be set to 2 if a sound effect is mapped, and 1 if not?
+| 0x2     | uint8    | Unknown
+| 0x3     | uint8    | Unknown
+| 0x4     | uint16   | Unknown
+| 0x6     | uint16   | Unknown
+| 0x8     | float    | Unknown
+| 0xC     | int32    | Sound Effect: Index in Game
+| 0x10    | int16    | Sound Effect: Index in SCD
+| 0x12    | int16    | Sound Effect: Index in SCD
+
+This table has entries of two different sizes, 0x10 and 0x14. </br>
+An example of this can be seen with how se999 loads its sound effects. While se999 only has 96 sound effects found inside</br>
+on both PC and PS2, it uses indexes up to 154, with some indexes like 60 through 70 being left blank. </br>
+Dummy entries that are only 0x10 long are used to pad sound effect indexes between numbers that are used and have sounds in the SCD for them.</br>
+Otherwise, entries that are 0x14 long are used where the last 4 bytes are used to map sounds in the SCD to the specified index.
+
+
+## Table 0
+First entry seems to be 0x58 long.
+All entries after seem to be 0x62 long.
+
+## Stream (pointed to by SoundEntry Table)
+| Offset | Type  | Description
+|--------|-------|------------
+| 0x0     | uint32   | Stream Size
+| 0x4     | uint32   | Channel Count
+| 0x8     | uint32   | Sample Rate
+| 0xC     | uint32   | Codec
+| 0x10    | uint32   | Loop Start
+| 0x14    | uint32   | Loop End
+| 0x18    | uint32   | Extra Data Size
+| 0x1C    | uint32   | Auxiliary Chunk Count
+| 0x20    | uint8[StreamSize]   | Data
+
+## Table 2
+Entries are 0x80 long.

--- a/docs/kh2/notable-files.md
+++ b/docs/kh2/notable-files.md
@@ -6,7 +6,7 @@
 | [00worldpoint.bin](file/type/00worldpoint.md) | Save points                       |
 | [00objentry.bin](file/type/00objentry.md)     | Object entries and params         |
 | [03system.bin](file/type/03system.md)         | Various params                    |
-| [12soundinfo.bar](file/type/12soundinfo.bar)  | Defines footstep/ambient sound effects per room in a world.|
+| [12soundinfo.bar](file/type/12soundinfo.md)  | Defines footstep/ambient sound effects per room in a world.|
 | [15jigsaw.bin](file/type/15jigsaw.md)         | Defines puzzle pieces (Final Mix) |
 | [jiminy.bar](file/type/jiminy.md)             | Jiminy's journal info             |
 | [mixdata.bar](file/type/mixdata.md)           | Moogle shop info                  |

--- a/docs/kh2/notable-files.md
+++ b/docs/kh2/notable-files.md
@@ -9,3 +9,4 @@
 | [15jigsaw.bin](file/type/15jigsaw.md)         | Defines puzzle pieces (Final Mix) |
 | [jiminy.bar](file/type/jiminy.md)             | Jiminy's journal info             |
 | [mixdata.bar](file/type/mixdata.md)           | Moogle shop info                  |
+| [12soundinfo.bar](file/type/12soundinfo.bar)  | Defines footstep/ambient sound effects per room in a world.|

--- a/docs/kh2/notable-files.md
+++ b/docs/kh2/notable-files.md
@@ -6,7 +6,7 @@
 | [00worldpoint.bin](file/type/00worldpoint.md) | Save points                       |
 | [00objentry.bin](file/type/00objentry.md)     | Object entries and params         |
 | [03system.bin](file/type/03system.md)         | Various params                    |
+| [12soundinfo.bar](file/type/12soundinfo.bar)  | Defines footstep/ambient sound effects per room in a world.|
 | [15jigsaw.bin](file/type/15jigsaw.md)         | Defines puzzle pieces (Final Mix) |
 | [jiminy.bar](file/type/jiminy.md)             | Jiminy's journal info             |
 | [mixdata.bar](file/type/mixdata.md)           | Moogle shop info                  |
-| [12soundinfo.bar](file/type/12soundinfo.bar)  | Defines footstep/ambient sound effects per room in a world.|


### PR DESCRIPTION
Some more comprehensive documentation on the SCD format for KH2. The knowledge here is probably identical for the other games that use SCD, but this is untested.

This updated SCD documentation includes some info I haven't found anywhere else, like the Sound Mapping Table that maps sound effects to ID's to be used by the game, as well as controls the volume of each sound, as well as an int in the SoundEntry table that controls how long audio should play for.

Also includes documentation on 12soundinfo.bar, this is a file that controls various ambient sound effects in KH2's maps like footsteps and environmental sounds on a per-room basis.

