### PR TITLE
BinaryArchive class

### DIFF
--- a/OpenKh.Kh2/BinaryArchive.cs
+++ b/OpenKh.Kh2/BinaryArchive.cs
@@ -1,0 +1,346 @@
+using OpenKh.Common;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xe.BinaryMapper;
+
+namespace OpenKh.Kh2
+{
+    // Bianry Archives are used to store subfiles.
+    // The previous version for this type of file is "Bar.cs". It dealt with linking through name + entry type and a more refined linking structure was required.
+    public class BinaryArchive
+    {
+        /******************************************
+         * Constants
+         ******************************************/
+        private const string SIGNATURE = "BAR";
+        private const int HEADER_SIZE = 0x10;
+        private const int ENTRY_SIZE = 0x10;
+
+        /******************************************
+         * Properties
+         ******************************************/
+        public byte ExternalFlags { get; set; }
+        public byte Version { get; set; }
+        public MotionsetType MSetType { get; set; }
+        public List<Entry> Entries { get; set; }
+        public List<byte[]> Subfiles {  get; set; }
+
+        /******************************************
+         * Constructors
+         ******************************************/
+
+        public BinaryArchive()
+        {
+            Entries = new List<Entry>();
+            Subfiles = new List<byte[]>();
+        }
+
+        /******************************************
+         * Functions - Static
+         ******************************************/
+
+        // Creates the BinaryArchive from the given Stream. The final position is the same as the initial position.
+        public static BinaryArchive Read(Stream barStream)
+        {
+            BinaryArchive binaryArchive = new BinaryArchive();
+
+            int initialPosition = (int)barStream.Position;
+
+            // Read Header
+            HeaderBinary header = BinaryMapping.ReadObject<HeaderBinary>(barStream);
+            binaryArchive.ExternalFlags = (byte)((header.ExternalFlagsAndVersion & 0xF0) >> 4);
+            binaryArchive.Version = (byte)(header.ExternalFlagsAndVersion & 0x0F);
+            binaryArchive.MSetType = (MotionsetType)header.MotionSetType;
+
+            // Read Entries
+            List<EntryBinary> entryBinaries = new List<EntryBinary>();
+            Dictionary<int, int> fileOffsetSize = new Dictionary<int, int>();
+
+            for (int i = 0; i < header.EntryCount; i++)
+            {
+                entryBinaries.Add(BinaryMapping.ReadObject<EntryBinary>(barStream));
+                EntryBinary entryBinary = entryBinaries[i];
+                if(entryBinary.Size == 0)
+                {
+                    entryBinary.Offset = -1;
+                }
+
+                if (!fileOffsetSize.ContainsKey(entryBinary.Offset) && entryBinary.Offset != -1)
+                {
+                    fileOffsetSize.Add(entryBinary.Offset, entryBinary.Size);
+                }
+
+                Entry entry = new Entry();
+                entry.Type = (EntryType)entryBinary.Type;
+                entry.Name = entryBinary.Name;
+                entry.Link = entryBinary.Size == 0 ? -1 : fileOffsetSize.Keys.ToList().IndexOf(entryBinary.Offset);
+                binaryArchive.Entries.Add(entry);
+            }
+
+            // Read SubFiles
+            foreach (int fileOffset in fileOffsetSize.Keys)
+            {
+                byte[] fileBytes = new byte[fileOffsetSize[fileOffset]];
+                barStream.Position = initialPosition + fileOffset;
+                barStream.Read(fileBytes, 0, fileOffsetSize[fileOffset]);
+                binaryArchive.Subfiles.Add(fileBytes);
+            }
+
+            barStream.Position = initialPosition;
+
+            return binaryArchive;
+        }
+        public static BinaryArchive Read(byte[] binaryFile)
+        {
+            MemoryStream memStream = new MemoryStream(binaryFile);
+            return Read(memStream);
+        }
+
+        public static bool IsValid(Stream stream)
+        {
+            if (stream.Length < 4)
+            {
+                return false;
+            }
+
+            string signatureBytes = System.Text.Encoding.ASCII.GetString(stream.ReadBytes(3));
+            stream.Position -= 3;
+
+            if (signatureBytes == SIGNATURE)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        /******************************************
+         * Functions - Local
+         ******************************************/
+
+        // Returns the BinaryArchive as a byte array
+        public byte[] getAsByteArray()
+        {
+            RemoveUnlinkedSubfiles();
+
+            using MemoryStream fileStream = new MemoryStream();
+
+            // Header
+            HeaderBinary headerBinary = new HeaderBinary();
+            headerBinary.Signature = SIGNATURE;
+            headerBinary.ExternalFlagsAndVersion = (byte)((ExternalFlags << 4) | (Version & 0x0F));
+            headerBinary.EntryCount = Entries.Count;
+            headerBinary.Address = 0;
+            headerBinary.MotionSetType = (int)MSetType;
+            BinaryMapping.WriteObject(fileStream, headerBinary);
+
+            // SubFiles
+            fileStream.Position += Entries.Count * ENTRY_SIZE;
+            List<int> offsets = new List<int>();
+            foreach(byte[] subfile in Subfiles)
+            {
+                offsets.Add((int)fileStream.Position);
+                fileStream.Write(subfile, 0, subfile.Length);
+
+                // Padding to 16
+                byte excess = (byte)(fileStream.Position % 16);
+                if(excess > 0)
+                {
+                    for (int i = 0; i < 16 - excess; i++)
+                    {
+                        fileStream.WriteByte(0);
+                    }
+                }
+            }
+
+            // Entries
+            List<int> usedSubFiles = new List<int>();
+            for (int i = 0; i < Entries.Count; i++)
+            {
+                Entry entry = Entries[i];
+                EntryBinary entryBinary = new EntryBinary();
+                entryBinary.Type = (short)entry.Type;
+                entryBinary.Name = entry.Name;
+                entryBinary.Offset = entry.Link == -1 ? -1 : offsets[entry.Link];
+                entryBinary.Size = entry.Link == -1 ? 0 : Subfiles[entry.Link].Length;
+
+                if (!usedSubFiles.Contains(entry.Link))
+                {
+                    entryBinary.Flag = 0;
+                    usedSubFiles.Add(entry.Link);
+                }
+                else
+                {
+                    entryBinary.Flag = 1;
+                }
+
+                fileStream.Position = HEADER_SIZE + (i * ENTRY_SIZE);
+                BinaryMapping.WriteObject(fileStream, entryBinary);
+            }
+
+            return fileStream.ToArray();
+        }
+
+        public void RemoveUnlinkedSubfiles()
+        {
+            List<int> links = new List<int>();
+            foreach(Entry entry in Entries)
+            {
+                if(entry.Link != -1 && !links.Contains(entry.Link))
+                {
+                    links.Add(entry.Link);
+                }
+            }
+            links.Sort();
+
+            Dictionary<int,int> newIndices = new Dictionary<int,int>();
+            for(int i = 0; i < links.Count; i++)
+            {
+                if (links[i] != i)
+                {
+                    newIndices.Add(links[i], i);
+                }
+            }
+
+            List<int> indicesToDelete = new List<int>();
+            for (int i = 0; i < Subfiles.Count; i++)
+            {
+                if (!links.Contains(i))
+                {
+                    indicesToDelete.Add(i);
+                }
+            }
+
+            for (int i = Subfiles.Count; i >= 0; i--)
+            {
+                if (indicesToDelete.Contains(i))
+                {
+                    Subfiles.RemoveAt(i);
+                }
+            }
+
+            foreach (Entry entry in Entries)
+            {
+                if (newIndices.ContainsKey(entry.Link))
+                {
+                    entry.Link = newIndices[entry.Link];
+                }
+            }
+        }
+
+        /******************************************
+         * Subclasses
+         ******************************************/
+        public class Entry
+        {
+            public EntryType Type { get; set; }
+            public int Link { get; set; } // Index of the subfile it links to
+            private string _name;
+            public string Name
+            {
+                get
+                {
+                    return _name;
+                }
+                set
+                {
+                    value += "\0\0\0\0";
+                    _name = value.Substring(0, 4);
+                }
+            }
+
+            public Entry()
+            {
+                Name = "\0\0\0\0";
+                Link = -1;
+            }
+
+            // For visualizing easier in Debug Locals
+            public override string ToString()
+            {
+                return "[" + Name + "] Link: " + Link + "; Type: " + Type;
+            }
+        }
+
+        /******************************************
+         * Enums
+         ******************************************/
+        public enum EntryType //2b
+        {
+            Dummy = 0,
+            Binary = 1,
+            List = 2,
+            Bdx = 3,
+            Model = 4,
+            DrawOctalTree = 5,
+            CollisionOctalTree = 6,
+            ModelTexture = 7,
+            Dpx = 8,
+            Motion = 9,
+            Tim2 = 10,
+            CameraOctalTree = 11,
+            AreaDataSpawn = 12,
+            AreaDataScript = 13,
+            FogColor = 14,
+            ColorOctalTree = 15,
+            MotionTriggers = 16,
+            Anb = 17,
+            Pax = 18,
+            MapCollision2 = 19,
+            Motionset = 20,
+            BgObjPlacement = 21,
+            Event = 22,
+            ModelCollision = 23,
+            Imgd = 24,
+            Seqd = 25,
+            Layout = 28,
+            Imgz = 29,
+            AnimationMap = 30,
+            Seb = 31,
+            Wd = 32,
+            Unknown33,
+            IopVoice = 34,
+            RawBitmap = 36,
+            MemoryCard = 37,
+            WrappedCollisionData = 38,
+            Unknown39 = 39,
+            Unknown40 = 40,
+            Unknown41 = 41,
+            Minigame = 42,
+            JimiData = 43,
+            Progress = 44,
+            Synthesis = 45,
+            BarUnknown = 46,
+            Vibration = 47,
+            Vag = 48,
+        }
+        public enum MotionsetType //4b
+        {
+            Default = 0,
+            Player = 1,
+            Raw = 2
+        }
+
+        /******************************************
+         * Helper classes for reading and writing
+         ******************************************/
+        // struct BINARC
+        public class HeaderBinary
+        {
+            [Data(Count = 3)] public string Signature { get; set; } // BAR
+            [Data] public byte ExternalFlagsAndVersion { get; set; } // 4b external flags; 4b Version
+            [Data] public int EntryCount { get; set; }
+            [Data] public int Address { get; set; } // Always 0 unless ingame
+            [Data] public int MotionSetType { get; set; } // 30b Replace; 2b Flag (MotionSet Type)
+        }
+        // struct INFO
+        public class EntryBinary
+        {
+            [Data] public short Type { get; set; }
+            [Data] public short Flag { get; set; } // Bitflag
+            [Data(Count = 4)] public string Name { get; set; }
+            [Data] public int Offset { get; set; }
+            [Data] public int Size { get; set; }
+        }
+    }
+}

--- a/OpenKh.Tools.Kh2ObjectEditor/Classes/MotionSelector_Wrapper.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Classes/MotionSelector_Wrapper.cs
@@ -1,15 +1,28 @@
 using OpenKh.Kh2;
+using OpenKh.Tools.Kh2ObjectEditor.Services;
 
 namespace OpenKh.Tools.Kh2ObjectEditor.Classes
 {
     public class MotionSelector_Wrapper
     {
         public int Index { get; set; }
-        public Bar.Entry Entry { get; set; }
+        public BinaryArchive.Entry Entry { get; set; }
         public string Name { get; set; }
-        public bool IsDummy { get { return Name.Contains("DUMM") || Entry.Stream.Length == 0; } }
+        public bool IsDummy { get { return Name.Contains("DUMM") || LinkedSubfile.Length == 0; } }
+        public byte[] LinkedSubfile
+        {
+            get
+            {
+                if(Entry.Link == -1)
+                {
+                    return new byte[0];
+                }
 
-        public MotionSelector_Wrapper(int index, Bar.Entry entry)
+                return MsetService.Instance.MsetBinarc.Subfiles[Entry.Link];
+            }
+        }
+
+        public MotionSelector_Wrapper(int index, BinaryArchive.Entry entry)
         {
             Index = index;
             Entry = entry;
@@ -18,9 +31,9 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Classes
         public void setName()
         {
             Name = "[" + Index + "] " + Entry.Name + " [" + (MotionSet.MotionName)(Index / 4) + "]";
-            if (Entry.Type == Bar.EntryType.Motionset)
+            if (Entry.Type == BinaryArchive.EntryType.Motionset)
                 Name += "<RC>";
-            if (Entry.Stream.Length == 0)
+            if (LinkedSubfile.Length == 0)
                 Name += "<DUMMY>";
         }
     }

--- a/OpenKh.Tools.Kh2ObjectEditor/Classes/Object_Wrapper.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Classes/Object_Wrapper.cs
@@ -13,7 +13,7 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Classes
         public string MsetPath { get; set; }
 
         public Bar MdlxBar { get; set; }
-        public Bar MsetBar { get; set; }
+        public BinaryArchive MsetBar { get; set; }
 
         public ModelSkeletal ModelFile { get; set; }
         public ModelCollision CollisionFile { get; set; }
@@ -49,7 +49,7 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Classes
                 if (!Bar.IsValid(streamMset))
                     throw new Exception("File is not a valid MSET: " + MsetPath);
 
-                MsetBar = Bar.Read(streamMset);
+                MsetBar = BinaryArchive.Read(streamMset);
             }
         }
 
@@ -82,9 +82,9 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Classes
             if(MsetBar != null)
             {
                 MsetEntries = new List<MotionSelector_Wrapper>();
-                for(int i = 0; i < MsetBar.Count; i++)
+                for(int i = 0; i < MsetBar.Entries.Count; i++)
                 {
-                    MsetEntries.Add(new MotionSelector_Wrapper(i, MsetBar[i]));
+                    MsetEntries.Add(new MotionSelector_Wrapper(i, MsetBar.Entries[i]));
                 }
             }
         }

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Motions/ModuleMotions_Control.xaml.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Motions/ModuleMotions_Control.xaml.cs
@@ -32,13 +32,13 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Views
 
 
             // Reaction Command
