### PR TITLE
Fix some YamlGenerator (ModsManager) inconvenience

### DIFF
--- a/OpenKh.Kh2/Messages/Internals/JapaneseEventDecode.cs
+++ b/OpenKh.Kh2/Messages/Internals/JapaneseEventDecode.cs
@@ -29,7 +29,7 @@ namespace OpenKh.Kh2.Messages.Internals
             [0x14] = new DataCmdModel(MessageCommand.Delay, 2),
             [0x15] = new DataCmdModel(MessageCommand.CharDelay, 2),
             [0x16] = new SingleDataCmdModel(MessageCommand.Unknown16),
-            [0x17] = null,
+            [0x17] = new DataCmdModel(MessageCommand.DelayAndFade, 2),
             [0x18] = new DataCmdModel(MessageCommand.Unknown18, 2),
             [0x19] = new TableCmdModel(MessageCommand.Table2, JapaneseEventTable._table2),
             [0x1a] = new TableCmdModel(MessageCommand.Table3, JapaneseEventTable._table3),

--- a/OpenKh.Kh2/Messages/Internals/JapaneseSystemDecode.cs
+++ b/OpenKh.Kh2/Messages/Internals/JapaneseSystemDecode.cs
@@ -29,7 +29,7 @@ namespace OpenKh.Kh2.Messages.Internals
             [0x14] = new DataCmdModel(MessageCommand.Delay, 2),
             [0x15] = new DataCmdModel(MessageCommand.CharDelay, 2),
             [0x16] = new SingleDataCmdModel(MessageCommand.Unknown16),
-            [0x17] = null,
+            [0x17] = new DataCmdModel(MessageCommand.DelayAndFade, 2),
             [0x18] = new DataCmdModel(MessageCommand.Unknown18, 2),
             [0x19] = new TableCmdModel(MessageCommand.Table2, JapaneseSystemTable._table2),
             [0x1a] = new TableCmdModel(MessageCommand.Table3, JapaneseSystemTable._table3),

--- a/OpenKh.Tools.ModsManager/ViewModels/ModViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/ModViewModel.cs
@@ -37,7 +37,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
             }
             else
             {
-                Author = _model.Metadata.OriginalAuthor;
+                Author = _model.Metadata?.OriginalAuthor;
                 Name = Source;
             }
 
@@ -131,7 +131,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         public string ReportBugUrl => $"https://github.com/{Source}/issues";
         public string FilesToPatch => string.Join('\n', GetFilesToPatch());
 
-        public string Description => _model.Metadata.Description;
+        public string Description => _model.Metadata?.Description;
 
         public string Homepage
         {
@@ -163,7 +163,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
 
         private IEnumerable<string> GetFilesToPatch()
         {
-            foreach (var asset in _model.Metadata.Assets)
+            foreach (var asset in _model.Metadata?.Assets ?? Enumerable.Empty<Patcher.AssetFile>())
             {
                 yield return asset.Name;
                 if (asset.Multi != null)

--- a/OpenKh.Tools.ModsManager/Views/YamlGeneratorWindow.xaml.cs
+++ b/OpenKh.Tools.ModsManager/Views/YamlGeneratorWindow.xaml.cs
@@ -62,11 +62,13 @@ namespace OpenKh.Tools.ModsManager.Views
                     ? await File.ReadAllBytesAsync(modYmlFilePath)
                     : null;
 
-                var createNewModYml = rawInput == null;
-
                 var mod = (rawInput != null)
                     ? Metadata.Read(new MemoryStream(rawInput, false))
                     : new Metadata();
+
+                var createNewModYml = mod == null;
+
+                mod ??= new Metadata(); // The empty yaml file brings null instance.
 
                 mod.Title ??= Path.GetFileName(Path.GetDirectoryName(modYmlFilePath));
                 mod.OriginalAuthor ??= "You";


### PR DESCRIPTION
Fix ModsManager crashes on startup when `mod.yml` is empty file.

Fix Generator of YamlGenerator fails due to null error, if mod.yml is an empty file.

Fix error `System.NotImplementedException: Command 17 not implemented yet` when trying to decode Japanese evt/sys messages.

Fix problems of ProvideExtractorsService:

- Remove redundant `await Task.Yield();`
- Valid file path to msg.yml is now set:
  ```
  - name: msg/jp/sys.bar
    method: binarc
    source:
    - name: sys
      method: kh2msg
      source:
      - name: msg/jp/sys_sys.yml
        language: jp
      type: list
  ```
- Japanese evt messages are now set to `je` like `language: je`:
  ```
  - name: msg/jp/al.bar
    method: binarc
    source:
    - name: sys
      method: kh2msg
      source:
      - name: msg/jp/al_al.yml
        language: je
      type: list
  ```
