### PR TITLE
Fixing Not Available Steam Files for Mod Manager

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -35,7 +35,10 @@ namespace OpenKh.Tools.ModsManager.Services
             public string Pcsx2Location { get; internal set; }
             public string PcReleaseLocation { get; internal set; }
             public string PcReleaseLocationKH3D { get; internal set; }
+            public string PcReleaseSteamLocation { get; internal set; }
+            public string PcReleaseSteamLocationKH3D { get; internal set; }
             public string PcReleaseLanguage { get; internal set; } = "en";
+            public string PcReleaseLanguageDT { get; internal set; } = "dt";
             public int RegionId { get; internal set; }
             public bool PanaceaInstalled { get; internal set; }
             public bool ShowConsole { get; internal set; } = false;
@@ -267,6 +270,24 @@ namespace OpenKh.Tools.ModsManager.Services
                 _config.Save(ConfigPath);
             }
         }
+        public static string PcReleaseSteamLocation
+        {
+            get => _config.PcReleaseSteamLocation;
+            set
+            {
+                _config.PcReleaseSteamLocation = value;
+                _config.Save(ConfigPath);
+            }
+        }
+        public static string PcReleaseSteamLocationKH3D
+        {
+            get => _config.PcReleaseSteamLocationKH3D;
+            set
+            {
+                _config.PcReleaseSteamLocationKH3D = value;
+                _config.Save(ConfigPath);
+            }
+        }
 
         public static string PcReleaseLanguage
         {
@@ -274,6 +295,15 @@ namespace OpenKh.Tools.ModsManager.Services
             set
             {
                 _config.PcReleaseLanguage = value;
+                _config.Save(ConfigPath);
+            }
+        }
+        public static string PcReleaseLanguageDT
+        {
+            get => _config.PcReleaseLanguageDT;
+            set
+            {
+                _config.PcReleaseLanguageDT = value;
                 _config.Save(ConfigPath);
             }
         }

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -54,6 +54,7 @@
                     <ComboBoxItem>OpenKH Game Engine</ComboBoxItem>
                     <ComboBoxItem>PlayStation 2 using PCSX2 emulator</ComboBoxItem>
                     <ComboBoxItem>PC Release via Epic Game Store</ComboBoxItem>
+                    <ComboBoxItem>PC Release via Steam</ComboBoxItem>
                 </ComboBox>
                 <StackPanel Visibility="{Binding OpenKhGameEngineConfigVisibility}">
                     <TextBlock Margin="0 0 0 3">Please select the location of OpenKH Game Engine</TextBlock>
@@ -107,6 +108,35 @@
                         </Grid.ColumnDefinitions>
                         <TextBox Grid.Column="0" Text="{Binding PcReleaseLocationKH3D, UpdateSourceTrigger=PropertyChanged}"/>
                         <Button Grid.Column="1" Grid.Row="4" Command="{Binding SelectPcReleaseKH3DCommand}">
+                            <Image Source="{StaticResource FolderOpen_16x}"/>
+                        </Button>
+                    </Grid>
+                    <TextBlock Margin="0 0 0 3" TextWrapping="Wrap">NOTE: Always be sure to use a supported version or risk breaking compatibility</TextBlock>
+                </StackPanel>
+                <StackPanel Visibility="{Binding PcReleaseSteamConfigVisibility}">
+                    <TextBlock Margin="0 0 0 3" TextWrapping="Wrap">
+                        Mod Manager supports both the 1.5+2.5 collection and KH3D from the 2.8 collection choose the filepath for at least one of the collections.
+                    </TextBlock>
+                    <Button Margin="0 10 0 10" Command="{Binding DetectInstallsCommand}">Detect Installations</Button>
+                    <TextBlock Margin="0 0 0 3">Folder location of the PC release of 1.5+2.5</TextBlock>
+                    <Grid Margin="0 0 0 3">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="20"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBox Grid.Column="0" Text="{Binding PcReleaseSteamLocation, UpdateSourceTrigger=PropertyChanged}"/>
+                        <Button Grid.Column="1" Grid.Row="4" Command="{Binding SelectPcSteamReleaseCommand}">
+                            <Image Source="{StaticResource FolderOpen_16x}"/>
+                        </Button>
+                    </Grid>
+                    <TextBlock Margin="0 0 0 3">Folder location of the PC release of 2.8</TextBlock>
+                    <Grid Margin="0 0 0 3">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="20"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBox Grid.Column="0" Text="{Binding PcReleaseSteamLocationKH3D, UpdateSourceTrigger=PropertyChanged}"/>
+                        <Button Grid.Column="1" Grid.Row="4" Command="{Binding SelectPcSteamReleaseKH3DCommand}">
                             <Image Source="{StaticResource FolderOpen_16x}"/>
                         </Button>
                     </Grid>
