### PR TITLE
Automated Installation Detection for Mod Manager 

### DIFF
--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -618,7 +618,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
 
                 if (!itemFiles.Any())
                 {
-                    MessageBox.Show("No Game Install Locations Found\n Please Manually Browse To Your Game Install Directory", "Failure", MessageBoxButton.OK);
+                    MessageBox.Show("No Game Install Locations Found\nPlease Manually Browse To Your Game Install Directory", "Failure", MessageBoxButton.OK);
                     return;
                 }
 

--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -609,7 +609,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
 
                 if (!Directory.Exists(directoryPath))
                 {
-                    MessageBox.Show("No Game Install Locations Found\n Please Manually Browse To Your Game Install Directory", "Failure", MessageBoxButton.OK);
+                    MessageBox.Show("No Game Install Locations Found\nPlease Manually Browse To Your Game Install Directory", "Failure", MessageBoxButton.OK);
                     return;
                 }
 

--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -480,6 +480,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         public Visibility LuaBackendFoundVisibility => IsLuaBackendInstalled ? Visibility.Visible : Visibility.Collapsed;
         public Visibility LuaBackendNotFoundVisibility => IsLuaBackendInstalled ? Visibility.Collapsed : Visibility.Visible;
         public RelayCommand InstallPanaceaCommand { get; }
+        public RelayCommand DetectInstallsCommand { get; }
         public RelayCommand RemovePanaceaCommand { get; }
         public bool PanaceaInstalled { get; set; }
         private string PanaceaSourceLocation => Path.Combine(AppContext.BaseDirectory, PanaceaDllName);
@@ -598,6 +599,88 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                             goto BEGIN;
                             break;
                     }
+                }
+            });
+            DetectInstallsCommand = new RelayCommand(_ =>
+            {
+                // Get ProgramData Folder Location
+                string programDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+                string directoryPath = Path.Combine(programDataFolder, "Epic\\EpicGamesLauncher\\Data\\Manifests");
+
+                if (!Directory.Exists(directoryPath))
+                {
+                    MessageBox.Show("No Game Install Locations Found\n Please Manually Browse To Your Game Install Directory", "Failure", MessageBoxButton.OK);
+                    return;
+                }
+
+                // Get List of .item Files in C:\ProgramData\Epic\EpicGamesLauncher\Data\Manifests\
+                IEnumerable<string> itemFiles = Directory.EnumerateFiles(directoryPath, "*.item");
+
+                if (!itemFiles.Any())
+                {
+                    MessageBox.Show("No Game Install Locations Found\n Please Manually Browse To Your Game Install Directory", "Failure", MessageBoxButton.OK);
+                    return;
+                }
+
+                bool installLocationFoundRemix = false;
+                bool installLocationFound3D = false;
+                foreach (string itemFile in itemFiles)
+                {
+                    // Read Each .item File and Locate Install Location For Games
+                    using StreamReader sr = new StreamReader(itemFile);
+                    string line;
+                    if (sr != null)
+                    {
+                        while ((line = sr.ReadLine()) is not null)
+                        {
+                            if (line.Contains("\"LaunchExecutable\": \"KINGDOM HEARTS HD 1.5+2.5 ReMIX.exe\","))
+                            {
+                                while ((line = sr.ReadLine()) is not null)
+                                {
+                                    if (line.Contains("\"InstallLocation\": \""))
+                                    {
+                                        installLocationFoundRemix = true;
+                                        int startIndex = line.IndexOf("\": \"") + 4;
+                                        int endIndex = line.IndexOf("\",");
+                                        string parsedText = line[startIndex..endIndex];
+                                        parsedText = parsedText.Replace("\\\\", "\\");
+                                        PcReleaseLocation = parsedText;
+                                    }
+                                }
+                            }
+                            else if (line.Contains("\"LaunchExecutable\": \"KINGDOM HEARTS HD 2.8 Final Chapter Prologue.exe\","))
+                            {
+                                while ((line = sr.ReadLine()) is not null)
+                                {
+                                    if (line.Contains("\"InstallLocation\": \""))
+                                    {
+                                        installLocationFound3D = true;
+                                        int startIndex = line.IndexOf("\": \"") + 4;
+                                        int endIndex = line.IndexOf("\",");
+                                        string parsedText = line[startIndex..endIndex];
+                                        parsedText = parsedText.Replace("\\\\", "\\");
+                                        PcReleaseLocationKH3D = parsedText;
+                                    }
+                                } 
+                            }
+                        }
+                    }
+                }
+                if (!installLocationFoundRemix && !installLocationFound3D)
+                {
+                    MessageBox.Show("No Game Install Locations Found\nPlease Manually Browse To Your Game Install Directory", "Failure", MessageBoxButton.OK);
+                }
+                else if (!installLocationFoundRemix && installLocationFound3D)
+                {
+                    MessageBox.Show("Kingdom Hearts HD 1.5+2.5: MISSING\nKingdom Hearts HD 2.8: FOUND", "Success", MessageBoxButton.OK);
+                }
+                else if (installLocationFoundRemix && !installLocationFound3D)
+                {
+                    MessageBox.Show("Kingdom Hearts HD 1.5+2.5: FOUND\nKingdom Hearts HD 2.8: MISSING", "Success", MessageBoxButton.OK);
+                }
+                else
+                {
+                    MessageBox.Show("Kingdom Hearts HD 1.5+2.5: FOUND\nKingdom Hearts HD 2.8: FOUND", "Success", MessageBoxButton.OK);
                 }
             });
             InstallPanaceaCommand = new RelayCommand(AlternateName =>

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -87,6 +87,7 @@
                     <TextBlock Margin="0 0 0 3" TextWrapping="Wrap">
                         Mod Manager supports both the 1.5+2.5 collection and KH3D from the 2.8 collection choose the filepath for at least one of the collections.
                     </TextBlock>
+                    <Button Margin="0 10 0 10" Command="{Binding DetectInstallsCommand}">Detect Installations</Button>
                     <TextBlock Margin="0 0 0 3">Folder location of the PC release of 1.5+2.5</TextBlock>
                     <Grid Margin="0 0 0 3">
                         <Grid.ColumnDefinitions>
@@ -109,7 +110,7 @@
                             <Image Source="{StaticResource FolderOpen_16x}"/>
                         </Button>
                     </Grid>
-                    <TextBlock Margin="0 0 0 3" TextWrapping="Wrap">NOTE: Always be sure to use a supported version as updated might break the compatibility</TextBlock>
+                    <TextBlock Margin="0 0 0 3" TextWrapping="Wrap">NOTE: Always be sure to use a supported version or risk breaking compatibility</TextBlock>
                 </StackPanel>
             </StackPanel>
         </xctk:WizardPage>


### PR DESCRIPTION
Added option to automatically detect game installation folders during Mod Manager setup wizard. Users can choose to click a button that will auto populate the folder directories during setup (if they exist). Can only find KH1.5+2.5 and KH2.8 installations from Epic Games Store.