### PR TITLE
Remove dependency of `DotNetZip`.

### DIFF
--- a/OpenKh.Egs/OpenKh.Egs.csproj
+++ b/OpenKh.Egs/OpenKh.Egs.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetZip" Version="1.16.0" />
     <PackageReference Include="Xe.BinaryMapper" Version="1.5.2" />
   </ItemGroup>
 

--- a/OpenKh.Imaging/OpenKh.Imaging.csproj
+++ b/OpenKh.Imaging/OpenKh.Imaging.csproj
@@ -10,7 +10,7 @@
 
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="Crc32.NET" Version="1.2.0" />
-    <PackageReference Include="DotNetZip" Version="1.16.0" />
+    <PackageReference Include="Iconic.Zlib.Netstandard" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -12,9 +12,9 @@ using System.Windows;
 using Xe.Tools;
 using Xe.Tools.Wpf.Commands;
 using Xe.Tools.Wpf.Dialogs;
-using Ionic.Zip;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.IO.Compression;
 
 namespace OpenKh.Tools.ModsManager.ViewModels
 {
@@ -990,9 +990,9 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     _client.DownloadFile(new System.Uri(releases.Assets[0].BrowserDownloadUrl), DownPath);
                     try
                     {
-                        using (ZipFile zip = new ZipFile(DownPath))
+                        using (var zip = ZipFile.OpenRead(DownPath))
                         {
-                            zip.ExtractAll(TempExtractionLocation, ExtractExistingFileAction.OverwriteSilently);
+                            zip.ExtractToDirectory(TempExtractionLocation, true);
                         }
                     }
                     catch


### PR DESCRIPTION
Some developers reported about `DotNetZip` in community discord.
It is now deprecated (not updatable anymore) and they say it displays a vulnerable status on JetBrains Rider IDE.

[NuGet Gallery | DotNetZip 1.16.0](https://www.nuget.org/packages/DotNetZip)

![2024-12-28_18h31_20](https://github.com/user-attachments/assets/6120541b-9221-41a0-ab6e-0474ed5d055a)

Remove the `DotNetZip` dependency.

Zlib decompression is still needed for the PNG image decoder.
So import `Iconic.Zlib.Netstandard` and I'm going to resolve this situation.