-            if (item.Entry.Type == Bar.EntryType.Motionset)
+            if (item.Entry.Type == BinaryArchive.EntryType.Motionset)
             {
                 System.Windows.Forms.MessageBox.Show("This is a Reaction Command", "Motion couldn't be loaded", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Error);
                 return;
             }
             // No motion
-            else if(item.Entry.Type != Bar.EntryType.Anb)
+            else if(item.Entry.Type != BinaryArchive.EntryType.Anb)
             {
                 System.Windows.Forms.MessageBox.Show("This is not a Motion or Reaction Command", "Motion couldn't be loaded", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Error);
                 return;
@@ -50,7 +50,7 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Views
                 return;
             }
             // Unnamed dummy
-            if (item.Entry.Stream.Length == 0)
+            if (item.LinkedSubfile.Length == 0)
             {
                 System.Windows.Forms.MessageBox.Show("This motion is a dummy (No data)", "Motion couldn't be loaded", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Error);
                 return;
@@ -90,12 +90,12 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Views
 
                 MotionSelector_Wrapper item = (MotionSelector_Wrapper)MotionList.SelectedItem;
 
-                Bar.Entry newMotionBar = new Bar.Entry();
-                newMotionBar.Name = "NDUM";
-                newMotionBar.Type = Bar.EntryType.Anb;
-                newMotionBar.Stream = new MemoryStream();
+                BinaryArchive.Entry newMotionEntry = new BinaryArchive.Entry();
+                newMotionEntry.Name = "NDUM";
+                newMotionEntry.Type = BinaryArchive.EntryType.Anb;
+                newMotionEntry.Link = -1;
 
-                MsetService.Instance.MsetBar.Insert(item.Index + 1, newMotionBar);
+                MsetService.Instance.MsetBinarc.Entries.Insert(item.Index + 1, new BinaryArchive.Entry());
 
                 ThisVM.loadMotions();
                 ThisVM.applyFilters();
@@ -107,7 +107,7 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Views
             {
                 MotionSelector_Wrapper item = (MotionSelector_Wrapper)MotionList.SelectedItem;
 
-                MsetService.Instance.MsetBar.RemoveAt(item.Index);
+                MsetService.Instance.MsetBinarc.Entries.RemoveAt(item.Index);
 
                 ThisVM.loadMotions();
                 ThisVM.applyFilters();
@@ -166,7 +166,7 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Views
 
             MotionSelector_Wrapper item = (MotionSelector_Wrapper)MotionList.SelectedItem;
 
-            if(item.Entry.Type != Bar.EntryType.Motionset) {
+            if(item.Entry.Type != BinaryArchive.EntryType.Motionset) {
                 System.Windows.Forms.MessageBox.Show("The selected entry is not a Moveset", "Can't export entry", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Error);
                 return;
             }
@@ -180,15 +180,10 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Views
                 sfd.ShowDialog();
                 if (sfd.FileName != "")
                 {
-                    MemoryStream memStream = (MemoryStream)item.Entry.Stream;
-                    memStream.Position = 0;
-                    File.WriteAllBytes(sfd.FileName, memStream.ToArray());
-                    item.Entry.Stream.Position = 0;
+                    File.WriteAllBytes(sfd.FileName, item.LinkedSubfile);
                 }
             }
             catch (Exception exc) { }
-
-            item.Entry.Stream.Position = 0;
         }
         public void RC_Replace(object sender, RoutedEventArgs e)
         {
@@ -214,8 +209,6 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Views
                 openMotionTabs(MsetService.Instance.LoadedMotion);
             }
             catch (Exception exception) { }
-
-            item.Entry.Stream.Position = 0;
         }
 
         private void Button_TEST(object sender, System.Windows.RoutedEventArgs e)

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Motions/MotionRenameWindow.xaml.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Motions/MotionRenameWindow.xaml.cs
@@ -13,12 +13,12 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Motions
             MotionIndex = motionIndex;
             ParentControl = parent;
             InitializeComponent();
