### PR TITLE
Lua Backend Configure Actual Error Handling

### DIFF
--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -634,8 +634,8 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         {
                             if (config.Contains("mod/kh1/scripts"))
                             {
-                                var errorMessage = MessageBox.Show($"Your Lua Backend is already configured to run scripts from an OpenKH Mod Manager installation." +
-                                    $" Do you want to change it so Lua Backend runs scripts from this version of OpenKH Mod Manager instead?", "Warning",
+                                var errorMessage = MessageBox.Show($"Your Lua Backend is already configured to run Lua scripts for KH1 from an OpenKH Mod Manager." +
+                                    $" Do you want to change Lua Backend to run scripts for KH1 from this version of OpenKH Mod Manager instead?", "Warning",
                                     MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No, MessageBoxOptions.DefaultDesktopOnly);
 
                                 switch (errorMessage)
@@ -662,8 +662,8 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         {
                             if (config.Contains("mod/kh2/scripts"))
                             {
-                                var errorMessage = MessageBox.Show($"Your Lua Backend is already configured to run scripts from an OpenKH Mod Manager installation." +
-                                    $" Do you want to change it so Lua Backend runs scripts from this version of OpenKH Mod Manager instead?", "Warning",
+                                var errorMessage = MessageBox.Show($"Your Lua Backend is already configured to run Lua scripts for KH2 from an OpenKH Mod Manager." +
+                                    $" Do you want to change Lua Backend to run scripts for KH2 from this version of OpenKH Mod Manager instead?", "Warning",
                                     MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No, MessageBoxOptions.DefaultDesktopOnly);
 
                                 switch (errorMessage)
@@ -690,8 +690,8 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         {
                             if (config.Contains("mod/bbs/scripts"))
                             {
-                                var errorMessage = MessageBox.Show($"Your Lua Backend is already configured to run mods from an OpenKH Mod Manager installation." +
-                                    $" Do you want to change it so Lua Backend runs scripts from this version of OpenKH Mod Manager instead?", "Warning",
+                                var errorMessage = MessageBox.Show($"Your Lua Backend is already configured to run Lua scripts for BBS from an OpenKH Mod Manager." +
+                                    $" Do you want to change Lua Backend to run scripts for BBS from this version of OpenKH Mod Manager instead?", "Warning",
                                     MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No, MessageBoxOptions.DefaultDesktopOnly);
 
                                 switch (errorMessage)
@@ -718,8 +718,8 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         {
                             if (config.Contains("mod/Recom/scripts"))
                             {
-                                var errorMessage = MessageBox.Show($"Your Lua Backend is already configured to run mods from an OpenKH Mod Manager installation." +
-                                    $" Do you want to change it so Lua Backend runs scripts from this version of OpenKH Mod Manager instead?", "Warning",
+                                var errorMessage = MessageBox.Show($"Your Lua Backend is already configured to run Lua scripts for ReCoM from an OpenKH Mod Manager." +
+                                    $" Do you want to change Lua Backend to run scripts for ReCoM from this version of OpenKH Mod Manager instead?", "Warning",
                                     MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No, MessageBoxOptions.DefaultDesktopOnly);
 
                                 switch (errorMessage)

--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -630,25 +630,117 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     if (File.Exists(Path.Combine(PcReleaseLocation, "LuaBackend.toml")))
                     {
                         string config = File.ReadAllText(Path.Combine(PcReleaseLocation, "LuaBackend.toml")).Replace("\\", "/").Replace("\\\\", "/");
-                        if (LuaScriptPaths.Contains("kh1") && !config.Contains("mod/kh1/scripts"))
+                        if (LuaScriptPaths.Contains("kh1"))
                         {
-                            int index = config.IndexOf("true }", config.IndexOf("[kh1]")) + 6;
-                            config = config.Insert(index, ", {path = \"" + Path.Combine(ConfigurationService.GameModPath, "kh1/scripts\" , relative = false}").Replace("\\", "/"));     
+                            if (config.Contains("mod/kh1/scripts"))
+                            {
+                                var errorMessage = MessageBox.Show($"Your Lua Backend is already configured to run scripts from an OpenKH Mod Manager installation." +
+                                    $" Do you want to change it so Lua Backend runs scripts from this version of OpenKH Mod Manager instead?", "Warning",
+                                    MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No, MessageBoxOptions.DefaultDesktopOnly);
+
+                                switch (errorMessage)
+                                {
+                                    case MessageBoxResult.Yes:
+                                    {
+                                        int index = config.IndexOf("scripts", config.IndexOf("[kh1]"));
+                                        config = config.Remove(index, config.IndexOf("]", index) - index + 1);
+                                        config = config.Insert(index, "scripts = [{ path = \"scripts/kh1/\", relative = true }" +
+                                            ", {path = \"" + Path.Combine(ConfigurationService.GameModPath, "kh1/scripts\" , relative = false}]").Replace("\\", "/"));
+                                        break;
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                int index = config.IndexOf("scripts", config.IndexOf("[kh1]"));
+                                config = config.Remove(index, config.IndexOf("]", index) - index + 1);
+                                config = config.Insert(index, "scripts = [{ path = \"scripts/kh1/\", relative = true }" +
+                                    ", {path = \"" + Path.Combine(ConfigurationService.GameModPath, "kh1/scripts\" , relative = false}]").Replace("\\", "/"));
+                            }
                         }
-                        if (LuaScriptPaths.Contains("kh2") && !config.Contains("mod/kh2/scripts"))
+                        if (LuaScriptPaths.Contains("kh2"))
                         {
-                            int index = config.IndexOf("true }", config.IndexOf("[kh2]")) + 6;
-                            config = config.Insert(index, ", {path = \"" + Path.Combine(ConfigurationService.GameModPath, "kh2/scripts\" , relative = false}").Replace("\\", "/"));
+                            if (config.Contains("mod/kh2/scripts"))
+                            {
+                                var errorMessage = MessageBox.Show($"Your Lua Backend is already configured to run scripts from an OpenKH Mod Manager installation." +
+                                    $" Do you want to change it so Lua Backend runs scripts from this version of OpenKH Mod Manager instead?", "Warning",
+                                    MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No, MessageBoxOptions.DefaultDesktopOnly);
+
+                                switch (errorMessage)
+                                {
+                                    case MessageBoxResult.Yes:
+                                    {
+                                        int index = config.IndexOf("scripts", config.IndexOf("[kh2]"));
+                                        config = config.Remove(index, config.IndexOf("]", index) - index + 1);
+                                        config = config.Insert(index, "scripts = [{ path = \"scripts/kh2/\", relative = true }" +
+                                            ", {path = \"" + Path.Combine(ConfigurationService.GameModPath, "kh2/scripts\" , relative = false}]").Replace("\\", "/"));
+                                        break;
+                                    }                                       
+                                }
+                            }
+                            else
+                            {
+                                int index = config.IndexOf("scripts", config.IndexOf("[kh2]"));
+                                config = config.Remove(index, config.IndexOf("]", index) - index + 1);
+                                config = config.Insert(index, "scripts = [{ path = \"scripts/kh2/\", relative = true }" +
+                                    ", {path = \"" + Path.Combine(ConfigurationService.GameModPath, "kh2/scripts\" , relative = false}]").Replace("\\", "/"));
+                            }
                         }
-                        if (LuaScriptPaths.Contains("bbs") && !config.Contains("mod/bbs/scripts"))
+                        if (LuaScriptPaths.Contains("bbs"))
                         {
-                            int index = config.IndexOf("true }", config.IndexOf("[bbs]")) + 6;
-                            config = config.Insert(index, ", {path = \"" + Path.Combine(ConfigurationService.GameModPath, "bbs/scripts\" , relative = false}").Replace("\\", "/"));
+                            if (config.Contains("mod/bbs/scripts"))
+                            {
+                                var errorMessage = MessageBox.Show($"Your Lua Backend is already configured to run mods from an OpenKH Mod Manager installation." +
+                                    $" Do you want to change it so Lua Backend runs scripts from this version of OpenKH Mod Manager instead?", "Warning",
+                                    MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No, MessageBoxOptions.DefaultDesktopOnly);
+
+                                switch (errorMessage)
+                                {
+                                    case MessageBoxResult.Yes:
+                                    {
+                                        int index = config.IndexOf("scripts", config.IndexOf("[bbs]"));
+                                        config = config.Remove(index, config.IndexOf("]", index) - index + 1);
+                                        config = config.Insert(index, "scripts = [{ path = \"scripts/bbs/\", relative = true }" +
+                                            ", {path = \"" + Path.Combine(ConfigurationService.GameModPath, "bbs/scripts\" , relative = false}]").Replace("\\", "/"));
+                                        break;
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                int index = config.IndexOf("scripts", config.IndexOf("[bbs]"));
+                                config = config.Remove(index, config.IndexOf("]", index) - index + 1);
+                                config = config.Insert(index, "scripts = [{ path = \"scripts/bbs/\", relative = true }" +
+                                    ", {path = \"" + Path.Combine(ConfigurationService.GameModPath, "bbs/scripts\" , relative = false}]").Replace("\\", "/"));
+                            }
                         }
-                        if (LuaScriptPaths.Contains("Recom") && !config.Contains("mod/Recom/scripts"))
+                        if (LuaScriptPaths.Contains("Recom"))
                         {
-                            int index = config.IndexOf("true }", config.IndexOf("[recom]")) + 6;
-                            config = config.Insert(index, ", {path = \"" + Path.Combine(ConfigurationService.GameModPath, "Recom/scripts\" , relative = false}").Replace("\\", "/"));
+                            if (config.Contains("mod/Recom/scripts"))
+                            {
+                                var errorMessage = MessageBox.Show($"Your Lua Backend is already configured to run mods from an OpenKH Mod Manager installation." +
+                                    $" Do you want to change it so Lua Backend runs scripts from this version of OpenKH Mod Manager instead?", "Warning",
+                                    MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No, MessageBoxOptions.DefaultDesktopOnly);
+
+                                switch (errorMessage)
+                                {
+                                    case MessageBoxResult.Yes:
+                                    {
+                                        int index = config.IndexOf("scripts", config.IndexOf("[recom]"));
+                                        config = config.Remove(index, config.IndexOf("]", index) - index + 1);
+                                        config = config.Insert(index, "scripts = [{ path = \"scripts/recom/\", relative = true }" +
+                                            ", {path = \"" + Path.Combine(ConfigurationService.GameModPath, "Recom/scripts\" , relative = false}]").Replace("\\", "/"));
+                                        break;
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                int index = config.IndexOf("scripts", config.IndexOf("[recom]"));
+                                config = config.Remove(index, config.IndexOf("]", index) - index + 1);
+                                config = config.Insert(index, "scripts = [{ path = \"scripts/recom/\", relative = true }" +
+                                    ", {path = \"" + Path.Combine(ConfigurationService.GameModPath, "Recom/scripts\" , relative = false}]").Replace("\\", "/"));
+                            }
                         }
                         File.WriteAllText(Path.Combine(PcReleaseLocation, "LuaBackend.toml"), config);
                         OnPropertyChanged(nameof(IsLuaBackendInstalled));

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -287,7 +287,7 @@
                 <Button Margin="0 0 0 6" Content="Install and Configure Lua Backend" HorizontalAlignment="Left" Width="200" Command="{Binding InstallLuaBackendCommand}" CommandParameter="false" Visibility="{Binding LuaBackendNotFoundVisibility}"/>
                 <Button Margin="0 0 0 6" Content="Configure Lua Backend" HorizontalAlignment="Left" Width="200" Command="{Binding InstallLuaBackendCommand}" CommandParameter="true" Visibility="{Binding LuaBackendFoundVisibility}"/>
                 <TextBlock Margin="0 2 0 10" Visibility="{Binding LuaBackendFoundVisibility}" TextWrapping="Wrap">
-                If you wish to reinstall Lua Backend to fix scripts not loading and the configure button did not work or just to uninstall completely press the button below.
+                If you wish to uninstall Lua Backend completely press the button below.
                 </TextBlock>
                 <Button Margin="0 0 0 6" Content="Uninstall Lua Backend" HorizontalAlignment="Left" Width="200" Command="{Binding RemoveLuaBackendCommand}" Visibility="{Binding LuaBackendFoundVisibility}"/>
             </StackPanel>


### PR DESCRIPTION
If during config of a pre-existing LuaBackend.toml MM detects a possible path to another MM (even if it is the same MM) displays a message box asking to overwrite it.

![image](https://github.com/OpenKH/OpenKh/assets/47014056/812af227-25f3-4f4f-b99d-e6d50100592e)

![image](https://github.com/OpenKH/OpenKh/assets/47014056/fe3152c3-e3d3-415d-9873-d2c2c2b729b8)

![image](https://github.com/OpenKH/OpenKh/assets/47014056/7526f602-91ef-437f-ab9b-72fd8f22598d)

![image](https://github.com/OpenKH/OpenKh/assets/47014056/f76a183f-585c-44cf-903a-31f1d8548b06)
