### PR TITLE
Add support for Github multi game collections

### DIFF
--- a/OpenKh.Patcher/Metadata.cs
+++ b/OpenKh.Patcher/Metadata.cs
@@ -22,6 +22,8 @@ namespace OpenKh.Patcher
         [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)] public string Game { get; set; }
         [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)] public int Specifications { get; set; }
         public List<Dependency> Dependencies { get; set; }
+        [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)] public bool IsCollection { get; set; }
+        [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)] public List<string> CollectionGames { get; set; }
         public List<AssetFile> Assets { get; set; }
 
         private static readonly IDeserializer deserializer =
@@ -186,6 +188,7 @@ namespace OpenKh.Patcher
         [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)] public string Language { get; set; }
         [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)] public bool IsSwizzled { get; set; }
         [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)] public int Index { get; set; }
+        [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)] public string Game { get; set; }
     }
 
     public class Multi

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -106,11 +106,15 @@ namespace OpenKh.Patcher
                     throw new Exception("No assets found.");
                 if (metadata.Game != null && GamesList.Contains(metadata.Game.ToLower()) && metadata.Game.ToLower() != LaunchGame.ToLower())
                     return;
+                if (metadata.IsCollection && !metadata.CollectionGames.Contains(LaunchGame))
+                    return;
 
                 var exclusiveLock = new object();
 
                 metadata.Assets.AsParallel().ForAll(assetFile =>
                 {
+                    if (assetFile.Game != null && assetFile.Game != LaunchGame)
+                        return;
                     var names = new List<string>();
                     names.Add(assetFile.Name);
                     if (assetFile.Multi != null)

--- a/OpenKh.Tools.ModsManager/Exceptions/Exceptions.cs
+++ b/OpenKh.Tools.ModsManager/Exceptions/Exceptions.cs
@@ -34,4 +34,15 @@ namespace OpenKh.Tools.ModsManager.Exceptions
 
         }
     }
+
+    public class ModMovedWithoutGameException : Exception
+    {
+        public string ModName { get; }
+
+        public ModMovedWithoutGameException(string modName) :
+            base($"The mod '{modName}' has been changed from a collection but a base game was not specified and could not be moved, it will be removed. Please reinstall in the appropriate launch game.")
+        {
+            ModName = modName;
+        }
+    }
 }

--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -26,6 +26,7 @@ namespace OpenKh.Tools.ModsManager.Services
 
             public int WizardVersionNumber { get; set; }
             public string ModCollectionPath { get; internal set; }
+            public string ModCollectionsPath { get; internal set; }
             public string GameModPath { get; internal set; }
             public string GameDataPath { get; internal set; }
             public int GameEdition { get; internal set; }
@@ -92,6 +93,8 @@ namespace OpenKh.Tools.ModsManager.Services
         static ConfigurationService()
         {
             string modsPath = Path.GetFullPath(Path.Combine(ModCollectionPath, ".."));
+            if (!Directory.Exists(Path.Combine(modsPath, "collections")))
+                Directory.CreateDirectory(Path.Combine(modsPath, "collections"));
             if (!Directory.Exists(Path.Combine(modsPath, "kh2")))
                 Directory.CreateDirectory(Path.Combine(modsPath, "kh2"));
             if (!Directory.Exists(Path.Combine(modsPath, "kh1")))
@@ -189,6 +192,16 @@ namespace OpenKh.Tools.ModsManager.Services
             set
             {
                 _config.ModCollectionPath = value;
+                _config.Save(ConfigPath);
+            }
+        }
+
+        public static string ModCollectionsPath
+        {
+            get => _config.ModCollectionsPath ?? Path.GetFullPath(Path.Combine(StoragePath, "mods", "collections"));
+            set
+            {
+                _config.ModCollectionsPath = value;
                 _config.Save(ConfigPath);
             }
         }

