### PR TITLE
Fix Sprite Groups window won't be opened.

### DIFF
--- a/OpenKh.Tools.LayoutEditor/AppSequenceEditor.cs
+++ b/OpenKh.Tools.LayoutEditor/AppSequenceEditor.cs
@@ -136,14 +136,15 @@ namespace OpenKh.Tools.LayoutEditor
 
         public bool Run()
         {
-            bool dummy = true;
-            if (ImGui.BeginPopupModal(SpriteEditDialogTitle, ref dummy,
+            bool canOpenSpriteEditDialog = true;
+            if (ImGui.BeginPopupModal(SpriteEditDialogTitle, ref canOpenSpriteEditDialog,
                 ImGuiWindowFlags.Popup | ImGuiWindowFlags.Modal | ImGuiWindowFlags.AlwaysAutoResize))
             {
                 _spriteEditDialog.Run();
                 ImGui.EndPopup();
             }
-            if (ImGui.BeginPopupModal(SpriteGroupEditDialogTitle, ref dummy,
+            bool canOpenSpriteGroupEditDialog = true;
+            if (ImGui.BeginPopupModal(SpriteGroupEditDialogTitle, ref canOpenSpriteGroupEditDialog,
                 ImGuiWindowFlags.Popup | ImGuiWindowFlags.Modal | ImGuiWindowFlags.AlwaysAutoResize))
             {
                 _spriteGroupEditDialog.Run();


### PR DESCRIPTION
`Sprite group edit` popup now opens _independently_ on selection: `Edit` → `Sprite groups...`

![2024-02-10_14h23_11](https://github.com/OpenKH/OpenKh/assets/5955540/4854b918-9f62-4c53-b49b-7328c0bef7fd)
