### PR TITLE
Fix YamlGenerator in ModsManager

### DIFF
--- a/OpenKh.Tools.ModsManager/Models/ViewHelper/ActionCommand.cs
+++ b/OpenKh.Tools.ModsManager/Models/ViewHelper/ActionCommand.cs
@@ -7,7 +7,7 @@ using System.Windows.Input;
 
 namespace OpenKh.Tools.ModsManager.Models.ViewHelper
 {
-    public record ActionCommand(string Display, ICommand Command)
+    public record ActionCommand(string Display, string ToolTip, ICommand Command)
     {
     }
 }

--- a/OpenKh.Tools.ModsManager/Views/NotepadVM.cs
+++ b/OpenKh.Tools.ModsManager/Views/NotepadVM.cs
@@ -1,28 +1,38 @@
 using OpenKh.Tools.ModsManager.Services;
-using OpenKh.Tools.ModsManager.UserControls;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Input;
 using Xe.Tools;
-using Xe.Tools.Wpf.Commands;
-using Xe.Tools.Wpf.Dialogs;
 
 namespace OpenKh.Tools.ModsManager.Views
 {
     public class NotepadVM : BaseNotifyPropertyChanged
     {
         public ColorThemeService ColorTheme => ColorThemeService.Instance;
-        public ICommand CopyAllCommand { get; set; }
-        public ICommand SaveAsCommand { get; set; }
 
-        private readonly GetActiveWindowService _getActiveWindowService = new GetActiveWindowService();
+        #region CopyAllCommand
+        private ICommand _copyAllCommand = null;
+        public ICommand CopyAllCommand
+        {
+            get => _copyAllCommand;
+            set
+            {
+                _copyAllCommand = value;
+                OnPropertyChanged(nameof(CopyAllCommand));
+            }
+        }
+        #endregion
 
-        private string SavedTo { get; set; }
+        #region SaveAsCommand
+        private ICommand _saveAsCommand = null;
+        public ICommand SaveAsCommand
+        {
+            get => _saveAsCommand;
+            set
+            {
+                _saveAsCommand = value;
+                OnPropertyChanged(nameof(SaveAsCommand));
+            }
+        }
+        #endregion
 
         #region Text
         private string _text = "";
@@ -36,47 +46,5 @@ namespace OpenKh.Tools.ModsManager.Views
             }
         }
         #endregion
-
-        public NotepadVM()
-        {
-            CopyAllCommand = new RelayCommand(
-                _ =>
-                {
-                    try
-                    {
-                        Clipboard.SetText(Text);
-                    }
-                    catch (Exception ex)
-                    {
-                        MessageBox.Show("Failed to copy!\n\n" + ex);
-                    }
-                }
-            );
-
-            SaveAsCommand = new RelayCommand(
-                _ =>
-                {
-                    FileDialog.OnSave(
-                        path =>
-                        {
-                            SavedTo = path;
-
-                            try
-                            {
-                                File.WriteAllText(path, Text);
-                            }
-                            catch (Exception ex)
-                            {
-                                MessageBox.Show("Failed to save to file!\n\n" + ex);
-                            }
-                        },
-                        new List<FileDialogFilter>()
-                            .AddAllFiles(),
-                        SavedTo,
-                        _getActiveWindowService.GetActiveWindow()
-                    );
-                }
-            );
-        }
     }
 }

--- a/OpenKh.Tools.ModsManager/Views/NotepadWindow.xaml.cs
+++ b/OpenKh.Tools.ModsManager/Views/NotepadWindow.xaml.cs
@@ -1,5 +1,7 @@
+using OpenKh.Tools.ModsManager.Services;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -11,6 +13,8 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
+using Xe.Tools.Wpf.Commands;
+using Xe.Tools.Wpf.Dialogs;
 
 namespace OpenKh.Tools.ModsManager.Views
 {
@@ -19,10 +23,53 @@ namespace OpenKh.Tools.ModsManager.Views
     /// </summary>
     public partial class NotepadWindow : Window
     {
+        private readonly GetActiveWindowService _getActiveWindowService = new GetActiveWindowService();
+
         public NotepadWindow()
         {
             InitializeComponent();
             DataContext = VM = new NotepadVM();
+
+            VM.CopyAllCommand = new RelayCommand(
+                _ =>
+                {
+                    try
+                    {
+                        Clipboard.SetText(VM.Text);
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show("Failed to copy!\n\n" + ex);
+                    }
+                }
+            );
+
+            var saveTo = "";
+
+            VM.SaveAsCommand = new RelayCommand(
+                _ =>
+                {
+                    FileDialog.OnSave(
+                        path =>
+                        {
+                            saveTo = path;
+
+                            try
+                            {
+                                File.WriteAllText(path, VM.Text);
+                            }
+                            catch (Exception ex)
+                            {
+                                MessageBox.Show("Failed to save to file!\n\n" + ex);
+                            }
+                        },
+                        new List<FileDialogFilter>()
+                            .AddAllFiles(),
+                        saveTo,
+                        _getActiveWindowService.GetActiveWindow()
+                    );
+                }
+            );
         }
 
         public NotepadVM VM { get; }

--- a/OpenKh.Tools.ModsManager/Views/SelectModTargetFilesVM.cs
+++ b/OpenKh.Tools.ModsManager/Views/SelectModTargetFilesVM.cs
@@ -15,7 +15,19 @@ namespace OpenKh.Tools.ModsManager.Views
     public class SelectModTargetFilesVM : BaseNotifyPropertyChanged
     {
         public ColorThemeService ColorTheme => ColorThemeService.Instance;
-        public ICommand SearchCommand { get; set; }
+
+        #region SearchCommand
+        private ICommand _searchCommand = null;
+        public ICommand SearchCommand
+        {
+            get => _searchCommand;
+            set
+            {
+                _searchCommand = value;
+                OnPropertyChanged(nameof(SearchCommand));
+            }
+        }
+        #endregion
 
         #region SearchKeywords
         private string _searchKeywords = "";
@@ -56,12 +68,31 @@ namespace OpenKh.Tools.ModsManager.Views
         }
         #endregion
 
-        public IEnumerable<ActionCommand> Actions { get; set; }
-
-        public Action<IEnumerable<SearchHit>> OnSearchHitsSelected { get; set; } = _ => { };
-
-        public SelectModTargetFilesVM()
+        #region Actions
+        private IEnumerable<ActionCommand> _actions = Array.Empty<ActionCommand>();
+        public IEnumerable<ActionCommand> Actions
         {
+            get => _actions;
+            set
+            {
+                _actions = value;
+                OnPropertyChanged(nameof(Actions));
+            }
         }
+        #endregion
+
+        #region SearchHitSelectedList
+        private IEnumerable<SearchHit> _searchHitSelectedList = Array.Empty<SearchHit>();
+        public IEnumerable<SearchHit> SearchHitSelectedList
+        {
+            get => _searchHitSelectedList;
+            set
+            {
+                _searchHitSelectedList = value;
+                OnPropertyChanged(nameof(SearchHitSelectedList));
+            }
+        }
+        #endregion
+
     }
 }

--- a/OpenKh.Tools.ModsManager/Views/SelectModTargetFilesWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SelectModTargetFilesWindow.xaml
@@ -10,7 +10,7 @@
         WindowStartupLocation="CenterOwner"
         d:DataContext="{d:DesignInstance Type=local:SelectModTargetFilesVM}"
         mc:Ignorable="d"
-        Title="SelectModTargetFilesWindow" Height="450" Width="800">
+        Title="SelectModTargetFilesWindow" Height="558" Width="800">
     <DockPanel LastChildFill="True">
         <DockPanel.Resources>
             <Style TargetType="TextBlock">
@@ -30,7 +30,7 @@
             <Button Margin="3" DockPanel.Dock="Right" Content="_Search" Padding="7" Command="{Binding SearchCommand}" IsDefault="True" />
             <TextBox Margin="3" VerticalAlignment="Center" Padding="3" Text="{Binding SearchKeywords,UpdateSourceTrigger=PropertyChanged}" />
         </DockPanel>
-        <TextBlock Text="Search result:" Margin="3" DockPanel.Dock="Top" />
+        <TextBlock Text="Search result (one item represents one file)" Margin="3" DockPanel.Dock="Top" />
         <StackPanel DockPanel.Dock="Right" HorizontalAlignment="Right" VerticalAlignment="Stretch">
             <TextBlock Text="Actions:" Margin="3" />
             <ItemsControl ItemsSource="{Binding Actions}">
@@ -41,6 +41,19 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
         </StackPanel>
+        <GroupBox Header="Help" DockPanel.Dock="Bottom"
+                  Foreground="{Binding ColorTheme.TextColor}">
+            <ItemsControl ItemsSource="{Binding Actions}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock TextWrapping="Wrap">
+                            <Underline><Run Text="{Binding Display}" /></Underline><LineBreak />
+                            <TextBlock Margin="7,0,0,0" Text="{Binding ToolTip}" TextWrapping="Wrap"></TextBlock>
+                        </TextBlock>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </GroupBox>
 
         <ListBox Margin="3" ItemsSource="{Binding SearchHits}" SelectionChanged="ListBox_SelectionChanged"
                  SelectionMode="Extended">

