### PR TITLE
Steam API trick

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -45,6 +45,8 @@ namespace OpenKh.Tools.ModsManager.Services
             public bool DevView { get; internal set; } = false;
             public bool AutoUpdateMods { get; internal set; }
             public string pcVersion { get; internal set; } = "EGS";
+            public bool steamAPITrick1525 {  get; internal set; } = false;
+            public bool steamAPITrick28 { get; internal set; } = false;
             public List<string> GamesToExtract { get; internal set; } = new List<string> { "kh2" };
             public bool SkipRemastered { get; internal set; } = false;
             public string LaunchGame { get; internal set; } = "kh2";
@@ -358,6 +360,24 @@ namespace OpenKh.Tools.ModsManager.Services
             set
             {
                 _config.pcVersion = value;
+                _config.Save(ConfigPath);
+            }
+        }
+        public static bool SteamAPITrick1525
+        {
+            get => _config.steamAPITrick1525;
+            set
+            {
+                _config.steamAPITrick1525 = value;
+                _config.Save(ConfigPath);
+            }
+        }
+        public static bool SteamAPITrick28
+        {
+            get => _config.steamAPITrick28;
+            set
+            {
+                _config.steamAPITrick28 = value;
                 _config.Save(ConfigPath);
             }
         }

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -705,7 +705,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                             return Task.CompletedTask;
                         }
                     }
-                    if (ConfigurationService.PCVersion == "Steam" && !(_launchGame == "kh3d"))
+                    if (ConfigurationService.PCVersion == "Steam" && !(_launchGame == "kh3d") && ConfigurationService.SteamAPITrick1525 == false)
                     {
                         if (ConfigurationService.PcReleaseLocation != null)
                         {
@@ -741,7 +741,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                             return Task.CompletedTask;
                         }
                     }
-                    else if (ConfigurationService.PCVersion == "Steam" && _launchGame == "kh3d")
+                    else if (ConfigurationService.PCVersion == "Steam" && _launchGame == "kh3d" && ConfigurationService.SteamAPITrick28 == false)
                     {
                         if (ConfigurationService.PcReleaseLocationKH3D != null)
                         {

--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -78,12 +78,21 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 OnPropertyChanged();
             }
         }
+        private Xceed.Wpf.Toolkit.WizardPage _wizardPageAfterLuaBackend;
+        public Xceed.Wpf.Toolkit.WizardPage WizardPageAfterLuaBackend
+        {
+            get => _wizardPageAfterLuaBackend;
+            private set
+            {
+                _wizardPageAfterLuaBackend = value;
+                OnPropertyChanged();
+            }
+        }
         public Xceed.Wpf.Toolkit.WizardPage PageIsoSelection { get; internal set; }
         public Xceed.Wpf.Toolkit.WizardPage PageEosInstall { get; internal set; }
-        public Xceed.Wpf.Toolkit.WizardPage PageEosConfig { get; internal set; }
-        public Xceed.Wpf.Toolkit.WizardPage PageLuaBackendInstall { get; internal set; }
+        public Xceed.Wpf.Toolkit.WizardPage PageSteamAPITrick { get; internal set; }
         public Xceed.Wpf.Toolkit.WizardPage PageRegion { get; internal set; }
-        public Xceed.Wpf.Toolkit.WizardPage PCLaunchOption { get; internal set; }
+        public Xceed.Wpf.Toolkit.WizardPage PageGameData { get; internal set; }
         public Xceed.Wpf.Toolkit.WizardPage LastPage { get; internal set; }
 
         public WizardPageStackService PageStack { get; set; } = new WizardPageStackService();
@@ -241,6 +250,11 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         ConfigurationService.PCVersion = "EGS";
                         break;
                 }
+                WizardPageAfterLuaBackend = LaunchOption switch
+                {
+                    1 => PageSteamAPITrick,
+                    _ => PageGameData,
+                };
             }
         }
         public RelayCommand SelectOpenKhGameEngineCommand { get; }
@@ -546,6 +560,8 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     return false;
             }
         }
