### PR TITLE
Improve update batch of ModsManager:

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/OpenkhUpdateProceederService.cs
+++ b/OpenKh.Tools.ModsManager/Services/OpenkhUpdateProceederService.cs
@@ -85,12 +85,28 @@ namespace OpenKh.Tools.ModsManager.Services
         private async Task CreateBatchFileAsync(string tempBatFile, string copyFrom, string copyTo, string execAfter)
         {
             var bat = new StringWriter();
+            bat.WriteLine($"chcp 65001");
             bat.WriteLine($"taskkill /im OpenKh.Tools.ModsManager.exe");
-            bat.WriteLine($"xcopy /d /e \"{copyFrom}\" \"{copyTo}\" || pause");
+            bat.WriteLine($"robocopy  {EscapeRobocopyArg(copyFrom)} {EscapeRobocopyArg(copyTo)} /e");
+            bat.WriteLine($"if errorlevel 8 pause");
             bat.WriteLine($"{execAfter}");
             bat.WriteLine($"rd /s /q \"{copyFrom}\"");
             bat.WriteLine($"del %0");
-            await File.WriteAllTextAsync(tempBatFile, bat.ToString(), Encoding.Default);
+            await File.WriteAllTextAsync(tempBatFile, bat.ToString(), Encoding.UTF8);
+        }
+
+        private string EscapeRobocopyArg(string arg)
+        {
+            if (0 <= arg.IndexOfAny(new char[] { ' ', '"' }))
+            {
+                var escaped1 = arg.Replace("\"", "\"\"");
+                var escaped2 = escaped1.EndsWith('\\') ? $"{escaped1}\\" : escaped1;
+                return $"\"{escaped2}\"";
+            }
+            else
+            {
+                return arg;
+            }
         }
     }
 }


### PR DESCRIPTION
- Use `chcp 65001` instruction: cmd.exe accepts UTF-8.
- Use `robocopy` instead of `xcopy`. It won't allow to skip copy of files. So it is more stable way for update purpose.