### PR TITLE
Remove exta yaml lines from auto-generated mod.yml when installing a PCPatch

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/ModsService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ModsService.cs
@@ -260,7 +260,7 @@ namespace OpenKh.Tools.ModsManager.Services
 
                 var _yamlPath = Path.Combine(modPath + "/mod.yml");
 
-                File.WriteAllText(_yamlPath, _yamlGen.ToString());
+                File.WriteAllText(_yamlPath, _yamlGen.ToString().Replace("\r\nspecifications: 0\r\ndependencies: ", "").Replace("\r\n    method: \r\n    platform: \r\n    package: \r\n    multi: \r\n    source: \r\n    required: false\r\n    type: \r\n    motionsetType: Default\r\n    language: \r\n    isSwizzled: false\r\n    index: 0\r\n  required: false\r\n  type: \r\n  motionsetType: Default\r\n  language: \r\n  isSwizzled: false\r\n  index: 0", "").Replace("\r\n  multi: ", ""));
             }
         }
 


### PR DESCRIPTION
Doesn't look great
but idk how to remove entries from the metadata so it only uses ones added.
From the beginning of the mod.yml to the end of the first asset/entry this
```
title: DDD Sora (KH2PCPATCH)
originalAuthor: Unknown
description: This is an automatically generated metadata for this KH2PCPATCH Modification.
game: kh2
specifications: 0
dependencies: 
assets:
- name: raw\obj\ACTOR_SORA.mdlx
  method: copy
  platform: pc
  package: kh2_fifth
  multi: 
  source:
  - name: raw\obj\ACTOR_SORA.mdlx
    method: 
    platform: 
    package: 
    multi: 
    source: 
    required: false
    type: 
    motionsetType: Default
    language: 
    isSwizzled: false
    index: 0
  required: false
  type: 
  motionsetType: Default
  language: 
  isSwizzled: false
  index: 0
  ```
  becomes this
  ```
title: DDD Sora (KH2PCPATCH)
originalAuthor: Unknown
description: This is an automatically generated metadata for this KH2PCPATCH Modification.
game: kh2
assets:
- name: raw\obj\ACTOR_SORA.mdlx
  method: copy
  platform: pc
  package: kh2_fifth
  source:
  - name: raw\obj\ACTOR_SORA.mdlx
  ```