### PR TITLE
Add a uninstall button for Lua Backend 

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -44,10 +44,7 @@ namespace OpenKh.Tools.ModsManager.Services
             public bool DevView { get; internal set; } = false;
             public bool AutoUpdateMods { get; internal set; }
             public bool isEGSVersion { get; internal set; } = true;
-            public bool Extractkh1 { get; internal set; }
-            public bool Extractkh2 { get; internal set; } = true;
-            public bool Extractbbs { get; internal set; }
-            public bool Extractrecom { get; internal set; }
+            public List<string> GamesToExtract { get; internal set; } = new List<string> { "kh2" };
             public string LaunchGame { get; internal set; } = "kh2";
 
             public void Save(string fileName)
@@ -336,37 +333,65 @@ namespace OpenKh.Tools.ModsManager.Services
         }
         public static bool Extractkh1
         {
-            get => _config.Extractkh1;
+            get => _config.GamesToExtract.Contains("kh1");
             set
             {
-                _config.Extractkh1 = value;
+                if (value)
+                {
+                    _config.GamesToExtract.Add("kh1");
+                }
+                else
+                {
+                    _config.GamesToExtract.Remove("kh1");
+                }
                 _config.Save(ConfigPath);
             }
         }
         public static bool Extractkh2
         {
-            get => _config.Extractkh2;
+            get => _config.GamesToExtract.Contains("kh2");
             set
             {
-                _config.Extractkh2 = value;
+                if (value)
+                {
+                    _config.GamesToExtract.Add("kh2");
+                }
+                else
+                {
+                    _config.GamesToExtract.Remove("kh2");
+                }
                 _config.Save(ConfigPath);
             }
         }
         public static bool Extractbbs
         {
-            get => _config.Extractbbs;
+            get => _config.GamesToExtract.Contains("bbs");
             set
             {
-                _config.Extractbbs = value;
+                if (value)
+                {
+                    _config.GamesToExtract.Add("bbs");
+                }
+                else
+                {
+                    _config.GamesToExtract.Remove("bbs");
+                }
                 _config.Save(ConfigPath);
             }
         }
         public static bool Extractrecom
         {
-            get => _config.Extractrecom;
+            get => _config.GamesToExtract.Contains("Recom");
             set
             {
-                _config.Extractrecom = value;
+                if (value)
+                {
+                    _config.GamesToExtract.Add("Recom");
+                }
+                else
+                {
+                    _config.GamesToExtract.Remove("Recom");
+                }
                 _config.Save(ConfigPath);
             }
         }

--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -48,6 +48,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         private string _gameDataLocation;
         private bool _isEGSVersion;
         private List<string> LuaScriptPaths = new List<string>();
+        private bool _overrideGameDataFound = false;
 
         private Xceed.Wpf.Toolkit.WizardPage _wizardPageAfterIntro;
         public Xceed.Wpf.Toolkit.WizardPage WizardPageAfterIntro
@@ -297,6 +298,19 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 }
             }
         }
+        public bool OverrideGameDataFound
+        {
+            get => _overrideGameDataFound;
+            set
+            {
+                _overrideGameDataFound = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(IsGameDataFound));
+                OnPropertyChanged(nameof(GameDataNotFoundVisibility));
+                OnPropertyChanged(nameof(GameDataFoundVisibility));
+            }
+              
+        }
         public string PcReleaseLanguage
         {
             get => _pcReleaseLanguage;
@@ -332,7 +346,8 @@ namespace OpenKh.Tools.ModsManager.ViewModels
             (GameEdition == EpicGames && (GameService.FolderContainsUniqueFile("kh2", Path.Combine(GameDataLocation, "kh2")) || 
             GameService.FolderContainsUniqueFile("kh1", Path.Combine(GameDataLocation, "kh1")) || 
             File.Exists(Path.Combine(GameDataLocation, "bbs", "message")) ||
-            File.Exists(Path.Combine(GameDataLocation, "Recom", "SYS")))));
+            File.Exists(Path.Combine(GameDataLocation, "Recom", "SYS"))))||
+            OverrideGameDataFound);
         public Visibility GameDataNotFoundVisibility => !IsGameDataFound ? Visibility.Visible : Visibility.Collapsed;
         public Visibility GameDataFoundVisibility => IsGameDataFound ? Visibility.Visible : Visibility.Collapsed;
         public Visibility ProgressBarVisibility => IsNotExtracting ? Visibility.Collapsed : Visibility.Visible;

