### PR TITLE
Remove KH2 as default game to extract 

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -47,7 +47,7 @@ namespace OpenKh.Tools.ModsManager.Services
             public string pcVersion { get; internal set; } = "EGS";
             public bool steamAPITrick1525 {  get; internal set; } = false;
             public bool steamAPITrick28 { get; internal set; } = false;
-            public List<string> GamesToExtract { get; internal set; } = new List<string> { "kh2" };
+            public List<string> GamesToExtract { get; internal set; } = new List<string>();
             public bool SkipRemastered { get; internal set; } = false;
             public string LaunchGame { get; internal set; } = "kh2";
             public bool DarkMode { get; internal set; } = true;


### PR DESCRIPTION
 to fix mod manager from preventing people who only set up mod manager for KH3D from being able to extract game data since it tries to extract KH2