### PR TITLE
Apply an alternative CheckBox default style to ModsManager

### DIFF
--- a/OpenKh.Tools.ModsManager/App.xaml
+++ b/OpenKh.Tools.ModsManager/App.xaml
@@ -7,6 +7,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/Xe.Tools.Wpf;component/Themes/Generic.xaml"/>
+                <ResourceDictionary Source="Styles/MonoStyleCheckBox.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/OpenKh.Tools.ModsManager/Styles/MonoStyleCheckBox.xaml
+++ b/OpenKh.Tools.ModsManager/Styles/MonoStyleCheckBox.xaml
@@ -1,0 +1,130 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Style TargetType="{x:Type CheckBox}">
+        <Setter Property="SnapsToDevicePixels"
+                Value="true" />
+        <Setter Property="OverridesDefaultStyle"
+                Value="true" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type CheckBox}">
+                    <BulletDecorator Background="Transparent">
+                        <BulletDecorator.Bullet>
+                            <Border x:Name="Border"
+                                    Width="13"
+                                    Height="13"
+                                    BorderBrush="{TemplateBinding Foreground}"
+                                    CornerRadius="0"
+                                    BorderThickness="1">
+                                <Grid>
+                                    <Path Visibility="Collapsed"
+                                          Width="7"
+                                          Height="7"
+                                          x:Name="CheckMark"
+                                          SnapsToDevicePixels="False"
+                                          StrokeThickness="2"
+                                          Stroke="{TemplateBinding Foreground}"
+                                          Data="M 0 0 L 7 7 M 0 7 L 7 0">
+                                    </Path>
+                                    <Path Visibility="Collapsed"
+                                          Width="7"
+                                          Height="7"
+                                          x:Name="InderminateMark"
+                                          SnapsToDevicePixels="False"
+                                          StrokeThickness="2"
+                                          Stroke="{TemplateBinding Foreground}"
+                                          Data="M 0 7 L 7 0">
+                                    </Path>
+                                </Grid>
+                            </Border>
+                        </BulletDecorator.Bullet>
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="MouseOver">
+                                    <Storyboard>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="Border"
+                                                                       Storyboard.TargetProperty="Opacity">
+                                            <EasingDoubleKeyFrame KeyTime="0"
+                                                                  Value="0.7" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Pressed">
+                                    <Storyboard>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="Border"
+                                                                       Storyboard.TargetProperty="Opacity">
+                                            <EasingDoubleKeyFrame KeyTime="0"
+                                                                  Value="0.6" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(Border.Background)"
+                                                                       Storyboard.TargetName="Border">
+                                            <DiscreteObjectKeyFrame KeyTime="0">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <SolidColorBrush Color="LightGray" />
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Disabled">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(Border.Background)"
+                                                                       Storyboard.TargetName="Border">
+                                            <DiscreteObjectKeyFrame KeyTime="0">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <SolidColorBrush Color="LightGray" />
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(Path.Stroke)"
+                                                                       Storyboard.TargetName="CheckMark">
+                                            <DiscreteObjectKeyFrame KeyTime="0">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <SolidColorBrush Color="Black" />
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(Path.Stroke)"
+                                                                       Storyboard.TargetName="InderminateMark">
+                                            <DiscreteObjectKeyFrame KeyTime="0">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <SolidColorBrush Color="Black" />
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="CheckStates">
+                                <VisualState x:Name="Checked">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)"
+                                                                       Storyboard.TargetName="CheckMark">
+                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                    Value="{x:Static Visibility.Visible}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Unchecked" />
+                                <VisualState x:Name="Indeterminate">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)"
+                                                                       Storyboard.TargetName="InderminateMark">
+                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                    Value="{x:Static Visibility.Visible}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <ContentPresenter Margin="4,0,0,0"
+                                          VerticalAlignment="Center"
+                                          HorizontalAlignment="Left"
+                                          RecognizesAccessKey="True" />
+                    </BulletDecorator>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -13,9 +13,6 @@
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
         <SolidColorBrush x:Key="textHyperlink" Color="#569CD6" />
-        <Style TargetType="CheckBox">
-            <Setter Property="Foreground" Value="{Binding ColorTheme.TextColor}"/>
-        </Style>
         <Style TargetType="xctk:WizardPage">
             <Setter Property="Foreground" Value="{Binding ColorTheme.TextColor}"/>
             <Setter Property="Background" Value="{Binding ColorTheme.BackgroundColor}"/>


### PR DESCRIPTION
On light mode (proposed)

![lightmode](https://github.com/OpenKH/OpenKh/assets/5955540/28b47d69-e4c2-4ddb-8ad6-284c62326d80)

On light mode (current)

![cur-light](https://github.com/OpenKH/OpenKh/assets/5955540/a7d762e4-c50d-4e39-aee5-d9fe550e7fbc)

On dark mode (proposed)

![darkmode](https://github.com/OpenKH/OpenKh/assets/5955540/a06476f3-dde7-4429-ace0-71de2c484463)

On dark mode (current _without workaround_)

![cur-dark](https://github.com/OpenKH/OpenKh/assets/5955540/f775457a-9778-495f-b778-35f60c7574eb)

WPF's default CheckBox style is well designed for native Windows light mode.
This may not be fit on our dark theme ↓

![2024-02-10_16h32_58](https://github.com/OpenKH/OpenKh/assets/5955540/9df96285-6e04-4118-9092-d14c16fea62d)

Currently one workaround is needed to apply dark mode on our WPF apps. 

```cs
    <Window.Resources>
        <Style TargetType="CheckBox">
            <Setter Property="Foreground" Value="{Binding ColorTheme.TextColor}"/>
        </Style>
    </Window.Resources>
```

About the design of check mark `X`, this is directly taken by sample of MSFT site: [CheckBox Styles and Templates - WPF .NET Framework | Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/checkbox-styles-and-templates?view=netframeworkdesktop-4.8).

This pull request proposes to apply this alternative CheckBox style to only ModsManager.

Also this may mitigate issue of #965