### PR TITLE
[ModManager] Add "InsertBefore" and "InsertAfter" tags for item listpatching

### DIFF
--- a/OpenKh.Kh2/SystemData/Item.cs
+++ b/OpenKh.Kh2/SystemData/Item.cs
@@ -59,6 +59,7 @@ namespace OpenKh.Kh2.SystemData
             [Data] public short Picture { get; set; }
             [Data] public byte Icon1 { get; set; }
             [Data] public byte Icon2 { get; set; }
+            public ushort InsertBefore { get; set; } = 0; // Default to 0, meaning append. Only used for Mod Manager.
         }
 
         public class Stat

--- a/OpenKh.Kh2/SystemData/Item.cs
+++ b/OpenKh.Kh2/SystemData/Item.cs
@@ -60,6 +60,7 @@ namespace OpenKh.Kh2.SystemData
             [Data] public byte Icon1 { get; set; }
             [Data] public byte Icon2 { get; set; }
             public ushort InsertBefore { get; set; } = 0; // Default to 0, meaning append. Only used for Mod Manager.
+            public ushort InsertAfter {get; set; } = 0;
         }
 
         public class Stat

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -701,22 +701,27 @@ namespace OpenKh.Patcher
                                 }
                                 else
                                 {
-                                    if (item.InsertBefore == 0) // Default case, append
-                                    {
-                                        itemList.Items.Add(item);
-                                    }
-                                    else
+                                    if (item.InsertBefore != 0) // Prioritize InsertBefore
                                     {
                                         var index = itemList.Items.FindIndex(x => x.Id == item.InsertBefore);
                                         if (index >= 0)
                                         {
                                             itemList.Items.Insert(index, item);
-                                        }
-                                        else
-                                        {
-                                            itemList.Items.Add(item); // If not found, append
+                                            continue;
                                         }
                                     }
+                                    else if (item.InsertAfter != 0) // If InsertBefore not set, check InsertAfter
+                                    {
+                                        var index = itemList.Items.FindIndex(x => x.Id == item.InsertAfter);
+                                        if (index >= 0)
+                                        {
+                                            itemList.Items.Insert(index + 1, item);
+                                            continue;
+                                        }
+                                    }
+
+                                    // Default case: append
+                                    itemList.Items.Add(item);
                                 }
                             }
                         }

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -689,6 +689,7 @@ namespace OpenKh.Patcher
                     case "item":
                         var itemList = Kh2.SystemData.Item.Read(stream);
                         var moddedItem = deserializer.Deserialize<Kh2.SystemData.Item>(sourceText);
+
                         if (moddedItem.Items != null)
                         {
                             foreach (var item in moddedItem.Items)
@@ -700,10 +701,26 @@ namespace OpenKh.Patcher
                                 }
                                 else
                                 {
-                                    itemList.Items.Add(item);
+                                    if (item.InsertBefore == 0) // Default case, append
+                                    {
+                                        itemList.Items.Add(item);
+                                    }
+                                    else
+                                    {
+                                        var index = itemList.Items.FindIndex(x => x.Id == item.InsertBefore);
+                                        if (index >= 0)
+                                        {
+                                            itemList.Items.Insert(index, item);
+                                        }
+                                        else
+                                        {
+                                            itemList.Items.Add(item); // If not found, append
+                                        }
+                                    }
                                 }
                             }
                         }
+
                         if (moddedItem.Stats != null)
                         {
                             foreach (var item in moddedItem.Stats)
@@ -719,6 +736,7 @@ namespace OpenKh.Patcher
                                 }
                             }
                         }
+
                         itemList.Write(stream.SetPosition(0));
                         break;
 

--- a/docs/tool/GUI.ModsManager/creatingMods.md
+++ b/docs/tool/GUI.ModsManager/creatingMods.md
@@ -315,6 +315,12 @@ Asset Example
     source:
       - name: FmlvList.yml
         type: fmlv
+  - name: atkp
+    method: listpatch
+    type: List
+    source:
+      - name: AtkpList.yml
+        type: atkp
 ```
 
 ### `trsr` Source Example

--- a/docs/tool/GUI.ModsManager/creatingMods.md
+++ b/docs/tool/GUI.ModsManager/creatingMods.md
@@ -382,6 +382,7 @@ Items:
   Picture: 1
   Icon1: 9
   Icon2: 0
+  InsertBefore: 7 #This will insert the item ID before the item ID you specify here. Defaults to 0, which will append to the item list instead. You can alternatively use InsertAfter. 
 ```
 ### `sklt` Source Example
 ```


### PR DESCRIPTION
Addresses #1129.

Adds "InsertBefore" and "InsertAfter" tags that can be used in item listpatching. This tag is set to 0 by default, and if not included in a YML, files will simply append to the end like before, maintaining backwards compatibility with current mods.

Example of usage:
````Items:
- Id: 9999
  Type: Consumable
  Flag0: 0
  Flag1: 40
  Rank: C
  StatEntry: 1
  Name: 33528
  Description: 33529
  ShopBuy: 40
  ShopSell: 10
  Command: 23
  Slot: 0
  Picture: 1
  Icon1: 9
  Icon2: 0
  InsertBefore: 7
- Id: 10000
  Type: Consumable
  Flag0: 0
  Flag1: 40
  Rank: C
  StatEntry: 1
  Name: 33528
  Description: 33529
  ShopBuy: 40
  ShopSell: 10
  Command: 23
  Slot: 0
  Picture: 1
  Icon1: 9
  Icon2: 0
  InsertBefore: 9999
- Id: 10001
  Type: Consumable
  Flag0: 0
  Flag1: 40
  Rank: C
  StatEntry: 1
  Name: 33528
  Description: 33529
  ShopBuy: 40
  ShopSell: 10
  Command: 23
  Slot: 0
  Picture: 1
  Icon1: 9
  Icon2: 0
  InsertAfter: 7
````


This will insert Item ID 9999 directly before Item ID 7, Item ID 10000 will be inserted directly before 9999, and Item ID 10001 will be inserted directly after 7. Otherwise if an item ID can't be found, it will default to appending.