--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -208,6 +208,8 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 OnPropertyChanged(nameof(PanaceaNotInstalledVisibility));
                 OnPropertyChanged(nameof(IsGameSelected));
                 OnPropertyChanged(nameof(IsGameDataFound));
+                OnPropertyChanged(nameof(LuaBackendFoundVisibility));
+                OnPropertyChanged(nameof(LuaBackendNotFoundVisibility));
             }
         }
         public bool IsEGSVersion
@@ -357,9 +359,17 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         public int RegionId { get; set; }
         public bool IsLuaBackendInstalled
         {
-            get => File.Exists(Path.Combine(PcReleaseLocation, "LuaBackend.dll")) && 
-                File.Exists(Path.Combine(PcReleaseLocation, "lua54.dll")) && 
-                File.Exists(Path.Combine(PcReleaseLocation, "LuaBackend.toml"));
+            get
+            {
+                if (PcReleaseLocation != null)
+                {
+                    return File.Exists(Path.Combine(PcReleaseLocation, "LuaBackend.dll")) &&
+                        File.Exists(Path.Combine(PcReleaseLocation, "lua54.dll")) &&
+                        File.Exists(Path.Combine(PcReleaseLocation, "LuaBackend.toml"));
+                }
+                else
+                    return false;
+            }
         }
         public RelayCommand InstallLuaBackendCommand { get; set; }
         public RelayCommand RemoveLuaBackendCommand { get; set; }

--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -591,22 +591,22 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     if (LuaScriptPaths.Contains("kh1"))
                     {
                         int index = config.IndexOf("true }", config.IndexOf("[kh1]")) + 6;
-                        config = config.Insert(index, ", {path = " + Path.Combine(ConfigurationService.GameModPath, "kh1/scripts , relative = false}").Replace("\\", "/"));
+                        config = config.Insert(index, ", {path = \"" + Path.Combine(ConfigurationService.GameModPath, "kh1/scripts\" , relative = false}").Replace("\\", "/"));
                     }
                     if (LuaScriptPaths.Contains("kh2"))
                     {
                         int index = config.IndexOf("true }", config.IndexOf("[kh2]")) + 6;
-                        config = config.Insert(index, ", {path = " + Path.Combine(ConfigurationService.GameModPath, "kh2/scripts , relative = false}").Replace("\\", "/"));
+                        config = config.Insert(index, ", {path = \"" + Path.Combine(ConfigurationService.GameModPath, "kh2/scripts\" , relative = false}").Replace("\\", "/"));
                     }
                     if (LuaScriptPaths.Contains("bbs"))
                     {
                         int index = config.IndexOf("true }", config.IndexOf("[bbs]")) + 6;
-                        config = config.Insert(index, ", {path = " + Path.Combine(ConfigurationService.GameModPath, "bbs/scripts , relative = false}").Replace("\\", "/"));
+                        config = config.Insert(index, ", {path = \"" + Path.Combine(ConfigurationService.GameModPath, "bbs/scripts\" , relative = false}").Replace("\\", "/"));
                     }
                     if (LuaScriptPaths.Contains("Recom"))
                     {
                         int index = config.IndexOf("true }", config.IndexOf("[recom]")) + 6;
-                        config = config.Insert(index, ", {path = " + Path.Combine(ConfigurationService.GameModPath, "Recom/scripts , relative = false}").Replace("\\", "/"));
+                        config = config.Insert(index, ", {path = \"" + Path.Combine(ConfigurationService.GameModPath, "Recom/scripts\" , relative = false}").Replace("\\", "/"));
                     }
                     File.WriteAllText(Path.Combine(PcReleaseLocation, "LuaBackend.toml"), config);
                     File.Delete(DownPath);