--- a/OpenKh.Tools.ModsManager/Views/SelectModTargetFilesWindow.xaml.cs
+++ b/OpenKh.Tools.ModsManager/Views/SelectModTargetFilesWindow.xaml.cs
@@ -30,10 +30,9 @@ namespace OpenKh.Tools.ModsManager.Views
 
         private void ListBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            VM.OnSearchHitsSelected(
-                ((ListBox)sender).SelectedItems
-                    .OfType<SearchHit>()
-            );
+            VM.SearchHitSelectedList = ((ListBox)sender).SelectedItems
+                .OfType<SearchHit>()
+                .ToArray();
         }
     }
 }

--- a/OpenKh.Tools.ModsManager/Views/YamlGeneratorVM.cs
+++ b/OpenKh.Tools.ModsManager/Views/YamlGeneratorVM.cs
@@ -32,12 +32,45 @@ namespace OpenKh.Tools.ModsManager.Views
     public class YamlGeneratorVM : BaseNotifyPropertyChanged
     {
         public ColorThemeService ColorTheme => ColorThemeService.Instance;
-        public ICommand GenerateCommand { get; set; }
-        public ICommand LoadPrefCommand { get; set; }
-        public ICommand SavePrefCommand { get; set; }
 
-        private Action<GetDiffService> OnToolSelected { get; set; } = _ => { };
-        private Action<string> OnYmlChanged { get; set; } = _ => { };
+        #region GenerateCommand
+        private ICommand _generateCommand = null;
+        public ICommand GenerateCommand
+        {
+            get => _generateCommand;
+            set
+            {
+                _generateCommand = value;
+                OnPropertyChanged(nameof(GenerateCommand));
+            }
+        }
+        #endregion
+
+        #region LoadPrefCommand
+        private ICommand _loadPrefCommand = null;
+        public ICommand LoadPrefCommand
+        {
+            get => _loadPrefCommand;
+            set
+            {
+                _loadPrefCommand = value;
+                OnPropertyChanged(nameof(LoadPrefCommand));
+            }
+        }
+        #endregion
+
+        #region SavePrefCommand
+        private ICommand _savePrefCommand = null;
+        public ICommand SavePrefCommand
+        {
+            get => _savePrefCommand;
+            set
+            {
+                _savePrefCommand = value;
+                OnPropertyChanged(nameof(SavePrefCommand));
+            }
+        }
+        #endregion
 
         #region SelectedPref
         private ConfigurationService.YamlGenPref _selectedPref = null;
@@ -87,7 +120,6 @@ namespace OpenKh.Tools.ModsManager.Views
             {
                 _modYmlFilePath = value;
                 OnPropertyChanged(nameof(ModYmlFilePath));
-                OnYmlChanged(_modYmlFilePath);
             }
         }
         #endregion 
@@ -128,7 +160,6 @@ namespace OpenKh.Tools.ModsManager.Views
             {
                 _selectedTool = value;
                 OnPropertyChanged(nameof(SelectedTool));
-                OnToolSelected(_selectedTool);
             }
         }
         #endregion
@@ -142,12 +173,22 @@ namespace OpenKh.Tools.ModsManager.Views
             {
                 _gameDataPath = value;
                 OnPropertyChanged(nameof(GameDataPath));
-                OnGameDataPathChanged(_gameDataPath);
             }
         }
         #endregion 
 
-        public ICommand AppenderCommand { get; set; }
+        #region AppenderCommand
+        private ICommand _appenderCommand = null;
+        public ICommand AppenderCommand
+        {
+            get => _appenderCommand;
+            set
+            {
+                _appenderCommand = value;
+                OnPropertyChanged(nameof(AppenderCommand));
+            }
+        }
+        #endregion
 
         #region AppenderTask
         private Task _appenderTask;
@@ -161,736 +202,5 @@ namespace OpenKh.Tools.ModsManager.Views
             }
         }
         #endregion