+        public RelayCommand InstallSteamAPIFile {  get; set; }
+        public RelayCommand RemoveSteamAPIFile { get; set; }
         public RelayCommand InstallLuaBackendCommand { get; set; }
         public RelayCommand RemoveLuaBackendCommand { get; set; }
         public Visibility LuaBackendFoundVisibility => IsLuaBackendInstalled ? Visibility.Visible : Visibility.Collapsed;
@@ -1268,6 +1284,44 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     OnPropertyChanged(nameof(IsLuaBackendInstalled));
                     OnPropertyChanged(nameof(LuaBackendFoundVisibility));
                     OnPropertyChanged(nameof(LuaBackendNotFoundVisibility));
+                }
+            });
+            InstallSteamAPIFile = new RelayCommand(_ =>
+            {
+                if (GameCollection == 0)
+                {
+                    if (Directory.Exists(ConfigurationService.PcReleaseLocation))
+                    {
+                        File.WriteAllText(Path.Combine(ConfigurationService.PcReleaseLocation, "steam_appid.txt"), "2552430");
+                        ConfigurationService.SteamAPITrick1525 = true;
+                    }
+                }
+                else if (GameCollection == 1)
+                {
+                    if (Directory.Exists(ConfigurationService.PcReleaseLocationKH3D))
+                    {
+                        File.WriteAllText(Path.Combine(ConfigurationService.PcReleaseLocationKH3D, "steam_appid.txt"), "2552440");
+                        ConfigurationService.SteamAPITrick28 = true;
+                    }
+                }
+            });
+            RemoveSteamAPIFile = new RelayCommand(_ =>
+            {
+                if (GameCollection == 0)
+                {
+                    if (File.Exists(Path.Combine(ConfigurationService.PcReleaseLocation, "steam_appid.txt")))
+                    {
+                        File.Delete(Path.Combine(ConfigurationService.PcReleaseLocation, "steam_appid.txt"));
+                        ConfigurationService.SteamAPITrick1525 = false;
+                    }
+                }
+                else if (GameCollection == 1)
+                {
+                    if (File.Exists(Path.Combine(ConfigurationService.PcReleaseLocationKH3D, "steam_appid.txt")))
+                    {
+                        File.Delete(Path.Combine(ConfigurationService.PcReleaseLocationKH3D, "steam_appid.txt"));
+                        ConfigurationService.SteamAPITrick28 = false;
+                    }
                 }
             });
         }

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -341,7 +341,7 @@
             Title="Install Lua Backend"
             Description="Lua Backend allows you to use Lua Scripts with the PC version of Kingdom Hearts."
             PreviousPage="{Binding PageStack.Back}"
-            NextPage="{Binding ElementName=PageGameData}">
+            NextPage="{Binding WizardPageAfterLuaBackend}">
             <StackPanel>
                 <TextBlock Margin="0 0 0 3">Game Collection</TextBlock>
                 <ComboBox Margin="0 0 0 6" SelectedIndex="{Binding GameCollection}">
@@ -369,6 +369,27 @@
                 If you wish to uninstall Lua Backend completely press the button below.
                 </TextBlock>
                 <Button Margin="0 0 0 6" Content="Uninstall Lua Backend" HorizontalAlignment="Left" Width="200" Command="{Binding RemoveLuaBackendCommand}" Visibility="{Binding LuaBackendFoundVisibility}"/>
+            </StackPanel>
+        </xctk:WizardPage>
+        <xctk:WizardPage
+            x:Name="PageSteamAPITrick"
+            PageType="Interior"
+            Title="Launch Games Directly (Steam)"
+            Description="Steam allows you to launch the exes directly through a one line text file located in the games install folder."
+            PreviousPage="{Binding PageStack.Back}"
+            NextPage="{Binding ElementName=PageGameData}">
+            <StackPanel>
+                <TextBlock Margin="0 0 0 3">Game Collection</TextBlock>
+                <ComboBox Margin="0 0 0 6" SelectedIndex="{Binding GameCollection}">
+                    <ComboBoxItem>KINGDOM HEARTS HD 1.5+2.5 ReMIX</ComboBoxItem>
+                    <ComboBoxItem>KINGDOM HEARTS HD 2.8 Final Chapter Prologue</ComboBoxItem>
+                </ComboBox>
+                <TextBlock Margin="0 0 0 3" TextWrapping="Wrap">
+                   <Run Foreground="Red">WARNING</Run>
+                    You must run the games first before creating this file otherwise the game will not boot. If you have installed it before running each game delete it using the delete button and run each game first.
+                </TextBlock>
+                <Button Margin="0 0 0 6" Content="Create steam_appid.txt" HorizontalAlignment="Left" Width="200" Command="{Binding InstallSteamAPIFile}"/>
+                <Button Margin="0 0 0 6" Content="Delete steam_appid.txt" HorizontalAlignment="Left" Width="200" Command="{Binding RemoveSteamAPIFile}"/>
             </StackPanel>
         </xctk:WizardPage>
         <xctk:WizardPage

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -386,7 +386,7 @@
                 </ComboBox>
                 <TextBlock Margin="0 0 0 3" TextWrapping="Wrap">
                    <Run Foreground="Red">WARNING</Run>
