### PR TITLE
[Mapgen] Add "disableBSPCollisionBuilder2" option for mapdef.yml

### DIFF
--- a/OpenKh.Command.MapGen/Models/MapGenConfig.cs
+++ b/OpenKh.Command.MapGen/Models/MapGenConfig.cs
@@ -69,6 +69,8 @@ namespace OpenKh.Command.MapGen.Models
 
         public bool disableBSPCollisionBuilder { get; set; }
 
+        public bool disableBSPCollisionBuilder2 { get; set; }
+
         public byte? maxColorIntensity { get; set; }
 
         public byte? maxAlpha { get; set; }

--- a/OpenKh.Command.MapGen/Models/MaterialDef.cs
+++ b/OpenKh.Command.MapGen/Models/MaterialDef.cs
@@ -84,6 +84,11 @@ namespace OpenKh.Command.MapGen.Models
         public byte floorLevel { get; set; }
 
         /// <summary>
+        /// Group value for Collision. Used with MapVisibility to turn on/off map meshes and collision.
+        /// </summary>
+        public byte group { get; set; }
+        
+        /// <summary>
         /// Collision.Attributes for camera collision. Still unknown. Such as 0x000003F0
         /// </summary>
         public int cameraFlags { get; set; }

--- a/OpenKh.Command.MapGen/Utils/FlattenCollisionBuilderAlt.cs
+++ b/OpenKh.Command.MapGen/Utils/FlattenCollisionBuilderAlt.cs
@@ -1,0 +1,101 @@
+using Assimp;
+using OpenKh.Command.MapGen.Interfaces;
+using OpenKh.Command.MapGen.Models;
+using OpenKh.Kh2;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+using static OpenKh.Kh2.Coct;
+
+//Alternate version of FlattenCollisionBuilder. 
+//Allows specifying faces as their own Group Numbers so that ARDs can hide/show specific collision.
+//Hackily implemented for now as an alternative option, because it can increase collision filesizes by ~1.5x due to each face becoming its own "mesh."
+namespace OpenKh.Command.MapGen.Utils
+{
+    public class FlattenCollisionBuilderAlt : ICollisionBuilder
+    {
+        private readonly Coct coct = new Coct();
+        private bool isValid = false;
+
+        public CollisionBuilt GetBuilt() => new CollisionBuilt
+        {
+            Coct = coct,
+            IsValid = isValid,
+        };
+
+        public FlattenCollisionBuilderAlt(
+            ISpatialNodeCutter cutter,
+            Func<MaterialDef, int> getAttributeFrom
+        )
+        {
+            var faces = cutter.Faces;
+            var helper = new Coct.BuildHelper(coct);
+
+            var collisionNode = new CollisionNode
+            {
+                Meshes = new List<CollisionMesh>(),
+            };
+
+            if (faces.Any())
+            {
+                isValid = true;
+
+                foreach (var face in faces)
+                {
+                    var matDef = face.matDef; // Access MaterialDef from the face
+
+                    if (matDef == null)
+                        continue; // Skip faces with no material definition
+
+                    var group = matDef.group;
+
+                    var collisionMesh = new CollisionMesh
+                    {
+                        Collisions = new List<Collision>(),
+                        Group = group
+                    };
+
+                    if (face.positionList.Length >= 3)
+                    {
+                        var v1 = face.positionList[0];
+                        var v2 = face.positionList[1];
+                        var v3 = face.positionList[2];
+                        var isQuad = face.positionList.Length == 4;
+
+                        var collision = coct.Complete(
+                            new Collision
+                            {
+                                Vertex1 = helper.AllocateVertex(v1.X, -v1.Y, -v1.Z),
+                                Vertex2 = helper.AllocateVertex(v2.X, -v2.Y, -v2.Z),
+                                Vertex3 = helper.AllocateVertex(v3.X, -v3.Y, -v3.Z),
+                                Vertex4 = Convert.ToInt16(isQuad ? helper.AllocateVertex(face.positionList[3].X, -face.positionList[3].Y, -face.positionList[3].Z) : -1),
+                                Attributes = new Attributes() { Flags = getAttributeFrom(matDef) },
+                                Ground = matDef.ground,
+                                FloorLevel = matDef.floorLevel,
+                            },
+                            inflate: 1
+                        );
+
+                        // Check for invalid plane (3 points are on the same line)
+                        if (!float.IsNaN(collision.Plane.D))
+                        {
+                            collisionMesh.Collisions.Add(collision);
+                        }
+                    }
+
+                    if (collisionMesh.Collisions.Any())
+                    {
+                        coct.Complete(collisionMesh);
+                        collisionNode.Meshes.Add(collisionMesh);
+                    }
+                }
+            }
+
+            coct.Nodes.Add(collisionNode);
+            helper.CompleteBBox(collisionNode);
+        }
+    }
+}