-            NameTextBox.Text = MsetService.Instance.MsetBar[MotionIndex].Name;
+            NameTextBox.Text = MsetService.Instance.MsetBinarc.Entries[MotionIndex].Name;
         }
 
         private void Button_Rename(object sender, RoutedEventArgs e)
         {
-            MsetService.Instance.MsetBar[MotionIndex].Name = NameTextBox.Text;
+            MsetService.Instance.MsetBinarc.Entries[MotionIndex].Name = NameTextBox.Text;
             ParentControl.ThisVM.Motions[MotionIndex].setName();
             ParentControl.ThisVM.applyFilters();
             this.Close();

--- a/OpenKh.Tools.Kh2ObjectEditor/Services/AttachmentService.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Services/AttachmentService.cs
@@ -75,12 +75,12 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Services
                 if (!Bar.IsValid(streamMset))
                     throw new Exception("File is not a valid MSET: " + tempMsetPath);
 
-                Bar Attach_MsetBar = Bar.Read(streamMset);
+                BinaryArchive Attach_MsetBar = BinaryArchive.Read(streamMset);
 
                 Attach_MsetEntries = new List<MotionSelector_Wrapper>();
-                for (int i = 0; i < Attach_MsetBar.Count; i++)
+                for (int i = 0; i < Attach_MsetBar.Entries.Count; i++)
                 {
-                    Attach_MsetEntries.Add(new MotionSelector_Wrapper(i, Attach_MsetBar[i]));
+                    Attach_MsetEntries.Add(new MotionSelector_Wrapper(i, Attach_MsetBar.Entries[i]));
                 }
             }
         }