-                    You must run the games first before creating this file otherwise the game will not boot. If you have installed it before running each game delete it using the delete button and run each game first.
+                    Steam must be running otherwise the game will fail to start. It will start to open then crash for seemingly no reason. Make sure steam is open if using this.
                 </TextBlock>
                 <Button Margin="0 0 0 6" Content="Create steam_appid.txt" HorizontalAlignment="Left" Width="200" Command="{Binding InstallSteamAPIFile}"/>
                 <Button Margin="0 0 0 6" Content="Delete steam_appid.txt" HorizontalAlignment="Left" Width="200" Command="{Binding RemoveSteamAPIFile}"/>

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -388,8 +388,8 @@
                    <Run Foreground="Red">WARNING</Run>
                     Steam must be running otherwise the game will fail to start. It will start to open then crash for seemingly no reason. Make sure steam is open if using this.
                 </TextBlock>
-                <Button Margin="0 0 0 6" Content="Create steam_appid.txt" HorizontalAlignment="Left" Width="200" Command="{Binding InstallSteamAPIFile}"/>
-                <Button Margin="0 0 0 6" Content="Delete steam_appid.txt" HorizontalAlignment="Left" Width="200" Command="{Binding RemoveSteamAPIFile}"/>
+                <Button Margin="0 0 0 6" Content="Create steam__appid.txt" HorizontalAlignment="Left" Width="200" Command="{Binding InstallSteamAPIFile}"/>
+                <Button Margin="0 0 0 6" Content="Delete steam__appid.txt" HorizontalAlignment="Left" Width="200" Command="{Binding RemoveSteamAPIFile}"/>
             </StackPanel>
         </xctk:WizardPage>
         <xctk:WizardPage

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml.cs
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml.cs
@@ -22,6 +22,8 @@ namespace OpenKh.Tools.ModsManager.Views
             _vm.PageIsoSelection = PageIsoSelection;
             _vm.PageEosInstall = PageEosInstall;
             _vm.PageRegion = PageRegion;
+            _vm.PageGameData = PageGameData;
+            _vm.PageSteamAPITrick = PageSteamAPITrick;
             _vm.LastPage = LastPage;
 
             _vm.PageStack.OnPageChanged(wizard.CurrentPage);


### PR DESCRIPTION
Allow mod manager to launch each of the 5 supported games directly when using steam.
If the game is installed on steam and you make a text file in the game install folder named `steam_appid.txt` with the contents being the appid of the launcher you can launch the games exes directly.

contents of the 1.5 2.5 .txt

![image](https://github.com/user-attachments/assets/b0bc1647-c368-4fd1-a1b9-8b139c266a1e)

contents of the 2.8 .txt

![image](https://github.com/user-attachments/assets/e92db70c-ee1a-4f9e-9ab4-0bb7dc03aeec)


for any curious reader this does also work for 0.2 but it needs to be next to the 0.2 exe which is in a folder further down the heiarchy for my personal install its inh `D:\SteamLibrary\steamapps\common\KINGDOM HEARTS HD 2.8 Final Chapter Prologue\KINGDOM HEARTS 0.2 Birth by Sleep\Binaries\Win64` uses the same appid as the 2.8 one for DDD its just the 0.2's exe is in a different location