### PR TITLE
[KH2 Object Editor] Add "Export all as PNG" & adjusted DPD texture order display

### DIFF
--- a/OpenKh.Kh2/Dpd.Texture.cs
+++ b/OpenKh.Kh2/Dpd.Texture.cs
@@ -13,8 +13,8 @@ namespace OpenKh.Kh2
             public short shCltDbp;
             private short shDbw;
             public short format; //shDpsm; 0x13 => 8bpp + 256 palette; 0x14 => 4bpp + 16 palette
-            private short shX;
-            private short shY;
+            public short shX;
+            public short shY;
             private short width;
             private short height;
             public uint unTex0L;

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdTexture_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdTexture_Control.xaml
@@ -10,7 +10,7 @@
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="auto" />
-            <ColumnDefinition Width="100" />
+            <ColumnDefinition Width="160" />
         </Grid.ColumnDefinitions>
 
         <Canvas Grid.Row="0">

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdTexture_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdTexture_Control.xaml
@@ -34,6 +34,7 @@
             <ListView.ContextMenu>
                 <ContextMenu>
                     <MenuItem Header="Export as PNG" Click="EffectImage_Export"/>
+                    <MenuItem Header="Export all as PNG" Click="EffectImage_ExportAll"/>
                     <MenuItem Header="Replace with PNG" Click="EffectImage_Replace"/>
                 </ContextMenu>
             </ListView.ContextMenu>

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdTexture_Control.xaml.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdTexture_Control.xaml.cs
@@ -40,7 +40,12 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Effects
                 ThisVM.ExportTexture(List_Textures.SelectedIndex);
             }
         }
-
+        
+        public void EffectImage_ExportAll(object sender, RoutedEventArgs e)
+        {
+            ThisVM.ExportAllTextures();
+        }
+        
         public void EffectImage_Replace(object sender, RoutedEventArgs e)
         {
             if (List_Textures.SelectedItem != null)

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdTexture_VM.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdTexture_VM.cs
@@ -28,26 +28,40 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Effects
 
             TextureWrappers.Clear();
 
-            // Sort textures based on shTexDbp
-            var sortedTextures = ThisDpd.TexturesList
+            // Group textures by their shTexDbp value
+            var groupedTextures = ThisDpd.TexturesList
                 .Select((texture, index) => new DpdTextureWrapper
                 {
                     Id = index,
-                    Name = $"Texture {index} (ORDER: 0x{texture.shTexDbp:X})",
                     Texture = texture,
                     SizeX = texture.Size.Width,
-                    SizeY = texture.Size.Height
+                    SizeY = texture.Size.Height,
                 })
-                .OrderBy(wrapper => wrapper.Texture.shTexDbp) // Sort by shTexDbp in ascending order
+                .GroupBy(wrapper => wrapper.Texture.shTexDbp)  // Group by shTexDbp value
+                .OrderBy(group => group.Key)  // Optional: sort groups by shTexDbp (ascending)
                 .ToList();
 
-            // Add each sorted wrapper to the ObservableCollection
-            foreach (var wrapper in sortedTextures)
+            // Now process each group and update the name accordingly
+            foreach (var group in groupedTextures)
             {
-                TextureWrappers.Add(wrapper);
+                var firstWrapper = group.First();  // Get the first texture in the group
+
+                foreach (var wrapper in group)
+                {
+                    // If it's the first texture, keep its original name
+                    if (wrapper.Id == firstWrapper.Id)
+                    {
+                        wrapper.Name = $"Texture {wrapper.Id}";
+                    }
+                    else
+                    {
+                        // For the rest of the textures, mark them as "COMBO with {firstWrapper.Id}"
+                        wrapper.Name = $"Texture {wrapper.Id} (COMBO with {firstWrapper.Id})";
+                    }
+                    TextureWrappers.Add(wrapper);
+                }
             }
         }
