### PR TITLE
Remove prerelease status from releases.

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -59,7 +59,6 @@ jobs:
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "latest"
-        prerelease: true
         title: "OpenKh Latest Build"
         files: |
           openkh.zip
@@ -70,7 +69,6 @@ jobs:
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "release2-${{github.run_number}}"
-        prerelease: true
         title: "OpenKh Build ${{github.run_number}} (${{github.ref_name}})"
         files: |
           openkh.zip


### PR DESCRIPTION
This way the GitHub API will return a response when querying for latest tag.