### PR TITLE
Add FAQ button to the mod manager

### DIFF
--- a/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
@@ -108,6 +108,13 @@
                     </MenuItem.Header>
                 </MenuItem>
                 <Separator/>
+                <MenuItem Header="Frequently Asked Questions" Command="{Binding OpenLinkCommand}"
+                    CommandParameter="https://openkh.dev/tool/GUI.ModsManager/FAQ">
+                    <MenuItem.Icon>
+                        <Image Source="{StaticResource WebURL_16x}"/>
+                    </MenuItem.Icon>
+                </MenuItem>
+                <Separator/>
                 <MenuItem Header="Download _latest version" Command="{Binding OpenLinkCommand}"
                     CommandParameter="https://github.com/OpenKH/OpenKh/releases">
                     <MenuItem.Icon>

--- a/OpenKh.Tools.ModsManager/Views/MainWindow.xaml.cs
+++ b/OpenKh.Tools.ModsManager/Views/MainWindow.xaml.cs
@@ -21,5 +21,10 @@ namespace OpenKh.Tools.ModsManager.Views
             WinSettings.Default.Save();
             base.OnClosed(e);
         }
+
+        private void MenuItem_Click(object sender, RoutedEventArgs e)
+        {
+
+        }
     }
 }


### PR DESCRIPTION
Ready to merge after #1078

This adds a `Frequently Asked Questions` button to the mod manager under the `Info` menu, which will link to a page on the site