--- a/OpenKh.Tools.ModsManager/Services/ModsService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ModsService.cs
@@ -460,8 +460,10 @@ namespace OpenKh.Tools.ModsManager.Services
                 var modPath = GetModPath(modName);
                 var isCollection = false;
                 if (!Directory.Exists(modPath))
+                {
                     isCollection = true;
                     modPath = GetCollectionPath(modName);
+                }
                 var updateCount = await RepositoryService.FetchUpdate(modPath);
                 var metadata = GetMetadata(modPath);
                 if (isCollection && !metadata.IsCollection)
@@ -483,13 +485,12 @@ namespace OpenKh.Tools.ModsManager.Services
             {
                 var modPath = GetModPath(modName);
                 var isCollection = false;
-                if (Directory.Exists(modPath))
-                    RepositoryService.FetchAndResetUponOrigin(modPath, progressOutput, progressNumber);
-                else
+                if (!Directory.Exists(modPath))
                 {
-                    RepositoryService.FetchAndResetUponOrigin(GetCollectionPath(modName), progressOutput, progressNumber);
                     isCollection = true;
+                    modPath = GetCollectionPath(modName);
                 }
+                RepositoryService.FetchAndResetUponOrigin(modPath, progressOutput, progressNumber);
                 var metadata = GetMetadata(modPath);
                 if (isCollection && !metadata.IsCollection)
                     MoveFromCollection(modName);

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -452,14 +452,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 {
                     Handle(() =>
                     {
-                        foreach (var filePath in Directory.GetFiles(mod.Path, "*", SearchOption.AllDirectories))
-                        {
-                            var attributes = File.GetAttributes(filePath);
-                            if (attributes.HasFlag(FileAttributes.ReadOnly))
-                                File.SetAttributes(filePath, attributes & ~FileAttributes.ReadOnly);
-                        }
-
-                        Directory.Delete(mod.Path, true);
+                        ModsService.CleanModFiles(mod.Path);
                         ModsList.RemoveAt(ModsList.IndexOf(SelectedValue));
                     });
                 }
@@ -615,7 +608,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         private async Task<bool> BuildPatches(bool fastMode)
         {
             IsBuilding = true;
-            var result = await ModsService.RunPacherAsync(fastMode);
+            var result = await ModsService.RunPatcherAsync(fastMode);
             IsBuilding = false;
 
             return result;

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -1,5 +1,6 @@
 using OpenKh.Common;
 using OpenKh.Tools.Common.Wpf;
+using OpenKh.Tools.ModsManager.Exceptions;
 using OpenKh.Tools.ModsManager.Models;
 using OpenKh.Tools.ModsManager.Services;
 using OpenKh.Tools.ModsManager.Views;

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -1,6 +1,5 @@
 using OpenKh.Common;
 using OpenKh.Tools.Common.Wpf;
-using OpenKh.Tools.ModsManager.Exceptions;
 using OpenKh.Tools.ModsManager.Models;
 using OpenKh.Tools.ModsManager.Services;
 using OpenKh.Tools.ModsManager.Views;

--- a/OpenKh.Tools.ModsManager/ViewModels/ModViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/ModViewModel.cs
@@ -165,6 +165,9 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         {
             foreach (var asset in _model.Metadata?.Assets ?? Enumerable.Empty<Patcher.AssetFile>())
             {
+                if (_model.Metadata.IsCollection)
+                    if (asset.Game != ConfigurationService.LaunchGame)
+                        continue;
                 yield return asset.Name;
                 if (asset.Multi != null)
                 {


### PR DESCRIPTION
Adds definitions to the mod.yml file for the following fields:
- isCollection: boolean for if the specific mod install is actually a collection (ie contains multiple games worth of info)
- collectionGames: string list of the games that have mods included
- asset.game: string to specify which game the script belongs with

This allows for the install and update of collection based mods from Github using the above tags in the mod.yml as well as the update and auto update of said installed mods. Creates a parent folder called collections on the same level as the game specific folders. And cleans up any installation of the mod that happened before it became a collection.