### PR TITLE
Kh2 MapStudio - Up down camera controls and reduced box opacity

### DIFF
--- a/OpenKh.Tools.Kh2MapStudio/App.cs
+++ b/OpenKh.Tools.Kh2MapStudio/App.cs
@@ -523,6 +523,10 @@ namespace OpenKh.Tools.Kh2MapStudio
                 camera.CameraPosition += Vector3.Multiply(camera.CameraLookAtZ, moveSpeed * 5);
             if (keyboard.IsKeyDown(Keys.E))
                 camera.CameraPosition -= Vector3.Multiply(camera.CameraLookAtZ, moveSpeed * 5);
+            if (keyboard.IsKeyDown(Keys.Space))
+                camera.CameraPosition += new Vector3(0, 1 * moveSpeed * 5, 0);
+            if (keyboard.IsKeyDown(Keys.LeftControl))
+                camera.CameraPosition += new Vector3(0, -1 * moveSpeed * 5, 0);
 
             if (keyboard.IsKeyDown(Keys.Up))
                 camera.CameraRotationYawPitchRoll += new Vector3(0, 0, 1 * speed);

--- a/OpenKh.Tools.Kh2MapStudio/MapRenderer.cs
+++ b/OpenKh.Tools.Kh2MapStudio/MapRenderer.cs
@@ -368,14 +368,14 @@ namespace OpenKh.Tools.Kh2MapStudio
                             var color = new xna.Color(1f, 0f, 0f, .5f);
                             var vertices = new PositionColoredTextured[]
                             {
-                                new PositionColoredTextured(-1, -1, -1, 0, 0, 1f, 0f, 0f, 1f),
-                                new PositionColoredTextured(+1, -1, -1, 0, 0, 1f, 0f, 0f, 1f),
-                                new PositionColoredTextured(+1, +1, -1, 0, 0, 1f, 0f, 0f, 1f),
-                                new PositionColoredTextured(-1, +1, -1, 0, 0, 1f, 0f, 0f, 1f),
-                                new PositionColoredTextured(-1, -1, +1, 0, 0, 1f, 0f, 0f, 1f),
-                                new PositionColoredTextured(+1, -1, +1, 0, 0, 1f, 0f, 0f, 1f),
-                                new PositionColoredTextured(+1, +1, +1, 0, 0, 1f, 0f, 0f, 1f),
-                                new PositionColoredTextured(-1, +1, +1, 0, 0, 1f, 0f, 0f, 1f),
+                                new PositionColoredTextured(-1, -1, -1, 0, 0, 1f, 0f, 0f, 0.3f),
+                                new PositionColoredTextured(+1, -1, -1, 0, 0, 1f, 0f, 0f, 0.3f),
+                                new PositionColoredTextured(+1, +1, -1, 0, 0, 1f, 0f, 0f, 0.3f),
+                                new PositionColoredTextured(-1, +1, -1, 0, 0, 1f, 0f, 0f, 0.3f),
+                                new PositionColoredTextured(-1, -1, +1, 0, 0, 1f, 0f, 0f, 0.3f),
+                                new PositionColoredTextured(+1, -1, +1, 0, 0, 1f, 0f, 0f, 0.3f),
+                                new PositionColoredTextured(+1, +1, +1, 0, 0, 1f, 0f, 0f, 0.3f),
+                                new PositionColoredTextured(-1, +1, +1, 0, 0, 1f, 0f, 0f, 0.3f),
                             };
                             var indices = new int[]
                             {

--- a/OpenKh.Tools.Kh2MapStudio/MapRenderer.cs
+++ b/OpenKh.Tools.Kh2MapStudio/MapRenderer.cs
@@ -366,16 +366,17 @@ namespace OpenKh.Tools.Kh2MapStudio
                             pass.Apply();
 
                             var color = new xna.Color(1f, 0f, 0f, .5f);
+                            float opacity = 0.3f;
                             var vertices = new PositionColoredTextured[]
                             {
-                                new PositionColoredTextured(-1, -1, -1, 0, 0, 1f, 0f, 0f, 0.3f),
-                                new PositionColoredTextured(+1, -1, -1, 0, 0, 1f, 0f, 0f, 0.3f),
-                                new PositionColoredTextured(+1, +1, -1, 0, 0, 1f, 0f, 0f, 0.3f),
-                                new PositionColoredTextured(-1, +1, -1, 0, 0, 1f, 0f, 0f, 0.3f),
-                                new PositionColoredTextured(-1, -1, +1, 0, 0, 1f, 0f, 0f, 0.3f),
-                                new PositionColoredTextured(+1, -1, +1, 0, 0, 1f, 0f, 0f, 0.3f),
-                                new PositionColoredTextured(+1, +1, +1, 0, 0, 1f, 0f, 0f, 0.3f),
-                                new PositionColoredTextured(-1, +1, +1, 0, 0, 1f, 0f, 0f, 0.3f),
+                                new PositionColoredTextured(-1, -1, -1, 0, 0, 1f, 0f, 0f, opacity),
+                                new PositionColoredTextured(+1, -1, -1, 0, 0, 1f, 0f, 0f, opacity),
+                                new PositionColoredTextured(+1, +1, -1, 0, 0, 1f, 0f, 0f, opacity),
+                                new PositionColoredTextured(-1, +1, -1, 0, 0, 1f, 0f, 0f, opacity),
+                                new PositionColoredTextured(-1, -1, +1, 0, 0, 1f, 0f, 0f, opacity),
+                                new PositionColoredTextured(+1, -1, +1, 0, 0, 1f, 0f, 0f, opacity),
+                                new PositionColoredTextured(+1, +1, +1, 0, 0, 1f, 0f, 0f, opacity),
+                                new PositionColoredTextured(-1, +1, +1, 0, 0, 1f, 0f, 0f, opacity),
                             };
                             var indices = new int[]
                             {


### PR DESCRIPTION
Added camera controls to move up (Shift) and down (Left Ctrl)
Changed the box opacity to 0.3 to be able to see the entities contained within.

![MapStudioUpdate](https://github.com/OpenKH/OpenKh/assets/20492864/e9bfe824-0ca0-49b8-b2d7-1e7db64dbcaa)
