### PR TITLE
Export ANB into animated FBX.

### DIFF
--- a/OpenKh.AssimpUtils/AssimpGeneric.cs
+++ b/OpenKh.AssimpUtils/AssimpGeneric.cs
@@ -6,6 +6,9 @@ namespace OpenKh.AssimpUtils
 {
     public class AssimpGeneric
     {
+        public static Microsoft.Xna.Framework.Matrix ToXna(Assimp.Matrix4x4 m) => new Microsoft.Xna.Framework.Matrix(m.A1, m.B1, m.C1, m.D1, m.A2, m.B2, m.C2, m.D2, m.A3, m.B3, m.C3, m.D3, m.A4, m.B4, m.C4, m.D4);
+        public static Assimp.Matrix4x4 ToAssimp(Microsoft.Xna.Framework.Matrix m) => new Assimp.Matrix4x4(m.M11, m.M21, m.M31, m.M41, m.M12, m.M22, m.M32, m.M42, m.M13, m.M23, m.M33, m.M43, m.M14, m.M24, m.M34, m.M44);
+
         public static Assimp.Matrix4x4 ToAssimp(Matrix4x4 m) => new Assimp.Matrix4x4(m.M11, m.M21, m.M31, m.M41, m.M12, m.M22, m.M32, m.M42, m.M13, m.M23, m.M33, m.M43, m.M14, m.M24, m.M34, m.M44);
         //public static Matrix4x4 ToNumerics(Assimp.Matrix4x4 m) => new Matrix4x4(m.A1, m.A2, m.A3, m.A4, m.B1, m.B2, m.B3, m.B4, m.C1, m.C2, m.C3, m.C4, m.D1, m.D2, m.D3, m.D4); // Pretty sure this is wrong
         public static Matrix4x4 ToNumerics(Assimp.Matrix4x4 m) => new Matrix4x4(m.A1, m.B1, m.C1, m.D1, m.A2, m.B2, m.C2, m.D2, m.A3, m.B3, m.C3, m.D3, m.A4, m.B4, m.C4, m.D4);

--- a/OpenKh.AssimpUtils/Kh2MdlxAssimp.cs
+++ b/OpenKh.AssimpUtils/Kh2MdlxAssimp.cs
@@ -34,7 +34,7 @@ namespace OpenKh.AssimpUtils
 
                 // TEXTURE
                 Assimp.TextureSlot texture = new Assimp.TextureSlot();
-                texture.FilePath = "Texture" + i;
+                texture.FilePath = "Texture" + i + "." + System.Drawing.Imaging.ImageFormat.Png.ToString().ToLower(); /* Not planning to export them in another extension right. */
                 texture.TextureType = Assimp.TextureType.Diffuse;
 
                 // MATERIAL

--- a/OpenKh.AssimpUtils/Kh2MdlxAssimp.cs
+++ b/OpenKh.AssimpUtils/Kh2MdlxAssimp.cs
@@ -96,6 +96,9 @@ namespace OpenKh.AssimpUtils
                 }
             }
 
+            List<Microsoft.Xna.Framework.Matrix> matricesToReverse = new List<Microsoft.Xna.Framework.Matrix>(0);
+            List<string> matricesToReverseNames = new List<string>(0);
+
             // BONES (Node hierarchy)
             foreach (Mdlx.Bone bone in mParser.Bones)
             {
@@ -115,53 +118,70 @@ namespace OpenKh.AssimpUtils
                 boneNode.Transform = AssimpGeneric.GetNodeTransformMatrix(new Vector3(bone.ScaleX, bone.ScaleY, bone.ScaleZ),
                                                                     new Vector3(bone.RotationX, bone.RotationY, bone.RotationZ),
                                                                     new Vector3(bone.TranslationX, bone.TranslationY, bone.TranslationZ));
+                
+                matricesToReverse.Add(AssimpGeneric.ToXna(boneNode.Transform));
+                matricesToReverseNames.Add(boneName);
 
                 parentNode.Children.Add(boneNode);
             }
 
