### PR TITLE
Kh2ObjectEditor - Export model and animations

### DIFF
--- a/OpenKh.AssimpUtils/OpenKh.AssimpUtils.csproj
+++ b/OpenKh.AssimpUtils/OpenKh.AssimpUtils.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\OpenKh.Engine.MonoGame\OpenKh.Engine.MonoGame.csproj" />
     <ProjectReference Include="..\OpenKh.Engine\OpenKh.Engine.csproj" />
     <ProjectReference Include="..\OpenKh.Kh1\OpenKh.Kh1.csproj" />
+    <ProjectReference Include="..\OpenKh.Kh2AnimEmu\OpenKh.Kh2AnimEmu.csproj" />
   </ItemGroup>
 
     <ItemGroup>

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Motions/ModuleMotions_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Motions/ModuleMotions_Control.xaml
@@ -60,6 +60,7 @@
                         <Separator/>
                         <MenuItem Header="Copy motion" Click="Motion_Copy"/>
                         <MenuItem Header="Replace with copied motion" Click="Motion_Replace"/>
+                        <MenuItem Header="Export FBX animation" Click="Motion_Export"/>
                         <MenuItem Header="Replace with imported FBX animation" Click="Motion_Import"/>
                         <Separator/>
                         <MenuItem Header="Export RC as mset" Click="RC_Export"/>

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Motions/ModuleMotions_VM.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Motions/ModuleMotions_VM.cs
@@ -95,6 +95,7 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Motions
         public void Motion_Replace(int index)
         {
             MsetService.Instance.MsetBinarc.Subfiles.Add(ClipboardService.Instance.FetchMotion());
+            MsetService.Instance.MsetBinarc.Entries[index].Type = BinaryArchive.EntryType.Anb;
             MsetService.Instance.MsetBinarc.Entries[index].Name = "COPY";
             MsetService.Instance.MsetBinarc.Entries[index].Link = MsetService.Instance.MsetBinarc.Subfiles.Count - 1;
 
@@ -132,14 +133,14 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Motions
 
             // Get as stream
             MemoryStream motionStream = (MemoryStream)ipm.toStream();
-
+            
             // Insert to mset
             int subfileIndex = MsetService.Instance.MsetBinarc.Entries[index].Link;
             MemoryStream replaceMotionStream = new MemoryStream(MsetService.Instance.MsetBinarc.Subfiles[subfileIndex]);
             AnimationBinary msetEntry = new AnimationBinary(replaceMotionStream);
             msetEntry.MotionFile = new Motion.InterpolatedMotion(motionStream);
             MsetService.Instance.MsetBinarc.Subfiles[subfileIndex] = ((MemoryStream)msetEntry.toStream()).ToArray();
-
+            
             loadMotions();
         }
         public void Motion_ImportRC(int index, string msetPath)

--- a/OpenKh.Tools.Kh2ObjectEditor/Views/Main_Window.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Views/Main_Window.xaml
@@ -30,6 +30,7 @@
                     <MenuItem Header="Overwrite Apdx" Click="Menu_Overwrite_Apdx"/>
                 </MenuItem>
             </MenuItem>
+            <MenuItem Header="Export Model" Click="Menu_ExportModel"/>
         </Menu>
 
         <Grid AllowDrop="True" Drop="Window_Drop">

--- a/OpenKh.Tools.Kh2ObjectEditor/Views/Main_Window.xaml.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Views/Main_Window.xaml.cs
@@ -1,10 +1,14 @@
 using Microsoft.Win32;
+using OpenKh.AssimpUtils;
+using OpenKh.Kh2;
+using OpenKh.Tools.Common.Wpf;
 using OpenKh.Tools.Kh2ObjectEditor.Services;
 using OpenKh.Tools.Kh2ObjectEditor.Utils;
 using OpenKh.Tools.Kh2ObjectEditor.ViewModel;
 using System.IO;
 using System.Linq;
 using System.Windows;
+using System.Windows.Media.Imaging;
 
 namespace OpenKh.Tools.Kh2ObjectEditor.Views
 {
@@ -155,6 +159,60 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Views
             }
         }
 
+        private void Menu_ExportModel(object sender, RoutedEventArgs e)
+        {
+            if(MdlxService.Instance.ModelFile != null)
+            {
+                Kh2.Models.ModelSkeletal model = null;
+                foreach (Bar.Entry barEntry in MdlxService.Instance.MdlxBar)
+                {
+                    if (barEntry.Type == Bar.EntryType.Model)
+                    {
+                        model = Kh2.Models.ModelSkeletal.Read(barEntry.Stream);
+                        barEntry.Stream.Position = 0;
+                    }
+                }
 
+                Assimp.Scene scene = Kh2MdlxAssimp.getAssimpScene(model);
+
+                System.Windows.Forms.SaveFileDialog sfd;
+                sfd = new System.Windows.Forms.SaveFileDialog();
+                sfd.Title = "Export model";
+                sfd.FileName = MdlxService.Instance.MdlxPath + "." + AssimpGeneric.GetFormatFileExtension(AssimpGeneric.FileFormat.fbx);
+                sfd.ShowDialog();
+                if (sfd.FileName != "")
+                {
+                    string dirPath = Path.GetDirectoryName(sfd.FileName);
+
+                    if (!Directory.Exists(dirPath))
+                        return;
+
+                    dirPath += "\\";
+
+                    AssimpGeneric.ExportScene(scene, AssimpGeneric.FileFormat.fbx, sfd.FileName);
+                    exportTextures(dirPath);
+                }
+            }
+        }
+
+        public void exportTextures(string filePath)
+        {
+            for (int i = 0; i < MdlxService.Instance.TextureFile.Images.Count; i++)
+            {
+                ModelTexture.Texture texture = MdlxService.Instance.TextureFile.Images[i];
+                BitmapSource bitmapImage = texture.GetBimapSource();
+
+                string fullPath = filePath + "Texture" + i.ToString("D4");
+                string finalPath = fullPath;
+                int repeat = 0;
+                while (File.Exists(finalPath))
+                {
+                    repeat++;
+                    finalPath = fullPath + " (" + repeat + ")";
+                }
+
+                AssimpGeneric.ExportBitmapSourceAsPng(bitmapImage, fullPath);
+            }
+        }
     }
 }


### PR DESCRIPTION
Added options to export the model (Top menu) and the animations (Right click/Contextual menu on motions)

Notes on animation exporting:

- Due to IKs there's no way to export animations by keys, instead the transformation matrices are calculated using the Kh2Anim library.
- Due to the amount of keys exported the animations can't be imported back unless edited to reduce the key count. Note that there's no error message for this, the animation will simply not change when this occurs.
- The animations look right in Blender but in Noesis it'll look messed up. I think this could be fixed by adding the "CustomFrameRate" metadata but Assimp refuses to export Metadata.
- Similar to the previous point, Assimp sets all scaling keys to 1 for some reason so scaling can't be exported.