@@ -204,6 +234,14 @@
                     </TextBlock>
                 </StackPanel>
                 <StackPanel Visibility="{Binding PcReleaseConfigVisibility}">
+                    <TextBlock Margin="0 0 0 6" Visibility="{Binding GameDataNotFoundVisibility}">
+                        You do not have any extracted data from a supported game.
+                    </TextBlock>
+                    <TextBlock Margin="0 0 0 6" Visibility="{Binding GameDataFoundVisibility}">
+                        You already have extracted data from a supported game.
+                    </TextBlock>
+                </StackPanel>
+                <StackPanel Visibility="{Binding PcReleaseSteamConfigVisibility}">
                     <TextBlock Margin="0 0 0 6" Visibility="{Binding GameDataNotFoundVisibility}">
                         You do not have any extracted data from a supported game.
                     </TextBlock>

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml.cs
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml.cs
@@ -34,7 +34,10 @@ namespace OpenKh.Tools.ModsManager.Views
         public string ConfigPcsx2Location { get => _vm.Pcsx2Location; set => _vm.Pcsx2Location = value; }
         public string ConfigPcReleaseLocation { get => _vm.PcReleaseLocation; set => _vm.PcReleaseLocation = value; }
         public string ConfigPcReleaseLocationKH3D { get => _vm.PcReleaseLocationKH3D; set => _vm.PcReleaseLocationKH3D = value; }
+        public string ConfigPcReleaseSteamLocation { get => _vm.PcReleaseSteamLocation; set => _vm.PcReleaseSteamLocation = value; }
+        public string ConfigPcReleaseSteamLocationKH3D { get => _vm.PcReleaseSteamLocationKH3D; set => _vm.PcReleaseSteamLocationKH3D = value; }
         public string ConfigPcReleaseLanguage { get => _vm.PcReleaseLanguage; set => _vm.PcReleaseLanguage = value; }
+        public string ConfigPcReleaseLanguageDT { get => _vm.PcReleaseLanguageDT; set => _vm.PcReleaseLanguageDT = value; }
         public string ConfigGameDataLocation { get => _vm.GameDataLocation; set => _vm.GameDataLocation = value; }
         public int ConfigRegionId { get => _vm.RegionId; set => _vm.RegionId = value; }
         public bool ConfigPanaceaInstalled { get => _vm.PanaceaInstalled; set => _vm.PanaceaInstalled = value; }


### PR DESCRIPTION
Added the option for Steam Installation Files!
It can auto detect directory
Mapped based on the .VDF of the libraries configured on Steam, so if the app is installed, this will find it in any directory.

Tested:
- Auto Detect Files
- Extract Game Data

Changes:
- Modified in the .xml a new option to the list.
- Modified obligatory find the "EOSSDK-Win64-Shipping.dll".
- Added 3 variables, "PcReleaseSteamLocation", "PcReleaseSteamLocationKH3D", "PcReleaseLanguageDT"; Steam in my case download as language the folder dt (IDK if its the case for anyone).
- Logic based on the 3 variables, nullish logic for detect location and assign the right variable.

*All tested with KH3D

Also this may mitigate issue of [#1056](https://github.com/OpenKH/OpenKh/issues/1056)

Output Succesfull:
![Captura de pantalla (105)](https://github.com/OpenKH/OpenKh/assets/53585874/3447c400-3c69-4bfd-9904-b01a791919e8)