-            // BONE OFFSET MATRIX - IMPORTANT NOTE: This is for DAE (Collada) FBX ignores the offset matrices
+            ComputeMatrices(ref matricesToReverse, mParser);
+
             foreach (Assimp.Mesh mesh in scene.Meshes)
             {
-                // THIS IS TESTING DATA - Haven't figured out how to make it work
-
                 foreach (Assimp.Bone bone in mesh.Bones)
                 {
-                    // Get hierarchy
-                    Assimp.Node iNode = scene.RootNode.FindNode(bone.Name);
-                    List<Assimp.Node> nodeHierarchy = new List<Assimp.Node>();
-                    nodeHierarchy.Add(iNode);
-                    while (iNode.Parent != null)
-                    {
-                        iNode = iNode.Parent;
-                        nodeHierarchy.Add(iNode);
-                    }
-
-                    Assimp.Matrix4x4? boneOffsetMatrix = null;
-                    // Calc matrix
-                    for (int i = nodeHierarchy.Count - 1; i >= 0; i--)
-                    {
-                        if (boneOffsetMatrix == null)
-                        {
-                            boneOffsetMatrix = nodeHierarchy[i].Transform;
-                        }
-                        else
-                        {
-                            boneOffsetMatrix *= nodeHierarchy[i].Transform;
-                        }
-                    }
-
-                    Matrix4x4 tempMat = AssimpGeneric.ToNumerics((Assimp.Matrix4x4)boneOffsetMatrix);
-                    Matrix4x4.Invert(tempMat, out tempMat);
-
-                    bone.OffsetMatrix = AssimpGeneric.ToAssimp(tempMat);
-
-                    //bone.OffsetMatrix = Assimp.Matrix4x4.Identity;
-
-                    //Assimp.Matrix4x4.inverse(boneOffsetMatrix, bone.OffsetMatrix);
+                    bone.OffsetMatrix = AssimpGeneric.ToAssimp(Microsoft.Xna.Framework.Matrix.Invert(matricesToReverse[matricesToReverseNames.IndexOf(bone.Name)]));
                 }
             }
 
             return scene;
+        }
+
+        public static void ReverseMatrices(ref List<Microsoft.Xna.Framework.Matrix> matrices, MdlxParser mParser)
+        {
+            bool[] treatedMatrices = new bool[mParser.Bones.Count];
+
+            int dirtyCount;
+            do
+            {
+                dirtyCount = mParser.Bones.Count;
+                for (int b = 0; b < mParser.Bones.Count; b++)
+                {
+                    if (treatedMatrices[b] == false)
+                    {
+                        int remainingToTreat = 0;
+                        for (int j = 0; j < mParser.Bones.Count; j++)
+                        {
+                            if (mParser.Bones[j].Parent == b && treatedMatrices[j] == false)
+                                remainingToTreat++;
+                        }
+                        if (remainingToTreat == 0) /* Children's children are all calculated. */
+                        {
+                            if (mParser.Bones[b].Parent > -1)
+                            {
+                                matrices[b] *= Microsoft.Xna.Framework.Matrix.Invert(matrices[mParser.Bones[b].Parent]);
+                            }
+                            treatedMatrices[b] = true;
+                            dirtyCount--;
+                        }
+                    }
+                    else
+                        dirtyCount--;
+                }
+            }
+            while (dirtyCount > 0);
+        }
+
+        public static void ComputeMatrices(ref List<Microsoft.Xna.Framework.Matrix> matrices, MdlxParser mParser)
+        {
+            for (int b = 0; b < mParser.Bones.Count; b++)
+            {
+                if (mParser.Bones[b].Parent > -1)
+                {
+                    matrices[b] *= matrices[mParser.Bones[b].Parent];
+                }
+            }
         }
 
         public static Assimp.Scene getAssimpScene(ModelSkeletal model)

--- a/OpenKh.AssimpUtils/OpenKh.AssimpUtils.csproj
+++ b/OpenKh.AssimpUtils/OpenKh.AssimpUtils.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\OpenKh.Engine.MonoGame\OpenKh.Engine.MonoGame.csproj" />
     <ProjectReference Include="..\OpenKh.Engine\OpenKh.Engine.csproj" />
     <ProjectReference Include="..\OpenKh.Kh1\OpenKh.Kh1.csproj" />
   </ItemGroup>

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/Main_Window.xaml.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/Main_Window.xaml.cs
@@ -153,15 +153,16 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
                     dirPath += "\\";
 
                     AssimpGeneric.ExportScene(scene, fileFormat, sfd.FileName);
-                    exportTextures(dirPath);
+                    exportTextures(mainWiewModel.TextureFile.Images, dirPath);
                 }
             }
         }
