### PR TITLE
Update extraction time msg.

### DIFF
--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -229,8 +229,11 @@
                             You already have extracted data from a supported game.
                         </TextBlock>
                     </StackPanel>
-                    <TextBlock Margin="0 0 0 3" TextWrapping="Wrap">
+                    <TextBlock Margin="0 0 0 3" TextWrapping="Wrap" Visibility="{Binding Pcsx2ConfigVisibility}">
                         Press the button below to initialize the game extraction. It will take between 5 and 15 minutes based on the speed of your hard drive.
+                    </TextBlock>
+                    <TextBlock Margin="0 0 0 3" TextWrapping="Wrap" Visibility="{Binding PcReleaseConfigVisibility}">
+                        Press the button below to initialize the game extraction. Depending on the speed of your storage, if its a hard drive or an SSD, and how many games selected to extract extraction time may vary a lot.
                     </TextBlock>
                     <Button Margin="0 0 0 6" Width="120" Height="22" HorizontalAlignment="Left" Command="{Binding ExtractGameDataCommand}">Extract game data</Button>
                     <ProgressBar Margin="0 0 0 6" Height="22" Visibility="{Binding ProgressBarVisibility}" Minimum="0" Maximum="1" Value="{Binding ExtractionProgress}"/>


### PR DESCRIPTION
The orignal message was mean for an ISO extraction. Extraction PC version is longer due to remastered assets and also there are 5 supported games so the PC version now has its own message instead and the old one only shows for emulator.

PC Extraction page msg
![image](https://github.com/user-attachments/assets/f11e71ff-abf8-488a-b6ce-e3bb8098fe7e)

Old msg for an ISO extraction
![image](https://github.com/user-attachments/assets/c582a611-1328-4c43-b654-da28f197be7e)