-
-        private Action<string> OnGameDataPathChanged { get; set; } = _ => { };
-
-        private readonly YamlGeneratorService _yamlGeneratorService = new YamlGeneratorService();
-        private readonly GetDiffToolsService _getDiffToolsService = new GetDiffToolsService();
-        private readonly GetActiveWindowService _getActiveWindowService = new GetActiveWindowService();
-        private readonly QueryApplyPatchService _queryApplyPatchService = new QueryApplyPatchService();
-        private readonly KeywordsMatcherService _keywordsMatcherService = new KeywordsMatcherService();
-        private readonly ISerializer _listSer = new SerializerBuilder()
-            .Build();
-        private readonly ProvideExtractorsService _provideExtractorsService = new ProvideExtractorsService();
-
-        private record MixedSource(CopySourceFile CopySourceFile, AssetFile AssetFile);
-
-        public YamlGeneratorVM()
-        {
-            var extractors = _provideExtractorsService
-                .GetExtractors()
-                .ToImmutableArray();
-
-            GetDiffService diffTool = null;
-
-            async Task ModifyMetadataAsync(
-                Func<Metadata, Task> action
-            )
-            {
-                var rawInput = await Task.Run(() => File.Exists(ModYmlFilePath))
-                    ? await File.ReadAllBytesAsync(ModYmlFilePath)
-                    : null;
-
-                var createNewModYml = rawInput == null;
-
-                var mod = (rawInput != null)
-                    ? Metadata.Read(new MemoryStream(rawInput, false))
-                    : new Metadata();
-
-                mod.Title ??= Path.GetFileName(Path.GetDirectoryName(ModYmlFilePath));
-                mod.OriginalAuthor ??= "You";
-                mod.Description ??= $"Generated on {DateTime.UtcNow:R}";
-                mod.Assets ??= new List<AssetFile>();
-
-                await action(mod);
-
-                mod.Assets = MergeAssetSource(mod.Assets.ToArray());
-
-                {
-                    var temp = new MemoryStream();
-                    mod.Write(temp);
-                    var rawOutput = temp.ToArray();
-
-                    var rawOutput2 = await diffTool.DiffAsync(rawInput, rawOutput);
-                    if (rawOutput2 != null)
-                    {
-                        if (createNewModYml || await _queryApplyPatchService.QueryAsync())
-                        {
-                            await File.WriteAllBytesAsync(ModYmlFilePath, rawOutput2);
-                            return;
-                        }
-                        else
-                        {
-                            return;
-                        }
-                    }
-                    else
-                    {
-                        return;
-                    }
-                }
-            }
-
-            void DisplayCopy(
-                IEnumerable<PrimarySource> primarySourceList,
-                Func<PrimarySource, IEnumerable<CopySourceFile>> getCopySourceList,
-                Func<IEnumerable<CopySourceFile>, Task> proceedAsync
-            )
-            {
-                var copyWin = new CopySourceFilesWindow();
-                copyWin.Owner = _getActiveWindowService.GetActiveWindow();
-                copyWin.Closed += (_, __) => copyWin.Owner?.Focus();
-                var copyVm = copyWin.VM;
-                SimpleAsyncActionCommand<object> proceedCopyCommand;
-                copyVm.ProceedCommand = proceedCopyCommand = new SimpleAsyncActionCommand<object>(
-                    async _ =>
-                    {
-                        await proceedAsync(copyVm.CopySourceList);
-
-                        copyWin.Close();
-                    },
-                    task => copyVm.ProceedTask = task
-                )
-                {
-                    IsEnabled = false,
-                };
-                copyVm.PropertyChanged += (_, e) =>
-                {
-                    if (e.PropertyName == null || e.PropertyName == nameof(copyVm.SelectedPrimarySource))
-                    {
-                        var one = copyVm.SelectedPrimarySource;
-
-                        proceedCopyCommand.IsEnabled = one != null;
-
-                        copyVm.CopySourceList = getCopySourceList(one)
-                            .ToArray();
-                    }
-                };
-                copyVm.CheckAllCommand = new RelayCommand(
-                    _ =>
-                    {
-                        copyVm.CopySourceList.ToList().ForEach(it => it.DoAction = true);
-                    }
-                );
-                copyVm.UncheckAllCommand = new RelayCommand(
-                    _ =>
-                    {
-                        copyVm.CopySourceList.ToList().ForEach(it => it.DoAction = false);
-                    }
-                );
-                copyVm.PrimarySourceList = primarySourceList
-                    .ToArray();
-                copyWin.Show();
-            }
-
-            List<AssetFile> CreateSourceFromArgs(params AssetFile[] assetFiles) => new List<AssetFile>(assetFiles);
-
-
-            SimpleAsyncActionCommand<object> appenderCommand;
-
-            AppenderCommand = appenderCommand = new SimpleAsyncActionCommand<object>(
-                async _ =>
-                {
-                    SimpleAsyncActionCommand<object> searchCommand;
-
-                    var sourceDir = GameDataPath;
-                    var destDir = Path.GetDirectoryName(ModYmlFilePath);
-
-                    var targetWindow = new SelectModTargetFilesWindow();
-                    var targetVm = targetWindow.VM;
-                    targetVm.SearchCommand = searchCommand = new SimpleAsyncActionCommand<object>(
-                        async _ =>
-                        {
-                            var ifMatch = _keywordsMatcherService.CreateMatcher(targetVm.SearchKeywords);
-                            targetVm.SearchHits = await Task.Run(
-                                () => Directory.EnumerateFiles(sourceDir, "*", SearchOption.AllDirectories)
-                                    .Select(
-                                        file => (
-                                            Path: file,
-                                            Relative: Path.GetRelativePath(sourceDir, file)
-                                                .Replace('\\', '/')
-                                        )
-                                    )
-                                    .Where(pair => ifMatch(pair.Relative))
-                                    .Select(
-                                        pair => new SearchHit(
-                                            FullPath: pair.Path,
-                                            RelativePath: pair.Relative,
-                                            Display: pair.Relative
-                                        )
-                                    )
-                                    .ToArray()
-                            );
-                        },
-                        it => targetVm.SearchingTask = it
-                    );
-
-                    var selectionIsGood = new BehaviorSubject<bool>(false);
-
-                    var actions = new List<ActionCommand>();
-
-                    SimpleAsyncActionCommand<object> copyMultiCommand;
-                    SimpleAsyncActionCommand<object> copyEachCommand;
-                    SimpleAsyncActionCommand<object> binArcCommand;
-                    SimpleAsyncActionCommand<object> pathCommand;
-
-                    var hits = Enumerable.Empty<SearchHit>();
-
-                    actions.Add(
-                        new ActionCommand(
-                            "Copy multi",
-                            copyMultiCommand = new SimpleAsyncActionCommand<object>(
-                                async _ =>
-                                {
-                                    await Task.Yield();
-
-                                    SearchHit selectedHit = null;
-
-                                    DisplayCopy(
-                                        primarySourceList: hits
-                                            .Select(hit => new PrimarySource(hit.Display)),
-                                        getCopySourceList: one =>
-                                        {
-                                            return hits
-                                                .Where(
-                                                    hit => hit.Display == one?.Display
-                                                )
-                                                .Select(
-                                                    hit =>
-                                                    {
-                                                        selectedHit = hit;
-
-                                                        var sourcePath = Path.Combine(sourceDir, hit.RelativePath);
-                                                        var destPath = Path.Combine(destDir, hit.RelativePath);
-                                                        var exists = File.Exists(destPath);
-                                                        return new CopySourceFile(
-                                                            one.Display,
-                                                            "Copy",
-                                                            exists,
-                                                            async () =>
-                                                            {
-                                                                await Task.Run(
-                                                                    () => File.Copy(sourcePath, destPath, true)
-                                                                );
-                                                            }
-                                                        )
-                                                        {
-                                                            DoAction = !exists,
-                                                        };
-                                                    }
-                                                );
-                                        },
-                                        proceedAsync: async copySourceList =>
-                                        {
-                                            foreach (var source in copySourceList.Where(it => it.DoAction))
-                                            {
-                                                await source.AsyncAction();
-                                            }
-
-                                            await ModifyMetadataAsync(
-                                                async mod =>
-                                                {
-                                                    await Task.Yield();
-
-                                                    mod.Assets.Add(
-                                                        new AssetFile
-                                                        {
-                                                            Name = selectedHit.RelativePath,
-                                                            Multi = new List<Multi>(
-                                                                hits
-                                                                    .Where(
-                                                                        hit => !ReferenceEquals(hit, selectedHit)
-                                                                    )
-                                                                    .Select(
-                                                                        hit => new Multi
-                                                                        {
-                                                                            Name = hit.RelativePath,
-                                                                        }
-                                                                    )
-                                                                    .ToArray()
-                                                            ),
-                                                            Method = "copy",
-                                                            Source = CreateSourceFromArgs(
-                                                                new AssetFile
-                                                                {
-                                                                    Name = selectedHit.RelativePath,
-                                                                }
-                                                            ),
-                                                        }
-                                                    );
-                                                }
-                                            );
-                                        }
-                                    );
-                                }
-                            )
-                            {
-                                IsEnabled = false,
-                            }
-                        )
-                    );
-
-                    actions.Add(
-                        new ActionCommand(
-                            "Copy each",
-                            copyEachCommand = new SimpleAsyncActionCommand<object>(
-                                async _ =>
-                                {
-                                    await Task.Yield();
-
-                                    var copySourceList = hits
-                                        .Select(
-                                            hit =>
-                                            {
-                                                var sourcePath = Path.Combine(sourceDir, hit.RelativePath);
-                                                var destPath = Path.Combine(destDir, hit.RelativePath);
-                                                var exists = File.Exists(destPath);
-                                                return new CopySourceFile(
-                                                    hit.RelativePath,
-                                                    "Copy",
-                                                    exists,
-                                                    async () =>
-                                                    {
-                                                        await Task.Run(
-                                                            () => File.Copy(sourcePath, destPath, true)
-                                                        );
-                                                    }
-                                                )
-                                                {
-                                                    DoAction = !exists,
-                                                };
-                                            }
-                                        )
-                                        .ToArray();
-
-                                    DisplayCopy(
-                                        primarySourceList: new PrimarySource[] { new PrimarySource("(No selection needed)") },
-                                        getCopySourceList: one => copySourceList,
-                                        proceedAsync: async copySourceList =>
-                                        {
-                                            foreach (var source in copySourceList.Where(it => it.DoAction))
-                                            {
-                                                await source.AsyncAction();
-                                            }
-
-                                            await ModifyMetadataAsync(
-                                                async mod =>
-                                                {
-                                                    await Task.Yield();
-
-                                                    mod.Assets.AddRange(
-                                                        hits
-                                                            .Select(
-                                                                hit => new AssetFile
-                                                                {
-                                                                    Name = hit.RelativePath,
-                                                                    Method = "copy",
-                                                                    Source = CreateSourceFromArgs(
-                                                                        new AssetFile
-                                                                        {
-                                                                            Name = hit.RelativePath,
-                                                                        }
-                                                                    ),
-                                                                }
-                                                            )
-                                                    );
-                                                }
-                                            );
-                                        }
-                                    );
-                                }
-                            )
-                            {
-                                IsEnabled = false,
-                            }
-                        )
-                    );
-
-                    actions.Add(
-                        new ActionCommand(
-                            "binarc",
-                            binArcCommand = new SimpleAsyncActionCommand<object>(
-                                async _ =>
-                                {
-                                    await Task.Yield();
-
-                                    IEnumerable<MixedSource> mixedSourceList = Array.Empty<MixedSource>();
-
-                                    IEnumerable<MixedSource> UpdateMixedSourceListAndReturn(bool applyExtractors)
-                                    {
-                                        return mixedSourceList = hits
-                                            .SelectMany(
-                                                hit =>
-                                                {
-                                                    var sourcePath = Path.Combine(sourceDir, hit.RelativePath);
-
-                                                    var stream = new MemoryStream(File.ReadAllBytes(sourcePath), false);
-
-                                                    var barEntries = Bar.IsValid(stream)
-                                                        ? Bar.Read(stream).AsEnumerable()
-                                                        : Array.Empty<Bar.Entry>();
-
-                                                    return barEntries
-                                                        .Select(
-                                                            barEntry =>
-                                                            {
-                                                                var extractor = applyExtractors
-                                                                    ? extractors.FirstOrDefault(
-                                                                        one => one.IfApply(barEntry.Name, barEntry.Type, barEntry.Index)
-                                                                            && one.SourceFileTest(hit.RelativePath)
-                                                                    )
-                                                                    : null;
-
-                                                                var destRelative = Path.Combine(
-                                                                    Path.GetDirectoryName(hit.RelativePath),
-                                                                    $"{Path.GetFileNameWithoutExtension(hit.RelativePath)}_{barEntry.Name}{extractor?.FileExtension}"
-                                                                );
-                                                                var destPath = Path.Combine(
-                                                                    destDir,
-                                                                    destRelative
-                                                                );
-
-                                                                var exists = File.Exists(destPath);
-
-                                                                var copySourceFile = new CopySourceFile(
-                                                                    $"{hit.RelativePath} ({barEntry.Name} {barEntry.Type} {extractor?.FileExtension})",
-                                                                    "Extract",
-                                                                    exists,
-                                                                    async () =>
-                                                                    {
-                                                                        await Task.Run(
-                                                                            async () =>
-                                                                            {
-                                                                                Directory.CreateDirectory(Path.GetDirectoryName(destPath));
-
-                                                                                using (var destStream = File.Create(destPath))
-                                                                                {
-                                                                                    if (extractor?.ExtractAsync != null)
-                                                                                    {
-                                                                                        await destStream.WriteAsync(
-                                                                                            await extractor.ExtractAsync(barEntry)
-                                                                                        );
-                                                                                    }
-                                                                                    else
-                                                                                    {
-                                                                                        barEntry.Stream.FromBegin().CopyTo(destStream);
-                                                                                    }
-                                                                                }
-                                                                            }
-                                                                        );
-                                                                    }
-                                                                )
-                                                                {
-                                                                    DoAction = !exists,
-                                                                };
-
-                                                                var assetFile = new AssetFile
-                                                                {
-                                                                    Name = hit.RelativePath,
-                                                                    Method = "binarc",
-                                                                    Source = (extractor?
-                                                                        .SourceBuilder(
-                                                                            new SourceBuilderArg(
-                                                                                DestName: barEntry.Name,
-                                                                                DestType: barEntry.Type.ToString().ToLowerInvariant(),
-                                                                                SourceName: destRelative.Replace('\\', '/'),
-                                                                                OriginalRelativePath: hit.RelativePath
-                                                                            )
-                                                                        )?
-                                                                        .ToList()
-                                                                    )
-                                                                        ?? CreateSourceFromArgs(
-                                                                            new AssetFile
-                                                                            {
-                                                                                Name = barEntry.Name,
-                                                                                Type = barEntry.Type.ToString().ToLowerInvariant(),
-                                                                                Method = "copy",
-                                                                                Source = CreateSourceFromArgs(
-                                                                                    new AssetFile
-                                                                                    {
-                                                                                        Name = destRelative.Replace('\\', '/'),
-                                                                                    }
-                                                                                ),
-                                                                            }
-                                                                    ),
-                                                                };
-
-                                                                return new MixedSource(copySourceFile, assetFile);
-                                                            }
-                                                        );
-                                                }
-                                            )
-                                            .ToArray();
-                                    }
-
-                                    var applyExtractors = new PrimarySource("Apply built in extractors");
-                                    var applyNone = new PrimarySource("None");
-
-                                    DisplayCopy(
-                                        primarySourceList: new PrimarySource[] { applyExtractors, applyNone, },
-                                        getCopySourceList: one =>
-                                        {
-                                            return UpdateMixedSourceListAndReturn(
-                                                applyExtractors: ReferenceEquals(one, applyExtractors)
-                                            )
-                                                .Select(tuple => tuple.CopySourceFile);
-                                        },
-                                        proceedAsync: async copySourceList =>
-                                        {
-                                            foreach (var source in copySourceList.Where(it => it.DoAction))
-                                            {
-                                                try
-                                                {
-                                                    await source.AsyncAction();
-                                                }
-                                                catch (Exception ex)
-                                                {
-                                                    throw new Exception($"Error while processing of: {source.Display}", ex);
-                                                }
-                                            }
-
-                                            await ModifyMetadataAsync(
-                                                async mod =>
-                                                {
-                                                    await Task.Yield();
-
-                                                    mod.Assets.AddRange(
-                                                        mixedSourceList
-                                                            .Where(
-                                                                tuple => tuple.CopySourceFile.DoAction || tuple.CopySourceFile.DestinationFileExists
-                                                            )
-                                                            .Select(
-                                                                tuple => tuple.AssetFile
-                                                            )
-                                                    );
-                                                }
-                                            );
-                                        }
-                                    );
-                                }
-                            )
-                            {
-                                IsEnabled = false,
-                            }
-                        )
-                    );
-
-                    actions.Add(
-                        new ActionCommand(
-                            "path",
-                            pathCommand = new SimpleAsyncActionCommand<object>(
-                                async _ =>
-                                {
-                                    await Task.Yield();
-
-                                    var noteWin = new NotepadWindow();
-                                    var noteVm = noteWin.VM;
-                                    noteVm.Text = _listSer.Serialize(
-                                        new
-                                        {
-                                            multi = hits
-                                                .Select(hit => hit.RelativePath)
-                                                .ToArray(),
-                                        }
-                                    );
-                                    noteWin.Owner = _getActiveWindowService.GetActiveWindow();
-                                    noteWin.Closed += (_, __) => noteWin.Owner?.Focus();
-                                    noteWin.Show();
-                                }
-                            )
-                            {
-                                IsEnabled = false,
-                            }
-                        )
-                    );
-
-                    targetVm.Actions = actions;
-
-                    selectionIsGood
-                        .ObserveOn(Scheduler.Immediate)
-                        .Subscribe(
-                            it =>
-                            {
-                                copyMultiCommand.IsEnabled = it;
-                                copyEachCommand.IsEnabled = it;
-                                binArcCommand.IsEnabled = it;
-                                pathCommand.IsEnabled = it;
-                            }
-                        );
-
-                    targetVm.OnSearchHitsSelected = them =>
-                    {
-                        hits = them;
-                        selectionIsGood.OnNext(them.Any());
-                    };
-
-                    targetWindow.Owner = _getActiveWindowService.GetActiveWindow();
-                    targetWindow.Closed += (_, __) => targetWindow.Owner?.Focus();
-                    targetWindow.Show();
-                },
-                task => AppenderTask = task
-            );
-
-            SimpleAsyncActionCommand<object> generateCommand;
-
-            GenerateCommand = generateCommand = new SimpleAsyncActionCommand<object>(
-                async _ =>
-                    {
-                        await ModifyMetadataAsync(
-                            async mod =>
-                            {
-                                await _yamlGeneratorService.RefillAssetFilesAsync(
-                                assetFiles: mod.Assets,
-                                sourceDir: Path.GetDirectoryName(ModYmlFilePath)
-                            );
-                            }
-                        );
-                    },
-                    task => GeneratingTask = task
-                );
-
-            var toolIsGood = new BehaviorSubject<bool>(false);
-
-            OnToolSelected = it =>
-            {
-                diffTool = it;
-                toolIsGood.OnNext(it != null);
-            };
-
-            var ymlFilePathIsGood = new BehaviorSubject<bool>(false);
-
-            OnYmlChanged = it =>
-            {
-                ymlFilePathIsGood.OnNext(it.Length != 0);
-            };
-
-            Observable
-                .CombineLatest(toolIsGood, ymlFilePathIsGood)
-                .ObserveOn(Scheduler.Immediate)
-                .Subscribe(array => generateCommand.IsEnabled = array.All(it => it));
-
-            var gameDataPathIsGood = new BehaviorSubject<bool>(false);
-
-            OnGameDataPathChanged = path =>
-            {
-                try
-                {
-                    gameDataPathIsGood.OnNext((1 <= path?.Length) && Directory.Exists(path));
-                }
-                catch
-                {
-                    // ignore
-                }
-            };
-
-            Observable
-                .CombineLatest(ymlFilePathIsGood, gameDataPathIsGood)
-                .ObserveOn(Scheduler.Immediate)
-                .Subscribe(array => appenderCommand.IsEnabled = array.All(it => it));
-
-            {
-                Tools = _getDiffToolsService.GetDiffServices(".yml")
-                    .Append(
-                        new GetDiffService
-                        {
-                            Name = "Use output as is",
-                            DiffAsync = async (rawInput, rawOutput) =>
-                            {
-                                await Task.Yield();
-                                return rawOutput;
-                            }
-                        }
-                    )
-                    .ToArray();
-            }
-
-            void LoadPref(ConfigurationService.YamlGenPref pref)
-            {
-                GameDataPath = pref.GameDataPath;
-                ModYmlFilePath = pref.ModYmlFilePath;
-            }
-
-            LoadPrefCommand = new RelayCommand(
-                _ =>
-                {
-                    if (ConfigurationService.YamlGenPrefs.LastOrDefault(it => it.Label == PrefLabel) is ConfigurationService.YamlGenPref pref)
-                    {
-                        LoadPref(pref);
-                    }
-                }
-            );
-
-            SavePrefCommand = new RelayCommand(
-                _ =>
-                {
-                    if (PrefLabel.Length == 0)
-                    {
-                        PrefLabel = $"Saved at {DateTime.Now}";
-                    }
-
-                    var prefList = ConfigurationService.YamlGenPrefs.ToList();
-                    prefList.RemoveAll(
-                        pref => pref.Label == PrefLabel
-                    );
-                    prefList.Add(
-                        new ConfigurationService.YamlGenPref
-                        {
-                            Label = PrefLabel,
-                            GameDataPath = GameDataPath,
-                            ModYmlFilePath = ModYmlFilePath,
-                        }
-                    );
-                    ConfigurationService.YamlGenPrefs = prefList;
-
-                    var prev = SelectedPref;
-                    Prefs = prefList;
-                    SelectedPref = prefList.LastOrDefault(it => it.Label == prev?.Label);
-                }
-            );
-
-            Prefs = ConfigurationService.YamlGenPrefs;
-
-            if (ConfigurationService.YamlGenPrefs.LastOrDefault(it => it.Label == "default") is ConfigurationService.YamlGenPref pref)
-            {
-                SelectedPref = pref;
-                LoadPref(pref);
-            }
-        }
-
-        private List<AssetFile> MergeAssetSource(IEnumerable<AssetFile> sourceAssets)
-        {
-            var newAssets = new List<AssetFile>();
-
-            foreach (var source in sourceAssets)
-            {
-                if (false)
-                { }
-                else if (source.Method == "copy")
-                {
-                    newAssets.RemoveAll(it => it.Name == source.Name);
-                    newAssets.Add(source);
-                }
-                else if (source.Method == "binarc")
-                {
-                    var exists = newAssets.FirstOrDefault(it => it.Name == source.Name && it.Method == source.Method);
-                    if (exists == null)
-                    {
-                        exists = source;
-                        newAssets.Add(exists);
-                    }
-
-                    exists.Source ??= new List<AssetFile>();
-
-                    foreach (var one in source.Source?.ToArray() ?? Enumerable.Empty<AssetFile>())
-                    {
-                        exists.Source.RemoveAll(it => it.Name == one.Name && it.Method == one.Method);
-                        exists.Source.Add(one);
-                    }
-
-                }
-            }
-
-            return newAssets;
-        }
     }
 }