-        public void exportTextures(string filePath)
+        /* Changed to static to be used in "MsetLoader's FBX exporter without duplicating the method. " */
+        public static void exportTextures(List<ModelTexture.Texture> textures, string filePath)
         {
-            for(int i = 0; i < mainWiewModel.TextureFile.Images.Count; i++)
+            for(int i = 0; i < textures.Count; i++)
             {
-                ModelTexture.Texture texture = mainWiewModel.TextureFile.Images[i];
+                ModelTexture.Texture texture = textures[i];
                 BitmapSource bitmapImage = texture.GetBimapSource();
 
                 string fullPath = filePath + "Texture" + i;

--- a/OpenKh.Tools.Kh2MsetMotionEditor/OpenKh.Tools.Kh2MsetMotionEditor.csproj
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/OpenKh.Tools.Kh2MsetMotionEditor.csproj
@@ -34,6 +34,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\OpenKh.AssimpUtils\OpenKh.AssimpUtils.csproj" />
         <ProjectReference Include="..\OpenKh.Engine.MonoGame\OpenKh.Engine.MonoGame.csproj" />
         <ProjectReference Include="..\OpenKh.Engine\OpenKh.Engine.csproj" />
         <ProjectReference Include="..\OpenKh.Kh2\OpenKh.Kh2.csproj" />
@@ -41,6 +42,7 @@
         <ProjectReference Include="..\OpenKh.Tools.Common.WPF\OpenKh.Tools.Common.Wpf.csproj" />
         <ProjectReference Include="..\OpenKh.Tools.Common\OpenKh.Tools.Common.csproj" />
         <ProjectReference Include="..\OpenKh.Kh2AnimEmu\OpenKh.Kh2AnimEmu.csproj" />
+        <ProjectReference Include="..\OpenKh.Tools.Kh2MdlxEditor\OpenKh.Tools.Kh2MdlxEditor.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Usecases/InsideTools/MdlxMsetLoaderToolUsecase.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Usecases/InsideTools/MdlxMsetLoaderToolUsecase.cs
@@ -7,7 +7,11 @@ using System.IO;
 using System.Linq;
 using System.Numerics;
 using System.Windows;
+using OpenKh.AssimpUtils;
 using static OpenKh.Tools.Common.CustomImGui.ImGuiEx;
+using SharpDX.DXGI;
+using Assimp;
+using System.Collections.Generic;
 
 namespace OpenKh.Tools.Kh2MsetMotionEditor.Usecases.InsideTools
 {
@@ -230,6 +234,129 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.Usecases.InsideTools
                         }
                         ImGui.SameLine();
                         ImGui.Text("motion");
+                        ImGui.SameLine();;
+                        if (ImGui.Button($"Export selected motion as FBX##selectMotion"))
+                        {
+                            if (_loadedModel.SelectedMotionIndex<0)
+                            {
+                                System.Windows.Forms.MessageBox.Show("No motion selected.", "No motion selected.", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Exclamation);
+                            }
+                            else
+                            {
+                                if (_loadedModel.MdlxRenderableList.Count>0&&
+                                _loadedModel.MdlxRenderableList[0].Model is Mdlx)
+                                {
+                                    OpenKh.Engine.Parsers.MdlxParser mParser = new OpenKh.Engine.Parsers.MdlxParser(_loadedModel.MdlxRenderableList[0].Model);
+                                    Assimp.Scene scene = Kh2MdlxAssimp.getAssimpScene(mParser);
+
+
+
+
+
+                                    System.Windows.Forms.SaveFileDialog sfd;
+                                    sfd = new System.Windows.Forms.SaveFileDialog();
+                                    sfd.Title = "Export model";
+                                    sfd.FileName = _loadedModel.MdlxFile + "-"+ selectedMotionName.Replace(" ","_")+"." + AssimpGeneric.GetFormatFileExtension(AssimpGeneric.FileFormat.fbx);
+                                    sfd.ShowDialog();
+                                    if (sfd.FileName != "")
+                                    {
+                                        string dirPath = Path.GetDirectoryName(sfd.FileName);
+
+                                        if (!Directory.Exists(dirPath))
+                                            return;
+                                        dirPath += "\\";
+
+
+                                        var motionData = _loadedModel.MotionData;
+
+                                        if (motionData != null)
+                                        {
+                                            Animation animation = new Animation();
+                                            animation.Name = selectedMotionName;
+                                            animation.TicksPerSecond = 24f;
+                                            animation.DurationInTicks = (double)(1 / animation.TicksPerSecond) * motionData.InterpolatedMotionHeader.FrameCount;
+
+                                            for (int b=0;b< mParser.Bones.Count;b++)
+                                            {
+                                                NodeAnimationChannel nodeAnimationChannel = new NodeAnimationChannel();
+                                                nodeAnimationChannel.NodeName = "Bone" + b;
+                                                animation.NodeAnimationChannels.Add(nodeAnimationChannel);
+                                            }
+                                            for (int f = 0; f < motionData.InterpolatedMotionHeader.FrameCount; f++)
+                                            {
+                                                float timeKey = (float)((1/ animation.TicksPerSecond) * f);
+
+                                                var fkIk = _loadedModel.PoseProvider?.Invoke((float)f);
+
+                                                List<Microsoft.Xna.Framework.Matrix> matrices = new List<Microsoft.Xna.Framework.Matrix>(0);
+                                                List<bool> dirtyMatrices = new List<bool>(0);
+
+                                                if (fkIk != null && _loadedModel.MotionData?.IKHelpers is System.Collections.Generic.List<Motion.IKHelper> ikHelperList)
+                                                {
+                                                    var numFk = fkIk.Fk.Length;
+                                                    var numIk = fkIk.Ik.Length;
+                                                    var length = fkIk.Fk.Length;
+
+                                                    for (int mIndex=0; mIndex < length; mIndex++)
+                                                    {
+                                                        matrices.Add(fkIk.Fk[mIndex].ToXnaMatrix());
+                                                        dirtyMatrices.Add(true);
+                                                    }
+                                                }
+
+                                                int dirtyCount;
+                                                do
+                                                {
+                                                    dirtyCount = mParser.Bones.Count;
+                                                    for (int b = 0; b < mParser.Bones.Count; b++)
+                                                    {
+                                                        if (dirtyMatrices[b])
+                                                        {
+                                                            int childrenDirtyCount = 0;
+                                                            for (int j = 0; j < mParser.Bones.Count; j++)
+                                                            {
+                                                                if (mParser.Bones[j].Parent == b && dirtyMatrices[j])
+                                                                    childrenDirtyCount++;
+                                                            }
+                                                            if (childrenDirtyCount == 0) /* Children's children are all calculated already. */
+                                                            {
+                                                                if (mParser.Bones[b].Parent >-1)
+                                                                {
+                                                                    matrices[b] *= Microsoft.Xna.Framework.Matrix.Invert(matrices[mParser.Bones[b].Parent]);
+                                                                }
+                                                                dirtyMatrices[b] = false;
+                                                                dirtyCount--;
+                                                            }
+                                                        }
+                                                        else
+                                                            dirtyCount--;
+                                                    }
+                                                }
+                                                while (dirtyCount > 0);
+
+                                                for (int b = 0; b < mParser.Bones.Count; b++)
+                                                {
+                                                    NodeAnimationChannel channel = animation.NodeAnimationChannels[b];
+                                                    Microsoft.Xna.Framework.Vector3 scale;
+                                                    Microsoft.Xna.Framework.Quaternion rotate;
+                                                    Microsoft.Xna.Framework.Vector3 translate;
+                                                    matrices[b].Decompose(out scale, out rotate, out translate);
+                                                    channel.ScalingKeys.Add(new VectorKey(timeKey, new Vector3D(scale.X, scale.Y, scale.Z)));
+                                                    channel.RotationKeys.Add(new QuaternionKey(timeKey, new Assimp.Quaternion(rotate.W, rotate.X, rotate.Y, rotate.Z)));
+                                                    channel.PositionKeys.Add(new VectorKey(timeKey, new Vector3D(translate.X, translate.Y, translate.Z)));
+                                                }
+                                            }
+
+                                            scene.Animations.Add(animation);
+                                        }
+
+                                        AssimpGeneric.ExportScene(scene, AssimpGeneric.FileFormat.fbx, sfd.FileName);
+                                        OpenKh.Tools.Kh2MdlxEditor.Views.Main_Window.exportTextures(_loadedModel.MdlxRenderableList[0].Textures, dirPath);
+                                        System.Windows.Forms.MessageBox.Show("Export complete.", "Complete", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Information);
+                                    }
+                                }
+                            }
+                        }
 
                         if (ImGui.BeginPopupModal(selectMotionCaption, ref selectMotionVisible,
                             ImGuiWindowFlags.Popup | ImGuiWindowFlags.Modal))


### PR DESCRIPTION
- Added a feature in the Monogame GUI of MsetMotionEditor to export the selected animation binary into an animated FBX. 
- I will add a feature to export all at once later. 
- I made a method static in Main_Window.xaml.cs in order to use it without copy-pasting it in the MsetMotionEditor code. This method remains unchanged.