--- a/OpenKh.Command.MapGen/Utils/MapBuilder.cs
+++ b/OpenKh.Command.MapGen/Utils/MapBuilder.cs
@@ -722,7 +722,7 @@ namespace OpenKh.Command.MapGen.Utils
                     break;
                 }
                 default:
-                    throw new NotSupportedException();
+                    throw new NotSupportedException("ERROR! Non-triangulated mesh detected! Try triangulating your mesh and re-attempting.");
             }
         }
 

--- a/OpenKh.Command.MapGen/Utils/MapBuilder.cs
+++ b/OpenKh.Command.MapGen/Utils/MapBuilder.cs
@@ -66,6 +66,23 @@ namespace OpenKh.Command.MapGen.Utils
                 )
                     .GetBuilt();
             }
+            else if (config.disableBSPCollisionBuilder2)
+            {
+                logger.Debug($"Running flatten doct builder.");
+
+                doctBuilt = new FlattenDoctBuilder(
+                    new BSPNodeSplitter(
+                        singleFaces
+                            .Where(it => !it.matDef.nodraw),
+                        new BSPNodeSplitter.Option
+                        {
+                            PartitionSize = config.doctPartitionSize,
+                        }
+                    ),
+                    matDef => 0
+                )
+                    .GetBuilt();
+            }
             else
             {
                 logger.Debug($"Running hierarchical doct builder.");

--- a/docs/tool/CLI.MapGen/index.md
+++ b/docs/tool/CLI.MapGen/index.md
@@ -17,11 +17,13 @@ TOC
   - [uvscList](#uvsclist)
   - [disableTriangleStripsOptimization](#disabletrianglestripsoptimization)
   - [disableBSPCollisionBuilder](#disablebspcollisionbuilder)
+  - [disableBSPCollisionBuilder2](#disablebspcollisionbuilder2)
   - [ignore](#ignore)
   - [nodraw](#nodraw)
   - [noclip](#noclip)
   - [fromFile](#fromfile)
   - [surfaceFlags](#surfaceflags)
+  - [group](#group)
   - [maxColorIntensity](#maxcolorintensity)
   - [maxAlpha](#maxalpha)
   - [transparentFlag](#transparentflag)
@@ -230,6 +232,13 @@ disableTriangleStripsOptimization: true
 disableBSPCollisionBuilder: true
 ```
 
+### disableBSPCollisionBuilder2
+
+```yml
+# Alternate version of Disable BSP collision builder. Splits faces into their own mesh.
+disableBSPCollisionBuilder2: true
+```
+
 ### ignore
 
 ```yml
@@ -304,6 +313,17 @@ Hit_RTN: 0x8
 Nohit_Floor: 0x10
 Unk: 0x20, 0x40, 0x60, 0x80, 0xA0, 0xC0, 0xE0, 0x100, 0x120, 0x140, 0x160
 ```
+
+### group
+```yml
+# Specify `group` to this material.
+# Only usable on collision meshes, when using the disableBSPCollisionBuilder2 option.
+# When used, this will assign a group value to faces with this material.
+# This can turn the collision on or off depending on the value used for MapVisibility in the ARD.
+- name: 'floor'
+  group: 1
+```
+
 
 ### maxColorIntensity
 


### PR DESCRIPTION
This adds an alternate type of collision builder, based on FlattenCollisionBuilder. When used, this will split the generated collision in the collisionMesh part of the COCT so that each face becomes its own mesh. Then, you can choose to assign specific faces to a material and under the materials section, you can assign these faces a `group` value, so that this collision can be toggled on and off in-game using the MapVisibility command inside the ARD. This is how the game makes temporary barriers for forced fights.

Example of its usage:

```
disableBSPCollisionBuilder2: true

materials:
- name: 'Wall' #Wall (COLLISION)
  ground: 0
  surfaceFlags: 0x811
  group: 3
```