--- a/OpenKh.Tools.ModsManager/Views/YamlGeneratorWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/YamlGeneratorWindow.xaml
@@ -9,7 +9,7 @@
         WindowStartupLocation="CenterOwner"
         d:DataContext="{d:DesignInstance Type=local:YamlGeneratorVM}"
         mc:Ignorable="d"
-        Title="YamlGeneratorWindow" Height="510" Width="426">
+        Title="YamlGeneratorWindow" Height="694" Width="426">
     <DockPanel Margin="7">
         <DockPanel.Resources>
             <Style TargetType="TextBlock">
@@ -21,42 +21,59 @@
             </Style>
         </DockPanel.Resources>
         <StackPanel Orientation="Vertical">
-            <TextBlock>Preferences</TextBlock>
-            <StackPanel Orientation="Horizontal">
-                <ComboBox ItemsSource="{Binding Prefs}" VerticalAlignment="Center" IsEditable="True" Width="200"
+            <GroupBox Header="About">
+                <TextBlock TextWrapping="Wrap">YamlGenerator is an embedded tool. Provide a rapid crafting tools to satisfy mod.yml. This is a specialized utility for mod authors.</TextBlock>
+            </GroupBox>
+            <GroupBox Header="Preferences">
+                <StackPanel>
+                    <TextBlock TextWrapping="Wrap">Load and save the fields of: <Italic>mod.yml</Italic> and <Italic>GameDataPath</Italic></TextBlock>
+                    <StackPanel Orientation="Horizontal">
+                        <ComboBox ItemsSource="{Binding Prefs}" VerticalAlignment="Center" IsEditable="True" Width="200"
                           Text="{Binding PrefLabel,UpdateSourceTrigger=PropertyChanged}"
                           SelectedItem="{Binding SelectedPref}"
                           >
