### PR TITLE
[Mod Manager] Adjust objentry listpatching

### DIFF
--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -862,19 +862,18 @@ namespace OpenKh.Patcher
                     case "objentry":
                         var objEntryList = Kh2.Objentry.Read(stream).ToDictionary(x => x.ObjectId, x => x);
                         var moddedObjEntry = deserializer.Deserialize<Dictionary<uint, Kh2.Objentry>>(sourceText);
+
                         foreach (var objEntry in moddedObjEntry)
                         {
-                            if (objEntryList.ContainsKey(objEntry.Key))
-                            {
-                                objEntryList[objEntry.Key] = objEntry.Value;
-                            }
-                            else
-                            {
-                                objEntryList.Add(objEntry.Key, objEntry.Value);
-                            }
+                            objEntryList[objEntry.Key] = objEntry.Value; // Add or overwrite
                         }
-                        Kh2.Objentry.Write(stream.SetPosition(0), objEntryList.Values);
+
+                        // Sort final list by ObjId before writing
+                        var sortedEntries = objEntryList.Values.OrderBy(x => x.ObjectId).ToList();
+
+                        Kh2.Objentry.Write(stream.SetPosition(0), sortedEntries);
                         break;
+
 
                     case "plrp":
                         var plrpList = Kh2.Battle.Plrp.Read(stream);


### PR DESCRIPTION
Small tweak to objentry listpatching to sort newly added entries by ID before then patching them in. 

The game requires entries in objentry to be in numerical order, and will refuse to load in entries that don't adhere to this order.
Example being, Mod A listpatches an ID of 5000, and Mod B listpatches an ID of 4562.

If Mod A has lower priority than Mod B, then ID 5000 would be appended to objentry first, followed by the id of 4562. This means that any ObjID's lower than 5000 that get built after Mod A would fail to load in-game. In order for these two mods to work together, Mod A would need to be placed at a higher priority than Mod B.

Sorting by IDs first fixes this issue, as regardless of order, 4562 would be appended first, followed by 5000.