--- a/OpenKh.Tools.Kh2ObjectEditor/Services/ClipboardService.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Services/ClipboardService.cs
@@ -8,26 +8,17 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Services
     {
         // Note: Objects are copied as bytes or string in order to not copy the reference
 
-        private Stream _motion { get; set; }
-        public void StoreMotion(Bar.Entry motion)
+        private byte[] _motion { get; set; }
+        public void StoreMotion(byte[] motionFile)
         {
-            motion.Stream.Position = 0;
-            _motion = new MemoryStream();
-            motion.Stream.CopyTo(_motion);
-            _motion.Position = 0;
-            motion.Stream.Position = 0;
+            _motion = motionFile;
         }
-        public Stream FetchMotion()
+        public byte[] FetchMotion()
         {
             if (_motion == null)
                 return null;
 
-            Stream copy = new MemoryStream();
-            _motion.CopyTo(copy);
-            copy.Position = 0;
-            _motion.Position = 0;
-
-            return copy;
+            return _motion;
         }
 
         private Stream _dpd { get; set; }

--- a/OpenKh.Tools.Kh2ObjectEditor/Services/MsetService.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Services/MsetService.cs
@@ -10,7 +10,8 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Services
     {
         // Apdx File
         public string MsetPath { get; set; }
-        public Bar MsetBar { get; set; }
+        //public Bar MsetBar { get; set; }
+        public BinaryArchive MsetBinarc { get; set; }
         //public List<AnimationBinary> Motions { get; set; }
         //public List<Bar> MotionSets { get; set; } // Reaction Commands
         // public List<Motion> OtherMotions  { get; set; } // Some msets have 0x09 entries
@@ -27,11 +28,10 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Services
             MsetPath = msetPath;
 
             using var streamMset = File.Open(MsetPath, FileMode.Open);
-            if (!Bar.IsValid(streamMset))
+            if (!BinaryArchive.IsValid(streamMset))
                 throw new Exception("File is not a valid MSET: " + MsetPath);
 
-            MsetBar = Bar.Read(streamMset);
-            streamMset.Position = 0;
+            MsetBinarc = BinaryArchive.Read(streamMset);
         }
 
         public void LoadMotion(int motionIndex)
@@ -41,14 +41,16 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Services
         }
         public void LoadCurrentMotion()
         {
-            MsetBar[LoadedMotionId].Stream.Position = 0;
-            LoadedMotion = new AnimationBinary(MsetBar[LoadedMotionId].Stream);
-            MsetBar[LoadedMotionId].Stream.Position = 0;
+            BinaryArchive.Entry motionEntry = MsetBinarc.Entries[LoadedMotionId];
+            using MemoryStream fileStream = new MemoryStream(MsetBinarc.Subfiles[motionEntry.Link]);
+            LoadedMotion = new AnimationBinary(fileStream);
         }
 
         public void SaveMotion()
         {
-            MsetBar[LoadedMotionId].Stream = LoadedMotion.toStream();
+            BinaryArchive.Entry motionEntry = MsetBinarc.Entries[LoadedMotionId];
+            MemoryStream motionStream = (MemoryStream)LoadedMotion.toStream();
+            MsetBinarc.Subfiles[motionEntry.Link] = motionStream.ToArray();
         }
 
         public void SaveFile()
