### PR TITLE
Fix Lua Backend Config checkboxes not showing up

### DIFF
--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -225,6 +225,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 OnPropertyChanged(nameof(BothPcReleaseSelected));
                 OnPropertyChanged(nameof(PcRelease1525Selected));
                 OnPropertyChanged(nameof(PcRelease28Selected));
+                OnPropertyChanged(nameof(InstallForPc1525));
             }
         }
 
@@ -287,6 +288,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 OnPropertyChanged(nameof(BothPcReleaseSelected));
                 OnPropertyChanged(nameof(PcRelease1525Selected));
                 OnPropertyChanged(nameof(PcRelease28Selected));
+                OnPropertyChanged(nameof(InstallForPc28));
             }
         }
         public bool IsEGSVersion


### PR DESCRIPTION
without changing the selected collection first if you also just selected the proper filepath to the collection for the first time.