@@ -623,22 +623,22 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         if (LuaScriptPaths.Contains("kh1") && !config.Contains("mod/kh1/scripts"))
                         {
                             int index = config.IndexOf("true }", config.IndexOf("[kh1]")) + 6;
-                            config = config.Insert(index, ", {path = " + Path.Combine(ConfigurationService.GameModPath, "kh1/scripts , relative = false}").Replace("\\", "/"));     
+                            config = config.Insert(index, ", {path = \"" + Path.Combine(ConfigurationService.GameModPath, "kh1/scripts\" , relative = false}").Replace("\\", "/"));     
                         }
                         if (LuaScriptPaths.Contains("kh2") && !config.Contains("mod/kh2/scripts"))
                         {
                             int index = config.IndexOf("true }", config.IndexOf("[kh2]")) + 6;
-                            config = config.Insert(index, ", {path = " + Path.Combine(ConfigurationService.GameModPath, "kh2/scripts , relative = false}").Replace("\\", "/"));
+                            config = config.Insert(index, ", {path = \"" + Path.Combine(ConfigurationService.GameModPath, "kh2/scripts\" , relative = false}").Replace("\\", "/"));
                         }
                         if (LuaScriptPaths.Contains("bbs") && !config.Contains("mod/bbs/scripts"))
                         {
                             int index = config.IndexOf("true }", config.IndexOf("[bbs]")) + 6;
-                            config = config.Insert(index, ", {path = " + Path.Combine(ConfigurationService.GameModPath, "bbs/scripts , relative = false}").Replace("\\", "/"));
+                            config = config.Insert(index, ", {path = \"" + Path.Combine(ConfigurationService.GameModPath, "bbs/scripts\" , relative = false}").Replace("\\", "/"));
                         }
                         if (LuaScriptPaths.Contains("Recom") && !config.Contains("mod/Recom/scripts"))
                         {
                             int index = config.IndexOf("true }", config.IndexOf("[recom]")) + 6;
-                            config = config.Insert(index, ", {path = " + Path.Combine(ConfigurationService.GameModPath, "Recom/scripts , relative = false}").Replace("\\", "/"));
+                            config = config.Insert(index, ", {path = \"" + Path.Combine(ConfigurationService.GameModPath, "Recom/scripts\" , relative = false}").Replace("\\", "/"));
                         }
                         File.WriteAllText(Path.Combine(PcReleaseLocation, "LuaBackend.toml"), config);
                         OnPropertyChanged(nameof(IsLuaBackendInstalled));

--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -367,6 +367,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 File.Exists(Path.Combine(PcReleaseLocation, "LuaBackend.toml"));
         }
         public RelayCommand InstallLuaBackendCommand { get; set; }
+        public RelayCommand RemoveLuaBackendCommand { get; set; }
         public Visibility LuaBackendFoundVisibility => IsLuaBackendInstalled ? Visibility.Visible : Visibility.Collapsed;
         public Visibility LuaBackendNotFoundVisibility => IsLuaBackendInstalled ? Visibility.Collapsed : Visibility.Visible;
         public RelayCommand InstallPanaceaCommand { get; }
@@ -650,6 +651,15 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         OnPropertyChanged(nameof(LuaBackendNotFoundVisibility));
                     }
                 }
+            });
+            RemoveLuaBackendCommand = new RelayCommand(_ =>
+            {
+                File.Delete(Path.Combine(PcReleaseLocation, "LuaBackend.dll"));
+                File.Delete(Path.Combine(PcReleaseLocation, "lua54.dll"));
+                File.Delete(Path.Combine(PcReleaseLocation, "LuaBackend.toml"));
+                OnPropertyChanged(nameof(IsLuaBackendInstalled));
+                OnPropertyChanged(nameof(LuaBackendFoundVisibility));
+                OnPropertyChanged(nameof(LuaBackendNotFoundVisibility));
             });
         }
 

--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -47,10 +47,6 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         private string _pcReleaseLanguage;
         private string _gameDataLocation;
         private bool _isEGSVersion;
-        private bool _Extractkh2 = ConfigurationService.Extractkh2;
-        private bool _Extractkh1 = ConfigurationService.Extractkh1;
-        private bool _Extractbbs = ConfigurationService.Extractbbs;
-        private bool _Extractrecom = ConfigurationService.Extractrecom;
         private List<string> LuaScriptPaths = new List<string>();
 
         private Xceed.Wpf.Toolkit.WizardPage _wizardPageAfterIntro;