@@ -60,9 +62,7 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Services
             sfd.ShowDialog();
             if (sfd.FileName != "")
             {
-                MemoryStream memStream = new MemoryStream();
-                Bar.Write(memStream, MsetBar);
-                File.WriteAllBytes(sfd.FileName, memStream.ToArray());
+                File.WriteAllBytes(sfd.FileName, MsetBinarc.getAsByteArray());
             }
         }
 
@@ -71,9 +71,7 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Services
             if (MsetPath == null)
                 return;
 
-            MemoryStream memStream = new MemoryStream();
-            Bar.Write(memStream, MsetBar);
-            File.WriteAllBytes(MsetPath, memStream.ToArray());
+            File.WriteAllBytes(MsetPath, MsetBinarc.getAsByteArray());
         }
 
         // SINGLETON

--- a/OpenKh.Tools.Kh2ObjectEditor/ViewModel/ModuleLoader_VM.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/ViewModel/ModuleLoader_VM.cs
@@ -9,7 +9,7 @@ namespace OpenKh.Tools.Kh2ObjectEditor.ViewModel
         public Visibility TabModelEnabled { get { return MdlxService.Instance.MdlxBar == null ? Visibility.Collapsed : Visibility.Visible; } }
         public Visibility TabTexturesEnabled { get { return MdlxService.Instance.MdlxBar == null ? Visibility.Collapsed : Visibility.Visible; } }
         public Visibility TabUIEnabled { get { return (ApdxService.Instance.ImgdFace == null && ApdxService.Instance.ImgdCommand == null) ? Visibility.Collapsed : Visibility.Visible; } }