-                    <ComboBox.ItemTemplate>
-                        <DataTemplate>
-                            <TextBlock Text="{Binding Label}" />
-                        </DataTemplate>
-                    </ComboBox.ItemTemplate>
-                </ComboBox>
-                <TextBlock />
-                <Button Content="Load from it" Command="{Binding LoadPrefCommand}" HorizontalAlignment="Left" Padding="7" />
-                <TextBlock />
-                <Button Content="Save to it" Command="{Binding SavePrefCommand}" HorizontalAlignment="Left" Padding="7" />
-            </StackPanel>
-            <TextBlock>mod.yml</TextBlock>
-            <userControls:SaveFileSelectorControl FilePath="{Binding ModYmlFilePath,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"
-                                                  Filter="mod.yml|mod.yml|*|*" />
-            <TextBlock>You can select a diff tool to see changes:</TextBlock>
-            <ComboBox ItemsSource="{Binding Tools}" SelectedItem="{Binding SelectedTool}">
-                <ComboBox.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding Name}" />
-                    </DataTemplate>
-                </ComboBox.ItemTemplate>
-            </ComboBox>
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Label}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                        <TextBlock />
+                        <Button Content="Load from it" Command="{Binding LoadPrefCommand}" HorizontalAlignment="Left" Padding="7" />
+                        <TextBlock />
+                        <Button Content="Save to it" Command="{Binding SavePrefCommand}" HorizontalAlignment="Left" Padding="7" />
+                    </StackPanel>
+                </StackPanel>
+            </GroupBox>
+            <GroupBox Header="mod.yml">
+                <StackPanel>
+                    <TextBlock >Enter the file path to <Italic>mod.yml</Italic></TextBlock>
+                    <userControls:SaveFileSelectorControl FilePath="{Binding ModYmlFilePath,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"
+                                                      Filter="mod.yml|mod.yml|*|*" />
+                </StackPanel>
+            </GroupBox>
+            <GroupBox Header="Diff tool selection">
+                <StackPanel>
+                    <TextBlock TextWrapping="Wrap">You can select a diff tool to see changes for <Italic>mod.yml</Italic></TextBlock>
+                    <ComboBox ItemsSource="{Binding Tools}" SelectedItem="{Binding SelectedTool}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Name}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                </StackPanel>
+            </GroupBox>
             <GroupBox Header="Generator" Padding="7">
                 <StackPanel>
+                    <TextBlock TextWrapping="Wrap">This generator will construct an initial <Italic>mod.yml</Italic> for you.</TextBlock>
                     <Button Content="Generate or update mod.yml" Command="{Binding GenerateCommand}" HorizontalAlignment="Left" Padding="7" />
                     <userControls:TaskStatusObserverControl Padding="3" Task="{Binding GeneratingTask}" />
                 </StackPanel>
             </GroupBox>
             <GroupBox Header="Target files appender" Padding="7">
                 <StackPanel>
+                    <TextBlock TextWrapping="Wrap">This appender will copy the source files from <Italic>GameDataPath</Italic> into <Italic>mod.yml</Italic>. After copy process, you can edit the copied files for modding purpose.</TextBlock>
                     <TextBlock>GameDataPath</TextBlock>
                     <userControls:FolderSelectorControl FolderPath="{Binding GameDataPath,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" />
                     <TextBlock />

--- a/OpenKh.Tools.ModsManager/Views/YamlGeneratorWindow.xaml.cs
+++ b/OpenKh.Tools.ModsManager/Views/YamlGeneratorWindow.xaml.cs
@@ -1,6 +1,20 @@
+using OpenKh.Common;
+using OpenKh.Kh2;
+using OpenKh.Patcher;
+using OpenKh.Patcher.BarEntryExtractor;
+using OpenKh.Tools.Common.Wpf;
+using OpenKh.Tools.ModsManager.Models.ViewHelper;
+using OpenKh.Tools.ModsManager.Services;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel;
+using System.IO;
 using System.Linq;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