@@ -223,39 +219,23 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         }
         public bool Extractkh1
         {
-            get => _Extractkh1;
-            set
-            {
-                _Extractkh1 = value;
-                ConfigurationService.Extractkh1 = value;
-            }
+            get => ConfigurationService.Extractkh1;
+            set => ConfigurationService.Extractkh1 = value;
         }
         public bool Extractkh2
         {
-            get => _Extractkh2;
-            set
-            {
-                _Extractkh2 = value;
-                ConfigurationService.Extractkh2 = value;
-            }
+            get => ConfigurationService.Extractkh2;
+            set => ConfigurationService.Extractkh2 = value;
         }
         public bool Extractbbs
         {
-            get => _Extractbbs;
-            set
-            {
-                _Extractbbs = value;
-                ConfigurationService.Extractbbs = value;
-            }
+            get => ConfigurationService.Extractbbs;
+            set => ConfigurationService.Extractbbs = value;
         }
         public bool Extractrecom
         {
-            get => _Extractrecom;
-            set
-            {
-                _Extractrecom = value;
-                ConfigurationService.Extractrecom = value;
-            }
+            get => ConfigurationService.Extractrecom;
+            set => ConfigurationService.Extractrecom = value;
         }
         public bool LuaConfigkh1
         {

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -179,7 +179,7 @@
                 </TextBlock>
                 <TextBlock Margin="0 0 0 3" Visibility="{Binding PcReleaseConfigVisibility}" TextWrapping="Wrap">               
                     <Run Foreground="Red">WARNING</Run>
-                    If you do not extract a games data only Lua Scripts will function properly. Only check the box below if you will only be installing Lua Scripts in mod manager.
+                    If you do not extract a games data only Lua Scripts will function properly. Only check the box below if you will only be installing Lua Scripts in Mods Manager.
                 </TextBlock>
                 <CheckBox IsChecked="{Binding OverrideGameDataFound}" Content="Skip Game Extraction" Visibility="{Binding PcReleaseConfigVisibility}" Margin="0 0 0 4"/>
             </StackPanel>

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -281,6 +281,10 @@
                 </StackPanel>
                 <Button Margin="0 0 0 6" Content="Install and Configure Lua Backend" HorizontalAlignment="Left" Width="200" Command="{Binding InstallLuaBackendCommand}" CommandParameter="false" Visibility="{Binding LuaBackendNotFoundVisibility}"/>
                 <Button Margin="0 0 0 6" Content="Configure Lua Backend" HorizontalAlignment="Left" Width="200" Command="{Binding InstallLuaBackendCommand}" CommandParameter="true" Visibility="{Binding LuaBackendFoundVisibility}"/>
+                <TextBlock Margin="0 2 0 10" Visibility="{Binding LuaBackendFoundVisibility}" TextWrapping="Wrap">
+                If you wish to reinstall Lua Backend to fix scripts not loading and the configure button did not work or just to uninstall completely press the button below.
+                </TextBlock>
+                <Button Margin="0 0 0 6" Content="Uninstall Lua Backend" HorizontalAlignment="Left" Width="200" Command="{Binding RemoveLuaBackendCommand}" Visibility="{Binding LuaBackendFoundVisibility}"/>
             </StackPanel>
         </xctk:WizardPage>
         <xctk:WizardPage

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -177,6 +177,11 @@
                 <TextBlock Margin="0 0 0 3" Visibility="{Binding ExtractionCompleteVisibility}">
                     The extraction of the game's data succeded!
                 </TextBlock>
+                <TextBlock Margin="0 0 0 3" Visibility="{Binding PcReleaseConfigVisibility}" TextWrapping="Wrap">               
+                    <Run Foreground="Red">WARNING</Run>
+                    If you do not extract a games data only Lua Scripts will function properly. Only check the box below if you will only be installing Lua Scripts in mod manager.
+                </TextBlock>
+                <CheckBox IsChecked="{Binding OverrideGameDataFound}" Content="Skip Game Extraction" Visibility="{Binding PcReleaseConfigVisibility}" Margin="0 0 0 4"/>
             </StackPanel>
         </xctk:WizardPage>
         <xctk:WizardPage


### PR DESCRIPTION
To either uninstall or allow the user to easily reinstall in case the toml is messed up somehow

![image](https://github.com/OpenKH/OpenKh/assets/47014056/1e0162d1-d54a-4dd5-803c-5606cf24dac7)


Also changes the way the PC extract game data stores which games to extract to a list from a bool per game/checkbox