-        public Visibility TabMotionsEnabled { get { return MsetService.Instance.MsetBar == null ? Visibility.Collapsed : Visibility.Visible; } }
+        public Visibility TabMotionsEnabled { get { return MsetService.Instance.MsetBinarc == null ? Visibility.Collapsed : Visibility.Visible; } }
         public Visibility TabCollisionsEnabled { get { return MdlxService.Instance.CollisionFile == null ? Visibility.Collapsed : Visibility.Visible; } }
         public Visibility TabParticlesEnabled { get { return ApdxService.Instance.ApdxBar == null ? Visibility.Collapsed : Visibility.Visible; } }
         public Visibility TabAIEnabled { get { return MdlxService.Instance.BdxFile == null ? Visibility.Collapsed : Visibility.Visible; } }

--- a/OpenKh.Tools.Kh2ObjectEditor/ViewModel/Viewport_ViewModel.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/ViewModel/Viewport_ViewModel.cs
@@ -159,8 +159,7 @@ namespace OpenKh.Tools.Kh2ObjectEditor.ViewModel
             if (!ObjectEditorUtils.isFilePathValid(App_Context.Instance.MdlxPath, "mdlx") || !ObjectEditorUtils.isFilePathValid(MsetService.Instance.MsetPath, "mset") || MsetService.Instance.LoadedMotion == null)
                 return;
 