@@ -10,7 +24,8 @@ using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
+using Xe.Tools.Wpf.Commands;
+using YamlDotNet.Serialization;
 
 namespace OpenKh.Tools.ModsManager.Views
 {
@@ -19,12 +34,811 @@ namespace OpenKh.Tools.ModsManager.Views
     /// </summary>
     public partial class YamlGeneratorWindow : Window
     {
+        private readonly YamlGeneratorService _yamlGeneratorService = new YamlGeneratorService();
+        private readonly GetDiffToolsService _getDiffToolsService = new GetDiffToolsService();
+        private readonly GetActiveWindowService _getActiveWindowService = new GetActiveWindowService();
+        private readonly QueryApplyPatchService _queryApplyPatchService = new QueryApplyPatchService();
+        private readonly KeywordsMatcherService _keywordsMatcherService = new KeywordsMatcherService();
+        private readonly ISerializer _listSer = new SerializerBuilder()
+            .Build();
+        private readonly ProvideExtractorsService _provideExtractorsService = new ProvideExtractorsService();
+        private readonly CompositeDisposable _disposable = new CompositeDisposable();
+
+        private record MixedSource(CopySourceFile CopySourceFile, AssetFile AssetFile);
+
         public YamlGeneratorVM VM { get; }
 
         public YamlGeneratorWindow()
         {
             InitializeComponent();
             DataContext = VM = new YamlGeneratorVM();
+
+            var extractors = _provideExtractorsService
+                .GetExtractors()
+                .ToImmutableArray();
+
+            GetDiffService diffTool = null;
+
+            async Task ModifyMetadataAsync(
+                Func<Metadata, Task> action
+            )
+            {
+                var modYmlFilePath = VM.ModYmlFilePath;
+
+                var rawInput = await Task.Run(() => File.Exists(modYmlFilePath))
+                    ? await File.ReadAllBytesAsync(modYmlFilePath)
+                    : null;
+
+                var createNewModYml = rawInput == null;
+
+                var mod = (rawInput != null)
+                    ? Metadata.Read(new MemoryStream(rawInput, false))
+                    : new Metadata();
+
+                mod.Title ??= Path.GetFileName(Path.GetDirectoryName(modYmlFilePath));
+                mod.OriginalAuthor ??= "You";
+                mod.Description ??= $"Generated on {DateTime.UtcNow:R}";
+                mod.Assets ??= new List<AssetFile>();
+
+                await action(mod);
+
+                mod.Assets = MergeAssetSource(mod.Assets.ToArray());
+
+                {
+                    var temp = new MemoryStream();
+                    mod.Write(temp);
+                    var rawOutput = temp.ToArray();
+
+                    var rawOutput2 = await diffTool.DiffAsync(rawInput, rawOutput);
+                    if (rawOutput2 != null)
+                    {
+                        if (createNewModYml || await _queryApplyPatchService.QueryAsync())
+                        {
+                            await File.WriteAllBytesAsync(modYmlFilePath, rawOutput2);
+                            return;
+                        }
+                        else
+                        {
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        return;
+                    }
+                }
+            }
+
+            void DisplayCopy(
+                IEnumerable<PrimarySource> primarySourceList,
+                Func<PrimarySource, IEnumerable<CopySourceFile>> getCopySourceList,
+                Func<IEnumerable<CopySourceFile>, Task> proceedAsync
+            )
+            {
+                var copyWin = new CopySourceFilesWindow();
+                copyWin.Owner = _getActiveWindowService.GetActiveWindow();
+                var copyDisposables = new CompositeDisposable();
+                copyWin.Closed += (_, __) =>
+                {
+                    copyWin.Owner?.Focus();
+                    copyDisposables.Dispose();
+                };
+                var copyVm = copyWin.VM;
+                SimpleAsyncActionCommand<object> proceedCopyCommand;
+                copyVm.ProceedCommand = proceedCopyCommand = new SimpleAsyncActionCommand<object>(
+                    async _ =>
+                    {
+                        await proceedAsync(copyVm.CopySourceList);
+
+                        copyWin.Close();
+                    },
+                    task => copyVm.ProceedTask = task
+                )
+                {
+                    IsEnabled = false,
+                };
+
+                copyDisposables.Add(
+                    Observable.FromEvent<PropertyChangedEventHandler, PropertyChangedEventArgs>(
+                        h => (s, e) => h(e),
+                        h => copyVm.PropertyChanged += h,
+                        h => copyVm.PropertyChanged -= h
+                    )
+                        .Where(it => it.PropertyName == null || it.PropertyName == nameof(copyVm.SelectedPrimarySource))
+                        .Select(it => copyVm.SelectedPrimarySource)
+                        .Subscribe(
+                            one =>
+                            {
+                                proceedCopyCommand.IsEnabled = one != null;
+
+                                copyVm.CopySourceList = getCopySourceList(one)
+                                    .ToArray();
+                            }
+                        )
+                );
+
+                copyVm.CheckAllCommand = new RelayCommand(
+                    _ =>
+                    {
+                        copyVm.CopySourceList.ToList().ForEach(it => it.DoAction = true);
+                    }
+                );
+                copyVm.UncheckAllCommand = new RelayCommand(
+                    _ =>
+                    {
+                        copyVm.CopySourceList.ToList().ForEach(it => it.DoAction = false);
+                    }
+                );
+                copyVm.PrimarySourceList = primarySourceList
+                    .ToArray();
+                copyWin.Show();
+            }
+
+            List<AssetFile> CreateSourceFromArgs(params AssetFile[] assetFiles) => new List<AssetFile>(assetFiles);
+
+
+            SimpleAsyncActionCommand<object> appenderCommand;
+
+            VM.AppenderCommand = appenderCommand = new SimpleAsyncActionCommand<object>(
+                async _ =>
+                {
+                    SimpleAsyncActionCommand<object> searchCommand;
+
+                    var sourceDir = VM.GameDataPath;
+                    var destDir = Path.GetDirectoryName(VM.ModYmlFilePath);
+
+                    var targetWindow = new SelectModTargetFilesWindow();
+                    var targetVm = targetWindow.VM;
+                    targetVm.SearchCommand = searchCommand = new SimpleAsyncActionCommand<object>(
+                        async _ =>
+                        {
+                            var ifMatch = _keywordsMatcherService.CreateMatcher(targetVm.SearchKeywords);
+                            targetVm.SearchHits = await Task.Run(
+                                () => Directory.EnumerateFiles(sourceDir, "*", SearchOption.AllDirectories)
+                                    .Select(
+                                        file => (
+                                            Path: file,
+                                            Relative: Path.GetRelativePath(sourceDir, file)
+                                                .Replace('\\', '/')
+                                        )
+                                    )
+                                    .Where(pair => ifMatch(pair.Relative))
+                                    .Select(
+                                        pair => new SearchHit(
+                                            FullPath: pair.Path,
+                                            RelativePath: pair.Relative,
+                                            Display: pair.Relative
+                                        )
+                                    )
+                                    .ToArray()
+                            );
+                        },
+                        it => targetVm.SearchingTask = it
+                    );
+
+                    var selectionIsGood = new BehaviorSubject<bool>(false);
+
+                    var actions = new List<ActionCommand>();
+
+                    SimpleAsyncActionCommand<object> copyMultiCommand;
+                    SimpleAsyncActionCommand<object> copyEachCommand;
+                    SimpleAsyncActionCommand<object> binArcCommand;
+                    SimpleAsyncActionCommand<object> pathCommand;
+
+                    var hits = Enumerable.Empty<SearchHit>();
+
+                    actions.Add(
+                        new ActionCommand(
+                            "Copy multi",
+                            "Choose one more multiple files. And then select a representative file at the next window. Only the representative file will be copied. The rest files will just refer to representative file by multi field.",
+                            copyMultiCommand = new SimpleAsyncActionCommand<object>(
+                                async _ =>
+                                {
+                                    await Task.Yield();
+
+                                    SearchHit selectedHit = null;
+
+                                    DisplayCopy(
+                                        primarySourceList: hits
+                                            .Select(hit => new PrimarySource(hit.Display)),
+                                        getCopySourceList: one =>
+                                        {
+                                            return hits
+                                                .Where(
+                                                    hit => hit.Display == one?.Display
+                                                )
+                                                .Select(
+                                                    hit =>
+                                                    {
+                                                        selectedHit = hit;
+
+                                                        var sourcePath = Path.Combine(sourceDir, hit.RelativePath);
+                                                        var destPath = Path.Combine(destDir, hit.RelativePath);
+                                                        var exists = File.Exists(destPath);
+                                                        return new CopySourceFile(
+                                                            one.Display,
+                                                            "Copy",
+                                                            exists,
+                                                            async () =>
+                                                            {
+                                                                await Task.Run(
+                                                                    () => File.Copy(sourcePath, destPath, true)
+                                                                );
+                                                            }
+                                                        )
+                                                        {
+                                                            DoAction = !exists,
+                                                        };
+                                                    }
+                                                );
+                                        },
+                                        proceedAsync: async copySourceList =>
+                                        {
+                                            foreach (var source in copySourceList.Where(it => it.DoAction))
+                                            {
+                                                await source.AsyncAction();
+                                            }
+
+                                            await ModifyMetadataAsync(
+                                                async mod =>
+                                                {
+                                                    await Task.Yield();
+
+                                                    mod.Assets.Add(
+                                                        new AssetFile
+                                                        {
+                                                            Name = selectedHit.RelativePath,
+                                                            Multi = new List<Multi>(
+                                                                hits
+                                                                    .Where(
+                                                                        hit => !ReferenceEquals(hit, selectedHit)
+                                                                    )
+                                                                    .Select(
+                                                                        hit => new Multi
+                                                                        {
+                                                                            Name = hit.RelativePath,
+                                                                        }
+                                                                    )
+                                                                    .ToArray()
+                                                            ),
+                                                            Method = "copy",
+                                                            Source = CreateSourceFromArgs(
+                                                                new AssetFile
+                                                                {
+                                                                    Name = selectedHit.RelativePath,
+                                                                }
+                                                            ),
+                                                        }
+                                                    );
+                                                }
+                                            );
+                                        }
+                                    );
+                                }
+                            )
+                            {
+                                IsEnabled = false,
+                            }
+                        )
+                    );
+
+                    actions.Add(
+                        new ActionCommand(
+                            "Copy each",
+                            "Choose one more multiple files. Each file is simply copied. And then each file is mapped correspondingly.",
+                            copyEachCommand = new SimpleAsyncActionCommand<object>(
+                                async _ =>
+                                {
+                                    await Task.Yield();
+
+                                    var copySourceList = hits
+                                        .Select(
+                                            hit =>
+                                            {
+                                                var sourcePath = Path.Combine(sourceDir, hit.RelativePath);
+                                                var destPath = Path.Combine(destDir, hit.RelativePath);
+                                                var exists = File.Exists(destPath);
+                                                return new CopySourceFile(
+                                                    hit.RelativePath,
+                                                    "Copy",
+                                                    exists,
+                                                    async () =>
+                                                    {
+                                                        await Task.Run(
+                                                            () => File.Copy(sourcePath, destPath, true)
+                                                        );
+                                                    }
+                                                )
+                                                {
+                                                    DoAction = !exists,
+                                                };
+                                            }
+                                        )
+                                        .ToArray();
+
+                                    DisplayCopy(
+                                        primarySourceList: new PrimarySource[] { new PrimarySource("(No selection needed)") },
+                                        getCopySourceList: one => copySourceList,
+                                        proceedAsync: async copySourceList =>
+                                        {
+                                            foreach (var source in copySourceList.Where(it => it.DoAction))
+                                            {
+                                                await source.AsyncAction();
+                                            }
+
+                                            await ModifyMetadataAsync(
+                                                async mod =>
+                                                {
+                                                    await Task.Yield();
+
+                                                    mod.Assets.AddRange(
+                                                        hits
+                                                            .Select(
+                                                                hit => new AssetFile
+                                                                {
+                                                                    Name = hit.RelativePath,
+                                                                    Method = "copy",
+                                                                    Source = CreateSourceFromArgs(
+                                                                        new AssetFile
+                                                                        {
+                                                                            Name = hit.RelativePath,
+                                                                        }
+                                                                    ),
+                                                                }
+                                                            )
+                                                    );
+                                                }
+                                            );
+                                        }
+                                    );
+                                }
+                            )
+                            {
+                                IsEnabled = false,
+                            }
+                        )
+                    );
+
+                    actions.Add(
+                        new ActionCommand(
+                            "binarc",
+                            "Choose one more multiple files. Expand each file as bar file. And then you can select the required bar entries to be extracted.",
+                            binArcCommand = new SimpleAsyncActionCommand<object>(
+                                async _ =>
+                                {
+                                    await Task.Yield();
+
+                                    IEnumerable<MixedSource> mixedSourceList = Array.Empty<MixedSource>();
+
+                                    IEnumerable<MixedSource> UpdateMixedSourceListAndReturn(bool applyExtractors)
+                                    {
+                                        return mixedSourceList = hits
+                                            .SelectMany(
+                                                hit =>
+                                                {
+                                                    var sourcePath = Path.Combine(sourceDir, hit.RelativePath);
+
+                                                    var stream = new MemoryStream(File.ReadAllBytes(sourcePath), false);
+
+                                                    var barEntries = Bar.IsValid(stream)
+                                                        ? Bar.Read(stream).AsEnumerable()
+                                                        : Array.Empty<Bar.Entry>();
+
+                                                    return barEntries
+                                                        .Select(
+                                                            barEntry =>
+                                                            {
+                                                                var extractor = applyExtractors
+                                                                    ? extractors.FirstOrDefault(
+                                                                        one => one.IfApply(barEntry.Name, barEntry.Type, barEntry.Index)
+                                                                            && one.SourceFileTest(hit.RelativePath)
+                                                                    )
+                                                                    : null;
+
+                                                                var destRelative = Path.Combine(
+                                                                    Path.GetDirectoryName(hit.RelativePath),
+                                                                    $"{Path.GetFileNameWithoutExtension(hit.RelativePath)}_{barEntry.Name}{extractor?.FileExtension}"
+                                                                );
+                                                                var destPath = Path.Combine(
+                                                                    destDir,
+                                                                    destRelative
+                                                                );
+
+                                                                var exists = File.Exists(destPath);
+
+                                                                var copySourceFile = new CopySourceFile(
+                                                                    $"{hit.RelativePath} ({barEntry.Name} {barEntry.Type} {extractor?.FileExtension})",
+                                                                    "Extract",
+                                                                    exists,
+                                                                    async () =>
+                                                                    {
+                                                                        await Task.Run(
+                                                                            async () =>
+                                                                            {
+                                                                                Directory.CreateDirectory(Path.GetDirectoryName(destPath));
+
+                                                                                using (var destStream = File.Create(destPath))
+                                                                                {
+                                                                                    if (extractor?.ExtractAsync != null)
+                                                                                    {
+                                                                                        await destStream.WriteAsync(
+                                                                                            await extractor.ExtractAsync(barEntry)
+                                                                                        );
+                                                                                    }
+                                                                                    else
+                                                                                    {
+                                                                                        barEntry.Stream.FromBegin().CopyTo(destStream);
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        );
+                                                                    }
+                                                                )
+                                                                {
+                                                                    DoAction = !exists,
+                                                                };
+
+                                                                var assetFile = new AssetFile
+                                                                {
+                                                                    Name = hit.RelativePath,
+                                                                    Method = "binarc",
+                                                                    Source = (extractor?
+                                                                        .SourceBuilder(
+                                                                            new SourceBuilderArg(
+                                                                                DestName: barEntry.Name,
+                                                                                DestType: barEntry.Type.ToString().ToLowerInvariant(),
+                                                                                SourceName: destRelative.Replace('\\', '/'),
+                                                                                OriginalRelativePath: hit.RelativePath
+                                                                            )
+                                                                        )?
+                                                                        .ToList()
+                                                                    )
+                                                                        ?? CreateSourceFromArgs(
+                                                                            new AssetFile
+                                                                            {
+                                                                                Name = barEntry.Name,
+                                                                                Type = barEntry.Type.ToString().ToLowerInvariant(),
+                                                                                Method = "copy",
+                                                                                Source = CreateSourceFromArgs(
+                                                                                    new AssetFile
+                                                                                    {
+                                                                                        Name = destRelative.Replace('\\', '/'),
+                                                                                    }
+                                                                                ),
+                                                                            }
+                                                                    ),
+                                                                };
+
+                                                                return new MixedSource(copySourceFile, assetFile);
+                                                            }
+                                                        );
+                                                }
+                                            )
+                                            .ToArray();
+                                    }
+
+                                    var applyExtractors = new PrimarySource("Apply built in extractors");
+                                    var applyNone = new PrimarySource("None");
+
+                                    DisplayCopy(
+                                        primarySourceList: new PrimarySource[] { applyExtractors, applyNone, },
+                                        getCopySourceList: one =>
+                                        {
+                                            return UpdateMixedSourceListAndReturn(
+                                                applyExtractors: ReferenceEquals(one, applyExtractors)
+                                            )
+                                                .Select(tuple => tuple.CopySourceFile);
+                                        },
+                                        proceedAsync: async copySourceList =>
+                                        {
+                                            foreach (var source in copySourceList.Where(it => it.DoAction))
+                                            {
+                                                try
+                                                {
+                                                    await source.AsyncAction();
+                                                }
+                                                catch (Exception ex)
+                                                {
+                                                    throw new Exception($"Error while processing of: {source.Display}", ex);
+                                                }
+                                            }
+
+                                            await ModifyMetadataAsync(
+                                                async mod =>
+                                                {
+                                                    await Task.Yield();
+
+                                                    mod.Assets.AddRange(
+                                                        mixedSourceList
+                                                            .Where(
+                                                                tuple => tuple.CopySourceFile.DoAction || tuple.CopySourceFile.DestinationFileExists
+                                                            )
+                                                            .Select(
+                                                                tuple => tuple.AssetFile
+                                                            )
+                                                    );
+                                                }
+                                            );
+                                        }
+                                    );
+                                }
+                            )
+                            {
+                                IsEnabled = false,
+                            }
+                        )
+                    );
+
+                    actions.Add(
+                        new ActionCommand(
+                            "path",
+                            "Choose one more multiple files. And then, this will display the path list of selected files, as multi field of mod.yml file.",
+                            pathCommand = new SimpleAsyncActionCommand<object>(
+                                async _ =>
+                                {
+                                    await Task.Yield();
+
+                                    var noteWin = new NotepadWindow();
+                                    var noteVm = noteWin.VM;
+                                    noteVm.Text = _listSer.Serialize(
+                                        new
+                                        {
+                                            multi = hits
+                                                .Select(hit => hit.RelativePath)
+                                                .ToArray(),
+                                        }
+                                    );
+                                    noteWin.Owner = _getActiveWindowService.GetActiveWindow();
+                                    noteWin.Closed += (_, __) => noteWin.Owner?.Focus();
+                                    noteWin.Show();
+                                }
+                            )
+                            {
+                                IsEnabled = false,
+                            }
+                        )
+                    );
+
+                    targetVm.Actions = actions;
+
+                    selectionIsGood
+                        .ObserveOn(Scheduler.Immediate)
+                        .Subscribe(
+                            it =>
+                            {
+                                copyMultiCommand.IsEnabled = it;
+                                copyEachCommand.IsEnabled = it;
+                                binArcCommand.IsEnabled = it;
+                                pathCommand.IsEnabled = it;
+                            }
+                        );
+
+                    var targetDisposables = new CompositeDisposable();
+
+                    targetDisposables.Add(
+                        Observable.FromEvent<PropertyChangedEventHandler, PropertyChangedEventArgs>(
+                            h => (s, e) => h(e),
+                            h => targetVm.PropertyChanged += h,
+                            h => targetVm.PropertyChanged -= h
+                        )
+                            .Where(it => it.PropertyName == null || it.PropertyName == nameof(targetVm.SearchHitSelectedList))
+                            .Select(it => targetVm.SearchHitSelectedList)
+                            .Subscribe(
+                                them =>
+                                {
+                                    hits = them;
+                                    selectionIsGood.OnNext(them.Any());
+                                }
+                            )
+                    );
+
+                    targetWindow.Owner = _getActiveWindowService.GetActiveWindow();
+                    targetWindow.Closed += (_, __) =>
+                    {
+                        targetWindow.Owner?.Focus();
+                        targetDisposables.Dispose();
+                    };
+                    targetWindow.Show();
+                },
+                task => VM.AppenderTask = task
+            );
+
+            SimpleAsyncActionCommand<object> generateCommand;
+
+            VM.GenerateCommand = generateCommand = new SimpleAsyncActionCommand<object>(
+                async _ =>
+                {
+                    await ModifyMetadataAsync(
+                        async mod =>
+                        {
+                            await _yamlGeneratorService.RefillAssetFilesAsync(
+                            assetFiles: mod.Assets,
+                            sourceDir: Path.GetDirectoryName(VM.ModYmlFilePath)
+                        );
+                        }
+                    );
+                },
+                    task => VM.GeneratingTask = task
+                );
+
+            var toolIsGood = new BehaviorSubject<bool>(false);
+
+            var vmPropertyChanged = Observable.FromEvent<PropertyChangedEventHandler, PropertyChangedEventArgs>(
+                h => (s, e) => h(e),
+                h => VM.PropertyChanged += h,
+                h => VM.PropertyChanged -= h
+            );
+
+            _disposable.Add(
+                vmPropertyChanged
+                    .Where(it => it.PropertyName == null || it.PropertyName == nameof(VM.Tools))
+                    .Select(it => VM.Tools.FirstOrDefault())
+                    .ObserveOn(Scheduler.Immediate)
+                    .Subscribe(
+                        it =>
+                        {
+                            diffTool = it;
+                            toolIsGood.OnNext(it != null);
+                        }
+                    )
+            );
+
+            var ymlFilePathIsGood = new BehaviorSubject<bool>(false);
+
+            _disposable.Add(
+                vmPropertyChanged
+                    .Where(it => it.PropertyName == null || it.PropertyName == nameof(VM.ModYmlFilePath))
+                    .Select(it => VM.ModYmlFilePath)
+                    .ObserveOn(Scheduler.Immediate)
+                    .Subscribe(
+                        it =>
+                        {
+                            ymlFilePathIsGood.OnNext(it.Length != 0);
+                        }
+                    )
+            );
+
+            Observable
+                .CombineLatest(toolIsGood, ymlFilePathIsGood)
+                .ObserveOn(Scheduler.Immediate)
+                .Subscribe(array => generateCommand.IsEnabled = array.All(it => it));
+
+            var gameDataPathIsGood = new BehaviorSubject<bool>(false);
+
+            _disposable.Add(
+                vmPropertyChanged
+                    .Where(it => it.PropertyName == null || it.PropertyName == nameof(VM.GameDataPath))
+                    .Select(it => VM.GameDataPath)
+                    .ObserveOn(Scheduler.Immediate)
+                    .Subscribe(
+                        path =>
+                        {
+                            try
+                            {
+                                gameDataPathIsGood.OnNext((1 <= path?.Length) && Directory.Exists(path));
+                            }
+                            catch
+                            {
+                                // ignore
+                            }
+                        }
+                    )
+            );
+
+            Observable
+                .CombineLatest(ymlFilePathIsGood, gameDataPathIsGood)
+                .ObserveOn(Scheduler.Immediate)
+                .Subscribe(array => appenderCommand.IsEnabled = array.All(it => it));
+
+            {
+                VM.Tools = _getDiffToolsService.GetDiffServices(".yml")
+                    .Append(
+                        new GetDiffService
+                        {
+                            Name = "Use output as is",
+                            DiffAsync = async (rawInput, rawOutput) =>
+                            {
+                                await Task.Yield();
+                                return rawOutput;
+                            }
+                        }
+                    )
+                    .ToArray();
+            }
+
+            void LoadPref(ConfigurationService.YamlGenPref pref)
+            {
+                VM.GameDataPath = pref.GameDataPath;
+                VM.ModYmlFilePath = pref.ModYmlFilePath;
+            }
+
+            VM.LoadPrefCommand = new RelayCommand(
+                _ =>
+                {
+                    if (ConfigurationService.YamlGenPrefs.LastOrDefault(it => it.Label == VM.PrefLabel) is ConfigurationService.YamlGenPref pref)
+                    {
+                        LoadPref(pref);
+                    }
+                }
+            );
+
+            VM.SavePrefCommand = new RelayCommand(
+                _ =>
+                {
+                    if (VM.PrefLabel.Length == 0)
+                    {
+                        VM.PrefLabel = $"Saved at {DateTime.Now}";
+                    }
+
+                    var prefList = ConfigurationService.YamlGenPrefs.ToList();
+                    prefList.RemoveAll(
+                        pref => pref.Label == VM.PrefLabel
+                    );
+                    prefList.Add(
+                        new ConfigurationService.YamlGenPref
+                        {
+                            Label = VM.PrefLabel,
+                            GameDataPath = VM.GameDataPath,
+                            ModYmlFilePath = VM.ModYmlFilePath,
+                        }
+                    );
+                    ConfigurationService.YamlGenPrefs = prefList;
+
+                    var prev = VM.SelectedPref;
+                    VM.Prefs = prefList;
+                    VM.SelectedPref = prefList.LastOrDefault(it => it.Label == prev?.Label);
+                }
+            );
+
+            VM.Prefs = ConfigurationService.YamlGenPrefs;
+
+            if (ConfigurationService.YamlGenPrefs.LastOrDefault(it => it.Label == "default") is ConfigurationService.YamlGenPref pref)
+            {
+                VM.SelectedPref = pref;
+                LoadPref(pref);
+            }
+        }
+
+        private List<AssetFile> MergeAssetSource(IEnumerable<AssetFile> sourceAssets)
+        {
+            var newAssets = new List<AssetFile>();
+
+            foreach (var source in sourceAssets)
+            {
+                if (false)
+                { }
+                else if (source.Method == "copy")
+                {
+                    newAssets.RemoveAll(it => it.Name == source.Name);
+                    newAssets.Add(source);
+                }
+                else if (source.Method == "binarc")
+                {
+                    var exists = newAssets.FirstOrDefault(it => it.Name == source.Name && it.Method == source.Method);
+                    if (exists == null)
+                    {
+                        exists = source;
+                        newAssets.Add(exists);
+                    }
+
+                    exists.Source ??= new List<AssetFile>();
+
+                    foreach (var one in source.Source?.ToArray() ?? Enumerable.Empty<AssetFile>())
+                    {
+                        exists.Source.RemoveAll(it => it.Name == one.Name && it.Method == one.Method);
+                        exists.Source.Add(one);
+                    }
+
+                }
+            }
+
+            return newAssets;
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            base.OnClosed(e);
+            _disposable.Dispose();
         }
     }
 }


### PR DESCRIPTION
Mainly 2 changes. I completely forgot to commit to my git repository which should be applied to #959:

## Fix silent UI

Add some help messages to UI.

![2024-04-17_09h48_36](https://github.com/OpenKH/OpenKh/assets/5955540/7b1bfbda-6140-4014-b64b-ac8e3ad4d69d)

![2024-04-17_09h48_49](https://github.com/OpenKH/OpenKh/assets/5955540/623f5aca-e8de-4ffe-bb2a-f7cf39c152f4)

## Coding

Move business logic from `YamlGeneratorVM.cs` to `YamlGeneratorWindow.xaml.cs`

At the time 77b3b9df8dc4d6df478d6039d659c6576e4c021a, the coding style is like the following figure:

![2024-04-17_10h13_23](https://github.com/OpenKH/OpenKh/assets/5955540/b191f9b5-9873-44f9-813d-0e0e0a1283aa)

- _Business logic_ is like: when I click the search button, YamlGenerator will look for files having entered keywords.
- _DataBinding variables_ are like: bi directional storage to load/save the content directly associated with UI component. e.g. text to store search keywords entered by user. `public string SearchKeywords { get; set; }`

The problematic thing is that UI brings tons of _chain reactions_.

![2024-04-17_10h10_43](https://github.com/OpenKH/OpenKh/assets/5955540/45be95e2-40b1-4088-a697-c298216af2fc)

Imagine, if I merge both of _DataBinding vairables_ and _business logic_ into one `YamlGeneratorVM.cs`, it becomes too complex thing to maintenance in the future.

A preferred idea is to separate them independently.

![yamlgenerator-after](https://github.com/OpenKH/OpenKh/assets/5955540/b7b56ad2-0212-4324-b3b7-eb485fee90d9)

About reuse of common useful logics, it is better to move them to _UsefulService_ or such.

UI specific codes are usually non reusable.

The following figure shows example how to decompose _chain reactions_ into needed count of logics.

![tasks](https://github.com/OpenKH/OpenKh/assets/5955540/33b0c032-fac5-4140-8fce-5e7c3eea580a)

This way is easier to understand, however it costs both many CPU and RAM resources and also not reusable unfortunately too.
