### PR TITLE
Adding comments to entities around patching process and

### DIFF
--- a/OpenKh.Patcher/Metadata.cs
+++ b/OpenKh.Patcher/Metadata.cs
@@ -92,13 +92,95 @@ namespace OpenKh.Patcher
     public class AssetFile
     {
         [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)] public string Name { get; set; }
+
+        /// <summary>
+        /// "areadatascript"
+        /// "bdscript"
+        /// "binarc"
+        /// "copy"
+        /// "imgd"
+        /// "imgz"
+        /// "kh2msg"
+        /// "listpatch"
+        /// "spawnpoint"
+        /// "synthpatch"
+        /// </summary>
         [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)] public string Method { get; set; }
+
+        /// <summary>
+        /// null
+        /// ""
+        /// "both"
+        /// "pc"
+        /// "ps2"
+        /// </summary>
         [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)] public string Platform { get; set; }
+
+        /// <summary>
+        /// (null)
+        /// bbs_first
+        /// bbs_fourth
+        /// bbs_second
+        /// bbs_third
+        /// kh1_fifth
+        /// kh1_first
+        /// kh1_fourth
+        /// kh1_second
+        /// kh1_third
+        /// kh2_fifth
+        /// kh2_first
+        /// kh2_fourth
+        /// kh2_second
+        /// kh2_sixth
+        /// kh2_third
+        /// kh3d_first
+        /// kh3d_fourth
+        /// kh3d_second
+        /// kh3d_third
+        /// Recom
+        /// Theater
+        /// </summary>
         [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)] public string Package { get; set; }
         [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)] public List<Multi> Multi { get; set; }
         [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)] public List<AssetFile> Source { get; set; }
 
         [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)] public bool Required { get; set; }
+
+        /// <summary>
+        /// "areadatascript"
+        /// "areadataspawn"
+        /// "atkp"
+        /// "bdx"
+        /// "Binary"
+        /// "bons"
+        /// "cmd"
+        /// "condition"
+        /// "enmp"
+        /// "fmab"
+        /// "fmlv"
+        /// "imgd"
+        /// "imgz"
+        /// "internal"
+        /// "item"
+        /// "jigsaw"
+        /// "level"
+        /// "libretto"
+        /// "list"
+        /// "localset"
+        /// "lvup"
+        /// "magc"
+        /// "memt"
+        /// "objentry"
+        /// "place"
+        /// "plrp"
+        /// "przt"
+        /// "recipe"
+        /// "sklt"
+        /// "soundinfo"
+        /// "Synthesis"
+        /// "trsr"
+        /// "vtbl"
+        /// </summary>
         [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)] public string Type { get; set; }
         [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)] public Bar.MotionsetType MotionsetType { get; set; }
         [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)] public string Language { get; set; }

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -79,7 +79,23 @@ namespace OpenKh.Patcher
             "Recom",
         };
 