-            MsetService.Instance.MsetBar[MsetService.Instance.LoadedMotionId].Stream.Position = 0;
-            Bar anbBarFile = Bar.Read(MsetService.Instance.MsetBar[MsetService.Instance.LoadedMotionId].Stream);
+            Bar anbBarFile = Bar.Read(new MemoryStream(MsetService.Instance.MsetBinarc.Subfiles[MsetService.Instance.MsetBinarc.Entries[MsetService.Instance.LoadedMotionId].Link]));
 
             currentAnb = new AnbIndir(anbBarFile);
         }
@@ -272,14 +271,13 @@ namespace OpenKh.Tools.Kh2ObjectEditor.ViewModel
             Bar attach_AnbBarFile = new Bar();
             try // Some animations don't use the weapon
             {
-                attach_AnbBarFile = Bar.Read(AttachmentService.Instance.Attach_MsetEntries[MsetService.Instance.LoadedMotionId].Entry.Stream);
+                attach_AnbBarFile = Bar.Read(new MemoryStream(MsetService.Instance.MsetBinarc.Subfiles[MsetService.Instance.MsetBinarc.Entries[MsetService.Instance.LoadedMotionId].Link]));
             }
             catch (Exception ex)
             {
                 return new List<SimpleModel>();
             }
 
-            AttachmentService.Instance.Attach_MsetEntries[MsetService.Instance.LoadedMotionId].Entry.Stream.Position = 0;
             AnbIndir attach_Anb = new AnbIndir(attach_AnbBarFile);
 
             IAnimMatricesProvider attach_AnimMatricesProvider = attach_Anb.GetAnimProvider(temp_mdlxStream);


### PR DESCRIPTION
The Bar class doesn't handle file linking in a way that could be easily modified. Modifying this behaviour would lead to changing the whole structure so I made a new class.

### Bar.cs
Loads every entry with its offset, duplicate flag (Index) and a copy of the subfile it is pointing to. When rebuilding it stores the subfiles in a dictionary using as key the Name and Type of the file. When a duplicate flag (Index 1) is detected it searches for the subfile's offset in the dictionary.  Note that this means duplicate files must use the same name as the original otherwise an error is thrown.

### BinaryArchive.cs
Loads every subfile and then every entry with a link to its subfile. When rebuilding it writes the existing entries and linked subfiles so there's no room for error. Dummy entries' offsets are also set to -1, which makes them clearer and easier to process.

Overall BinaryArchive may be harder to use than Bar (2 lists vs 1) but offers better support and is less prone to errors. It also uses less memory because it isn't loading the duplicate files.

The ObjectEditor's mset module has been adapted to use BinaryArchive to prevent it from crashing due to same names in different motions or different names in duplicated motions.