-
 
         public BitmapSource getTexture(int index)
         {

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdTexture_VM.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdTexture_VM.cs
@@ -23,22 +23,31 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Effects
 
         public void loadWrappers()
         {
-            if (ThisDpd?.TexturesList == null || ThisDpd.TexturesList.Count < 0)
+            if (ThisDpd?.TexturesList == null || ThisDpd.TexturesList.Count <= 0)
                 return;
 
             TextureWrappers.Clear();
-            for (int i = 0; i < ThisDpd.TexturesList.Count; i++)
-            {
-                DpdTextureWrapper wrapper = new DpdTextureWrapper();
-                wrapper.Id = i;
-                wrapper.Name = "Texture " + i;
-                wrapper.Texture = ThisDpd.TexturesList[i];
-                wrapper.SizeX = wrapper.Texture.Size.Width;
-                wrapper.SizeY = wrapper.Texture.Size.Height;
 
+            // Sort textures based on shTexDbp
+            var sortedTextures = ThisDpd.TexturesList
+                .Select((texture, index) => new DpdTextureWrapper
+                {
+                    Id = index,
+                    Name = $"Texture {index} (ORDER: 0x{texture.shTexDbp:X})",
+                    Texture = texture,
+                    SizeX = texture.Size.Width,
+                    SizeY = texture.Size.Height
+                })
+                .OrderBy(wrapper => wrapper.Texture.shTexDbp) // Sort by shTexDbp in ascending order
+                .ToList();
+
+            // Add each sorted wrapper to the ObservableCollection
+            foreach (var wrapper in sortedTextures)
+            {
                 TextureWrappers.Add(wrapper);
             }
         }
+
 
         public BitmapSource getTexture(int index)
         {

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdTexture_VM.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdTexture_VM.cs
@@ -95,6 +95,35 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Effects
             }
         }
 
+        public void ExportAllTextures()
+        {
+            if (TextureWrappers == null || TextureWrappers.Count == 0)
+            {
+                System.Windows.Forms.MessageBox.Show("No textures to export.", "Export Error",
+                    System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Warning);
+                return;
+            }
+
+            System.Windows.Forms.FolderBrowserDialog fbd = new System.Windows.Forms.FolderBrowserDialog();
+            fbd.Description = "Select folder to export all textures";
+            if (fbd.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+            {
+                string exportPath = fbd.SelectedPath;
+
+                for (int i = 0; i < TextureWrappers.Count; i++)
+                {
+                    Dpd.Texture texture = TextureWrappers[i].Texture;
+                    MtMaterial mat = GetMaterial(texture);
+
+                    string filePath = System.IO.Path.Combine(exportPath, $"Effect_{i}.png");
+                    mat.ExportAsPng(filePath);
+                }
+
+                System.Windows.Forms.MessageBox.Show("All textures exported successfully!", "Export Complete",
+                    System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Information);
+            }
+        }
+        
         // Must have the same width and height and palette size
         public void ReplaceTexture(int index)
         {

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdTexture_VM.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdTexture_VM.cs
@@ -1,6 +1,7 @@
 using ModelingToolkit.Objects;
 using OpenKh.Kh2;
 using System;
+using System.Linq;
 using System.Collections.ObjectModel;
 using System.Drawing;
 using System.Windows.Forms;

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdTexture_VM.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdTexture_VM.cs
@@ -1,9 +1,10 @@
 using ModelingToolkit.Objects;
 using OpenKh.Kh2;
 using System;
-using System.Linq;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Drawing;
+using System.Linq;
 using System.Windows.Forms;
 using System.Windows.Media.Imaging;
 
@@ -66,10 +67,70 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Effects
 
         public BitmapSource getTexture(int index)
         {
-            Dpd.Texture texture = TextureWrappers[index].Texture;
+            var group = TextureWrappers
+                .Where(t => t.Texture.shTexDbp == TextureWrappers[index].Texture.shTexDbp)
+                .ToList();
 
-            MtMaterial mat = GetMaterial(texture);
-            return mat.GetAsBitmapImage();
+            if (group.Count == 1)
+            {
+                //if only one texture in the group, return as normal
+                MtMaterial mat = GetMaterial(group[0].Texture);
+                return mat.GetAsBitmapImage();
+            }
+
+            //get max width/height for combo texture
+            int maxWidth = group.Max(t => t.SizeX + t.Texture.shX);
+            int maxHeight = group.Max(t => t.SizeY + t.Texture.shY);
+
+            //blank bitmap for combined image
+            Bitmap combinedBitmap = new Bitmap(maxWidth, maxHeight);
+            using (Graphics g = Graphics.FromImage(combinedBitmap))
+            {
+                g.Clear(System.Drawing.Color.Transparent);
+
+                //adjust each texture position based on shX and shY values
+                foreach (var wrapper in group)
+                {
+                    MtMaterial mat = GetMaterial(wrapper.Texture);
+                    Bitmap img = mat.DiffuseTextureBitmap;
+                    g.DrawImage(img, wrapper.Texture.shX, wrapper.Texture.shY);
+                }
+            }
+
+            //new bitmap to include individual texture at the top, and a combined view below.
+            int individualHeight = group.Max(t => t.SizeY);
+            int combinedHeight = maxHeight + individualHeight + 64;  //64px space between textures
+
+            //make final bitmap
+            Bitmap finalBitmap = new Bitmap(maxWidth, combinedHeight);
+            using (Graphics g = Graphics.FromImage(finalBitmap))
+            {
+                g.Clear(System.Drawing.Color.Transparent);
+
+                //draw individual texture above
+                var selectedTextureWrapper = group.FirstOrDefault(t => t == TextureWrappers[index]);
+
+
+                //get material for final texture
+                MtMaterial selectedMat = GetMaterial(selectedTextureWrapper.Texture);
+                Bitmap selectedImg = selectedMat.DiffuseTextureBitmap;
+
+
+                //now draw the individual texture
+                g.DrawImage(selectedImg, selectedTextureWrapper.Texture.shX, selectedTextureWrapper.Texture.shY);
+
+                //prepare the combined texture
+                int offsetY = individualHeight + 64;  //offset it 64px down
+
+                g.DrawImage(combinedBitmap, 0, offsetY);
+            }
+
+            return System.Windows.Interop.Imaging.CreateBitmapSourceFromHBitmap(
+                finalBitmap.GetHbitmap(),
+                IntPtr.Zero,
+                System.Windows.Int32Rect.Empty,
+                BitmapSizeOptions.FromEmptyOptions()
+            );
         }
 
         public static byte SwapBits34(byte x)
@@ -82,18 +143,77 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Effects
 
         public void ExportTexture(int index)
         {
+            Dpd.Texture selectedTexture = TextureWrappers[index].Texture;
+
+            //find all textures with the same shTexDbp
+            var groupedTextures = TextureWrappers
+                .Where(wrapper => wrapper.Texture.shTexDbp == selectedTexture.shTexDbp)
+                .OrderBy(wrapper => wrapper.Id)
+                .ToList();
+
+            if (groupedTextures.Count == 1)
+            {
+                //if single texture, export normally
+                ExportSingleTexture(index);
+                return;
+            }
+
+            //prompt export path
+            System.Windows.Forms.FolderBrowserDialog fbd = new System.Windows.Forms.FolderBrowserDialog();
+            fbd.Description = "Select folder to export combined textures";
+            if (fbd.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+            {
+                string exportPath = fbd.SelectedPath;
+                ExportCombinedTexture(groupedTextures, exportPath);
+            }
+        }
+
+
+        private void ExportSingleTexture(int index)
+        {
             Dpd.Texture texture = TextureWrappers[index].Texture;
             MtMaterial mat = GetMaterial(texture);
 
-            System.Windows.Forms.SaveFileDialog sfd;
-            sfd = new System.Windows.Forms.SaveFileDialog();
-            sfd.Title = "Export image as PNG";
-            sfd.FileName = "Effect_" + index + ".png";
-            sfd.ShowDialog();
-            if (sfd.FileName != "")
+            SaveFileDialog sfd = new SaveFileDialog
+            {
+                Title = "Export image as PNG",
+                FileName = $"Effect_{index}.png",
+                Filter = "PNG Files|*.png"
+            };
+
+            if (sfd.ShowDialog() == DialogResult.OK)
             {
                 mat.ExportAsPng(sfd.FileName);
             }
+        }
+
+        private void ExportCombinedTexture(List<DpdTextureWrapper> groupedTextures, string exportPath)
+        {
+            //get max width and height based on shX, shY, SizeX, & SizeY
+            int maxWidth = groupedTextures.Max(wrapper => wrapper.Texture.shX + wrapper.SizeX);
+            int maxHeight = groupedTextures.Max(wrapper => wrapper.Texture.shY + wrapper.SizeY);
+
+            //crete a new combined image
+            Bitmap combinedBitmap = new Bitmap(maxWidth, maxHeight);
+            using (Graphics g = Graphics.FromImage(combinedBitmap))
+            {
+                g.Clear(System.Drawing.Color.Transparent); //transparent background
+
+                //draw each texture in its correct position using shX and shY as coordinates
+                foreach (var wrapper in groupedTextures)
+                {
+                    MtMaterial mat = GetMaterial(wrapper.Texture);
+                    Bitmap textureBitmap = mat.DiffuseTextureBitmap;
+
+                    //draw the texture at the appropriate position based on its shX, shY
+                    g.DrawImage(textureBitmap, wrapper.Texture.shX, wrapper.Texture.shY);
+                }
+            }
+
+            //generate a file name based on the shTexDbp value
+            string fileName = $"Effect_Combined_{groupedTextures.First().Texture.shTexDbp}.png";
+            string filePath = System.IO.Path.Combine(exportPath, fileName);
+            combinedBitmap.Save(filePath, System.Drawing.Imaging.ImageFormat.Png);
         }
 
         public void ExportAllTextures()
@@ -111,13 +231,14 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Effects
             {
                 string exportPath = fbd.SelectedPath;
 
-                for (int i = 0; i < TextureWrappers.Count; i++)
-                {
-                    Dpd.Texture texture = TextureWrappers[i].Texture;
-                    MtMaterial mat = GetMaterial(texture);
+                //group textures by shTexDbp value
+                var groupedTextures = TextureWrappers
+                    .GroupBy(wrapper => wrapper.Texture.shTexDbp)
+                    .ToList();
 
-                    string filePath = System.IO.Path.Combine(exportPath, $"Effect_{i}.png");
-                    mat.ExportAsPng(filePath);
+                foreach (var group in groupedTextures)
+                {
+                    ExportCombinedTexture(group.ToList(), exportPath);
                 }
 
                 System.Windows.Forms.MessageBox.Show("All textures exported successfully!", "Export Complete",


### PR DESCRIPTION
To coincide with #1151, DPD textures will now be displayed in the order they're meant to be ordered in-game, and will denote when they're part of a combo-texture like so:

![image](https://github.com/user-attachments/assets/75ef1183-519b-4a54-9fb5-009ef9a930a4)