-        public void Patch(string originalAssets, string outputDir, Metadata metadata, string modBasePath, int platform = 1, bool fastMode = false, IDictionary<string, string> packageMap = null, string LaunchGame = null, string Language = "en", bool Tests = false)
+        /// <param name="platform">(GameEdition) 0=OpenKH, 1=PCSX2-EX, 2=PC</param>
+        /// <param name="fastMode">If true, always the first package file (kh1_first, bbs_first, kh2_first or such) is selected.</param>
+        /// <param name="Tests">If true, always invoke context.CopyOriginalFile</param>
+        /// <param name="LaunchGame">(GameId) "kh1", "kh2", "bbs", "Recom", "kh3d"</param>
+        /// <param name="Language">en, jp</param>
+        public void Patch(
+            string originalAssets,
+            string outputDir,
+            Metadata metadata,
+            string modBasePath,
+            int platform = 1,
+            bool fastMode = false,
+            IDictionary<string, string> packageMap = null,
+            string LaunchGame = null,
+            string Language = "en",
+            bool Tests = false
+        )
         {
 
             var context = new Context(metadata, originalAssets, modBasePath, outputDir);
@@ -90,6 +106,8 @@ namespace OpenKh.Patcher
                     throw new Exception("No assets found.");
                 if (metadata.Game != null && GamesList.Contains(metadata.Game.ToLower()) && metadata.Game.ToLower() != LaunchGame.ToLower())
                     return;
+
+                var exclusiveLock = new object();
 
                 metadata.Assets.AsParallel().ForAll(assetFile =>
                 {
@@ -175,7 +193,10 @@ namespace OpenKh.Patcher
                         if (packageMap != null && packageMapLocation.Length > 0)
                         {
                             // Protect against multiple mods having the same file where one uses forward slash and one uses backslash
-                            packageMap[name.Replace("\\", "/")] = packageMapLocation;
+                            lock (exclusiveLock)
+                            {
+                                packageMap[name.Replace("\\", "/")] = packageMapLocation;
+                            }
                         }
 
                         context.EnsureDirectoryExists(dstFile);
@@ -198,10 +219,34 @@ namespace OpenKh.Patcher
                             //If copying a file from the mod (NOT Type: internal) make sure it exists (doesnt check if the location its going normally exists) OR
                             //If copying a file from the users extraction (Type: internal) make sure it exists (doesnt check if the location its going normally exists) OR
                             //Ignore if its from a test
-                            if ((assetFile.Method != "copy" && assetFile.Method != "imd" && (File.Exists(context.GetOriginalAssetPath(assetFile.Name)) || multi)) ||
-                            ((assetFile.Method == "copy" || assetFile.Method == "imd") && assetFile.Source[0].Type != "internal" && File.Exists(context.GetSourceModAssetPath(assetFile.Source[0].Name))) ||
-                            ((assetFile.Method == "copy" || assetFile.Method == "imd") && assetFile.Source[0].Type == "internal" && (File.Exists(context.GetOriginalAssetPath(assetFile.Source[0].Name)) || multi)) ||
-                            Tests)
+
+                            var needToCopyOriginalFile =
+                                (false
+                                || (true
+                                    && assetFile.Method != "copy"
+                                    && assetFile.Method != "imd"
+                                    && (false
+                                        || File.Exists(context.GetOriginalAssetPath(assetFile.Name))
+                                        || multi
+                                    )
+                                )
+                                || (true
+                                    && (assetFile.Method == "copy" || assetFile.Method == "imd")
+                                    && assetFile.Source[0].Type != "internal"
+                                    && File.Exists(context.GetSourceModAssetPath(assetFile.Source[0].Name))
+                                )
+                                || (true
+                                    && (assetFile.Method == "copy" || assetFile.Method == "imd")
+                                    && assetFile.Source[0].Type == "internal"
+                                    && (false
+                                        || File.Exists(context.GetOriginalAssetPath(assetFile.Source[0].Name))
+                                        || multi
+                                    )
+                                )
+                                || Tests
+                                );
+
+                            if (needToCopyOriginalFile)
                             {
                                 context.CopyOriginalFile(name, dstFile);
 
@@ -213,6 +258,8 @@ namespace OpenKh.Patcher
                             }
                             else
                             {
+                                // The following codes are for validation purposes only.
+
                                 List<string> globalFilePaths = new List<string> { ".a.fr", ".a.gr", ".a.it", ".a.sp", ".a.us", "/fr/", "/gr/", "/it/", "/sp/", "/us/" };
                                 if (assetFile.Method != "copy" && assetFile.Method != "imd")
                                 {
@@ -222,12 +269,12 @@ namespace OpenKh.Patcher
                                         {
                                             if (!context.GetOriginalAssetPath(name).Contains(".a.fm") && !context.GetOriginalAssetPath(name).Contains("/jp/"))
                                             {
-                                            Log.Warn("File not found: " + context.GetOriginalAssetPath(name) + " Skipping. \nPlease check your game extraction.");
+                                                Log.Warn("File not found: " + context.GetOriginalAssetPath(name) + " Skipping. \nPlease check your game extraction.");
                                             }
                                         }
                                         else
                                         {
-                                            if (!globalFilePaths.Any(x=>context.GetOriginalAssetPath(name).Contains(x)))
+                                            if (!globalFilePaths.Any(x => context.GetOriginalAssetPath(name).Contains(x)))
                                             {
                                                 Log.Warn("File not found: " + context.GetOriginalAssetPath(name) + " Skipping. \nPlease check your game extraction.");
                                             }


### PR DESCRIPTION
Adding comments to entities around the patching process.

Adding an `exclusiveLock` to `PatcherProcessor.Patch` so that it can accept any writable IDictionary (non-ConcurrentDictionary) instance.