### PR TITLE
Fix using English Filepath when extracting Japanesse version and SteamAPITrick wizard page showing improperly

### DIFF
--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -478,7 +478,6 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     ConfigPcsx2Location = ConfigurationService.Pcsx2Location,
                     ConfigPcReleaseLocation = ConfigurationService.PcReleaseLocation,
                     ConfigPcReleaseLocationKH3D = ConfigurationService.PcReleaseLocationKH3D,
-                    ConfigPcReleaseLanguage = ConfigurationService.PcReleaseLanguage,
                     ConfigRegionId = ConfigurationService.RegionId,
                     ConfigPanaceaInstalled = ConfigurationService.PanaceaInstalled,
                 };

--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -200,8 +200,10 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 switch (ConfigurationService.PcReleaseLanguage)
                 {
                     case "jp":
+                        _pcReleaseLanguage = "jp";
                         return 1;
                     default:
+                        _pcReleaseLanguage = "en";
                         return 0;
                 }
             }
@@ -211,9 +213,11 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 {
                     case 1:
                         ConfigurationService.PcReleaseLanguage = "jp";
+                        _pcReleaseLanguage = "jp";
                         break;
                     default:
                         ConfigurationService.PcReleaseLanguage = "en";
+                        _pcReleaseLanguage = "en";
                         break;
                 }
             }
@@ -226,10 +230,13 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 switch (ConfigurationService.PCVersion)
                 {
                     case "Steam":
+                        WizardPageAfterLuaBackend = PageSteamAPITrick;
                         return 1;
                     case "Other":
+                        WizardPageAfterLuaBackend = PageGameData;
                         return 2;
                     default:
+                        WizardPageAfterLuaBackend = PageGameData;
                         return 0;
                 }
             }
@@ -240,21 +247,19 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     case 1:
                         _pcVersion = "Steam";
                         ConfigurationService.PCVersion = "Steam";
+                        WizardPageAfterLuaBackend = PageSteamAPITrick;
                         break;
                     case 2:
                         _pcVersion = "Other";
                         ConfigurationService.PCVersion = "Other";
+                        WizardPageAfterLuaBackend = PageGameData;
                         break;
                     default:
                         _pcVersion = "EGS";
                         ConfigurationService.PCVersion = "EGS";
+                        WizardPageAfterLuaBackend = PageGameData;
                         break;
                 }
-                WizardPageAfterLuaBackend = LaunchOption switch
-                {
-                    1 => PageSteamAPITrick,
-                    _ => PageGameData,
-                };
             }
         }
         public RelayCommand SelectOpenKhGameEngineCommand { get; }
@@ -494,21 +499,6 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 OnPropertyChanged(nameof(GameDataFoundVisibility));
             }
 
-        }
-        public string PcReleaseLanguage
-        {
-            get => _pcReleaseLanguage;
-            set
-            {
-                _pcReleaseLanguage = value;
-                OnPropertyChanged();
-                OnPropertyChanged(nameof(PcReleaseLanguage));
-                OnPropertyChanged(nameof(IsLastPanaceaVersionInstalled));
-                OnPropertyChanged(nameof(PanaceaInstalledVisibility));
-                OnPropertyChanged(nameof(PanaceaNotInstalledVisibility));
-                OnPropertyChanged(nameof(IsGameSelected));
-                OnPropertyChanged(nameof(IsGameDataFound));
-            }
         }
 
         public RelayCommand SelectGameDataLocationCommand { get; }

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml.cs
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml.cs
@@ -37,7 +37,6 @@ namespace OpenKh.Tools.ModsManager.Views
         public string ConfigPcsx2Location { get => _vm.Pcsx2Location; set => _vm.Pcsx2Location = value; }
         public string ConfigPcReleaseLocation { get => _vm.PcReleaseLocation; set => _vm.PcReleaseLocation = value; }
         public string ConfigPcReleaseLocationKH3D { get => _vm.PcReleaseLocationKH3D; set => _vm.PcReleaseLocationKH3D = value; }
-        public string ConfigPcReleaseLanguage { get => _vm.PcReleaseLanguage; set => _vm.PcReleaseLanguage = value; }
         public string ConfigGameDataLocation { get => _vm.GameDataLocation; set => _vm.GameDataLocation = value; }
         public int ConfigRegionId { get => _vm.RegionId; set => _vm.RegionId = value; }
         public bool ConfigPanaceaInstalled { get => _vm.PanaceaInstalled; set => _vm.PanaceaInstalled = value; }


### PR DESCRIPTION
Remove old `PcReleaseLanguage` in setup wizard for new `PCReleaseLanguage from my last PR.

This also fixes trying to extract from `en` instead of `jp` when Japanese EGS version is selected if user doesnt restart the setup wizard after selecting those options. Also fixes SteamAPITrick setup wizard page showing when steam is not selected.