### PR TITLE
Add detail error logging for installing or updating mods

### DIFF
--- a/OpenKh.Common/Log.cs
+++ b/OpenKh.Common/Log.cs
@@ -103,5 +103,10 @@ namespace OpenKh.Common
 
             return name;
         }
+
+        public static string FormatSecondaryLinesWithIndent(string lines, string indent)
+        {
+            return lines.Replace("\n", "\n" + indent);
+        }
     }
 }

--- a/OpenKh.Tools.ModsManager/App.xaml.cs
+++ b/OpenKh.Tools.ModsManager/App.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using OpenKh.Common;
+using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Data;
@@ -13,5 +14,10 @@ namespace OpenKh.Tools.ModsManager
     /// </summary>
     public partial class App : Application
     {
+        protected override void OnExit(ExitEventArgs e)
+        {
+            Log.Close();
+            base.OnExit(e);
+        }
     }
 }

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -369,6 +369,10 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     }
                     catch (Exception ex)
                     {
+                        Log.Warn("Unable to install the mod `{0}`: {1}\n"
+                            , view.RepositoryName
+                            , Log.FormatSecondaryLinesWithIndent(ex.ToString(), "  ")
+                        );
                         Handle(ex);
                     }
                     finally

--- a/OpenKh.Tools.ModsManager/ViewModels/ModViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/ModViewModel.cs
@@ -1,3 +1,4 @@
+using OpenKh.Common;
 using OpenKh.Tools.ModsManager.Models;
 using OpenKh.Tools.ModsManager.Services;
 using OpenKh.Tools.ModsManager.Views;
@@ -86,6 +87,10 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 }
                 catch (Exception ex)
                 {
+                    Log.Warn("Unable to update the mod `{0}`: {1}\n"
+                        , Source
+                        , Log.FormatSecondaryLinesWithIndent(ex.ToString(), "  ")
+                    );
                     Handle(ex);
                 }
                 finally


### PR DESCRIPTION
The detail error message of install/update mods will be logged into file `OpenKh.Tools.ModsManager.log`.
It is flushed at app exit.

![2024-04-16_00h11_26](https://github.com/OpenKH/OpenKh/assets/5955540/48b111aa-2add-45eb-b808-fc3ad077b991)
