### PR TITLE
Kh2ObjectEditor - Effect caster flags and allow returns in AI edit

### DIFF
--- a/OpenKh.Kh2/Pax.cs
+++ b/OpenKh.Kh2/Pax.cs
@@ -1,4 +1,5 @@
 using OpenKh.Common;
+using OpenKh.Kh2.Utils;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -32,7 +33,7 @@ namespace OpenKh.Kh2
             [Data] public byte FadeoutFrame { get; set; }
             [Data] public short BoneId { get; set; }
 			[Data] public ulong Category { get; set; }
-			[Data] public uint Flag { get; set; }
+			[Data] public ElementFlags Flags { get; set; }
 			[Data] public float StartWait { get; set; }
 			[Data] public int SoundEffectNumber { get; set; }
 			[Data] public float TranslationX { get; set; }
@@ -44,10 +45,41 @@ namespace OpenKh.Kh2
 			[Data] public float ScaleX { get; set; }
 			[Data] public float ScaleZ { get; set; }
 			[Data] public float ScaleY { get; set; }
-			[Data] public int Unk40 { get; set; } // Reserve/Padding? Always 0
-			[Data] public int Unk44 { get; set; } // Reserve/Padding? Always 0
-            [Data] public int Unk48 { get; set; } // Reserve/Padding? Always 0
-            [Data] public int Unk4C { get; set; } // Reserve/Padding? Always 0
+			[Data] public BonePos BonePosition { get; set; }
+
+            public bool FlagBind { get => BitFlag.IsFlagSet(Flags, ElementFlags.Bind); set => Flags = BitFlag.SetFlag(Flags, ElementFlags.Bind, value); }
+            public bool FlagBindOnlyStart { get => BitFlag.IsFlagSet(Flags, ElementFlags.BindOnlyStart); set => Flags = BitFlag.SetFlag(Flags, ElementFlags.BindOnlyStart, value); }
+            public bool FlagBindOnlyPos { get => BitFlag.IsFlagSet(Flags, ElementFlags.BindOnlyPos); set => Flags = BitFlag.SetFlag(Flags, ElementFlags.BindOnlyPos, value); }
+            public bool FlagGetColor { get => BitFlag.IsFlagSet(Flags, ElementFlags.GetColor); set => Flags = BitFlag.SetFlag(Flags, ElementFlags.GetColor, value); }
+            public bool FlagGetBrightness { get => BitFlag.IsFlagSet(Flags, ElementFlags.GetBrightness); set => Flags = BitFlag.SetFlag(Flags, ElementFlags.GetBrightness, value); }
+            public bool FlagDestroyWhenMotionChange { get => BitFlag.IsFlagSet(Flags, ElementFlags.DestroyWhenMotionChange); set => Flags = BitFlag.SetFlag(Flags, ElementFlags.DestroyWhenMotionChange, value); }
+            public bool FlagDestroyFadeout { get => BitFlag.IsFlagSet(Flags, ElementFlags.DestroyFadeout); set => Flags = BitFlag.SetFlag(Flags, ElementFlags.DestroyFadeout, value); }
+            public bool FlagDestroyLoopend { get => BitFlag.IsFlagSet(Flags, ElementFlags.DestroyLoopend); set => Flags = BitFlag.SetFlag(Flags, ElementFlags.DestroyLoopend, value); }
+            public bool FlagBindScale { get => BitFlag.IsFlagSet(Flags, ElementFlags.BindScale); set => Flags = BitFlag.SetFlag(Flags, ElementFlags.BindScale, value); }
+            public bool FlagDestroyWhenObjectLeaves { get => BitFlag.IsFlagSet(Flags, ElementFlags.DestroyWhenObjectLeaves); set => Flags = BitFlag.SetFlag(Flags, ElementFlags.DestroyWhenObjectLeaves, value); }
+            public bool FlagDestroyWhenBindEffectOff { get => BitFlag.IsFlagSet(Flags, ElementFlags.DestroyWhenBindEffectOff); set => Flags = BitFlag.SetFlag(Flags, ElementFlags.DestroyWhenBindEffectOff, value); }
+            public bool FlagGetObjectFade { get => BitFlag.IsFlagSet(Flags, ElementFlags.GetObjectFade); set => Flags = BitFlag.SetFlag(Flags, ElementFlags.GetObjectFade, value); }
+            public bool FlagBonePos { get => BitFlag.IsFlagSet(Flags, ElementFlags.BonePos); set => Flags = BitFlag.SetFlag(Flags, ElementFlags.BonePos, value); }
+            public bool FlagBindCamera { get => BitFlag.IsFlagSet(Flags, ElementFlags.BindCamera); set => Flags = BitFlag.SetFlag(Flags, ElementFlags.BindCamera, value); }
+
+            [Flags]
+            public enum ElementFlags : uint
+            {
+                Bind = 0x01,
+                BindOnlyStart = 0x02,
+                BindOnlyPos = 0x04,
+                GetColor = 0x08,
+                GetBrightness = 0x10,
+                DestroyWhenMotionChange = 0x20,
+                DestroyFadeout = 0x40,
+                DestroyLoopend = 0x80,
+                BindScale = 0x100,
+                DestroyWhenObjectLeaves = 0x200,
+                DestroyWhenBindEffectOff = 0x400,
+                GetObjectFade = 0x800,
+                BonePos = 0x1000,
+                BindCamera = 0x2000
+            }
 
             /*internal static Element Read(BinaryReader reader)
 			{
@@ -78,7 +110,7 @@ namespace OpenKh.Kh2
 				};
 			}*/
 
-			internal void Save(BinaryWriter writer)
+            internal void Save(BinaryWriter writer)
 			{
 				writer.Write((ushort)EffectNumber);
 				writer.Write((ushort)Id);
@@ -86,7 +118,7 @@ namespace OpenKh.Kh2
                 writer.Write((byte)FadeoutFrame);
                 writer.Write((short)BoneId);
 				writer.Write(Category);
-				writer.Write(Flag);
+				writer.Write((uint)Flags);
 				writer.Write(StartWait);
 				writer.Write(SoundEffectNumber);
 				writer.Write(TranslationX);
@@ -98,15 +130,27 @@ namespace OpenKh.Kh2
 				writer.Write(ScaleX);
 				writer.Write(ScaleZ);
 				writer.Write(ScaleY);
-				writer.Write(Unk40);
-				writer.Write(Unk44);
-				writer.Write(Unk48);
-				writer.Write(Unk4C);
+				writer.Write(BonePosition.A);
+				writer.Write(BonePosition.B);
+				writer.Write(BonePosition.RatioA);
+				writer.Write(BonePosition.RatioB);
+				writer.Write(BonePosition.Adjust);
+				writer.Write(BonePosition.Padding);
             }
 
             public override string ToString()
             {
                 return "No: "+ EffectNumber + " | Id: " + Id + " | Gr: " + Group + " | Bone: " + BoneId + " | SEno: " + SoundEffectNumber;
+            }
+
+            public class BonePos
+            {
+                [Data] public ushort A { get; set; }
+                [Data] public ushort B { get; set; }
+                [Data] public float RatioA { get; set; }
+                [Data] public float RatioB { get; set; }
+                [Data] public byte Adjust { get; set; }
+                [Data(Count=3)] public byte[] Padding { get; set; }
             }
         }
 

--- a/OpenKh.Kh2/Utils/BitFlag.cs
+++ b/OpenKh.Kh2/Utils/BitFlag.cs
@@ -1,0 +1,65 @@
+using System;
+
+namespace OpenKh.Kh2.Utils
+{
+    public class BitFlag
+    {
+        // Ensure the type is an enum and supports flags
+        private static void ValidateEnumType<T>() where T : Enum
+        {
+            if (!typeof(T).IsDefined(typeof(FlagsAttribute), false))
+            {
+                throw new ArgumentException($"{typeof(T).Name} must have the [Flags] attribute.");
+            }
+        }
+
+        // Check if a flag is set
+        public static bool IsFlagSet<T>(T value, T flag) where T : Enum
+        {
+            ValidateEnumType<T>();
+            var intValue = Convert.ToInt32(value);
+            var intFlag = Convert.ToInt32(flag);
+            return (intValue & intFlag) == intFlag;
+        }
+
+        // Set a flag
+        public static T SetFlag<T>(T value, T flag) where T : Enum
+        {
+            ValidateEnumType<T>();
+            var intValue = Convert.ToInt32(value);
+            var intFlag = Convert.ToInt32(flag);
+            return (T)Enum.ToObject(typeof(T), intValue | intFlag);
+        }
+
+        // Set a flag to given value
+        public static T SetFlag<T>(T value, T flag, bool setValue) where T : Enum
+        {
+            if (setValue)
+            {
+                return SetFlag(value, flag);
+            }
+            else
+            {
+                return ClearFlag(value, flag);
+            }
+        }
+
+        // Clear a flag
+        public static T ClearFlag<T>(T value, T flag) where T : Enum
+        {
+            ValidateEnumType<T>();
+            var intValue = Convert.ToInt32(value);
+            var intFlag = Convert.ToInt32(flag);
+            return (T)Enum.ToObject(typeof(T), intValue & ~intFlag);
+        }
+
+        // Toggle a flag
+        public static T ToggleFlag<T>(T value, T flag) where T : Enum
+        {
+            ValidateEnumType<T>();
+            var intValue = Convert.ToInt32(value);
+            var intFlag = Convert.ToInt32(flag);
+            return (T)Enum.ToObject(typeof(T), intValue ^ intFlag);
+        }
+    }
+}

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/AI/ModuleAI_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/AI/ModuleAI_Control.xaml
@@ -22,7 +22,7 @@
         
         
         <ScrollViewer>
-            <TextBox x:Name="DecodedTextBlock" Text="{Binding BdxDecoded}" Width="auto" Height="auto"/>
+            <TextBox x:Name="DecodedTextBlock" Text="{Binding BdxDecoded}" Width="auto" Height="auto" AcceptsReturn="True"/>
         </ScrollViewer>
         
     </DockPanel>

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectElements_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectElements_Control.xaml
@@ -7,9 +7,14 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
-        <DataGrid Name="DataTable"
-                AutoGenerateColumns="False"
-                CanUserAddRows="False">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="30" />
+        </Grid.RowDefinitions>
+        <DataGrid Name="DataTable" Grid.Row="0"
+                  ItemsSource="{Binding LoadedEntries, Mode=TwoWay}"
+                  AutoGenerateColumns="False"
+                  CanUserAddRows="False">
             <DataGrid.Columns>
                 <DataGridTextColumn IsReadOnly="True" Binding="{Binding Path=Id}" Header="Id" />
                 <DataGridTextColumn Binding="{Binding Path=EffectNumber}" Header="Effect Number" />
@@ -26,7 +31,29 @@
                 <DataGridTextColumn Binding="{Binding Path=ScaleX}" Header="ScaleX" />
                 <DataGridTextColumn Binding="{Binding Path=ScaleY}" Header="ScaleY" />
                 <DataGridTextColumn Binding="{Binding Path=ScaleZ}" Header="ScaleZ" />
+                <DataGridCheckBoxColumn Binding="{Binding Path=FlagBind}" Header="Bind" />
+                <DataGridCheckBoxColumn Binding="{Binding Path=FlagBindOnlyStart}" Header="Bind Only Start" />
+                <DataGridCheckBoxColumn Binding="{Binding Path=FlagBindOnlyPos}" Header="Bind Only Pos" />
+                <DataGridCheckBoxColumn Binding="{Binding Path=FlagGetColor}" Header="Get Color" />
+                <DataGridCheckBoxColumn Binding="{Binding Path=FlagGetBrightness}" Header="Get Brightness" />
+                <DataGridCheckBoxColumn Binding="{Binding Path=FlagDestroyWhenMotionChange}" Header="Destroy When Motion Change" />
+                <DataGridCheckBoxColumn Binding="{Binding Path=FlagDestroyFadeout}" Header="Destroy Fadeout" />
+                <DataGridCheckBoxColumn Binding="{Binding Path=FlagDestroyLoopend}" Header="Destroy Loop End" />
+                <DataGridCheckBoxColumn Binding="{Binding Path=FlagBindScale}" Header="Bind Scale" />
+                <DataGridCheckBoxColumn Binding="{Binding Path=FlagDestroyWhenObjectLeaves}" Header="Destroy When Object Leaves" />
+                <DataGridCheckBoxColumn Binding="{Binding Path=FlagDestroyWhenBindEffectOff}" Header="Destroy When Bind Effect Off" />
+                <DataGridCheckBoxColumn Binding="{Binding Path=FlagGetObjectFade}" Header="Get Object Fade" />
+                <DataGridCheckBoxColumn Binding="{Binding Path=FlagBonePos}" Header="Bone Pos" />
+                <DataGridCheckBoxColumn Binding="{Binding Path=FlagBindCamera}" Header="Bind Camera" />
+                <DataGridTextColumn Binding="{Binding Path=BonePosition.A}" Header="BP A" />
+                <DataGridTextColumn Binding="{Binding Path=BonePosition.B}" Header="BP B" />
+                <DataGridTextColumn Binding="{Binding Path=BonePosition.RatioA}" Header="BP Ratio A" />
+                <DataGridTextColumn Binding="{Binding Path=BonePosition.RatioB}" Header="BP Ratio B" />
+                <DataGridTextColumn Binding="{Binding Path=BonePosition.Adjust}" Header="BP Adjust" />
             </DataGrid.Columns>
         </DataGrid>
+        <Button Grid.Row="1" Click="Button_Save">
+            Save Casters
+        </Button>
     </Grid>
 </UserControl>

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectElements_Control.xaml.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectElements_Control.xaml.cs
@@ -5,10 +5,13 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Effects
 {
     public partial class M_EffectElements_Control : UserControl
     {
+        M_EffectElements_VM thisVM;
         public M_EffectElements_Control()
         {
+            thisVM = new M_EffectElements_VM();
             InitializeComponent();
             loadElements();
+            this.DataContext = thisVM;
         }
 
         public void loadElements()
@@ -16,7 +19,12 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Effects
             if (ApdxService.Instance.PaxFile?.Elements == null)
                 return;
 
-            DataTable.ItemsSource = ApdxService.Instance.PaxFile.Elements;
+            thisVM.LoadEntries(ApdxService.Instance.PaxFile.Elements);
+        }
+
+        private void Button_Save(object sender, System.Windows.RoutedEventArgs e)
+        {
+            thisVM.SaveEntries();
         }
     }
 }

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectElements_VM.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectElements_VM.cs
@@ -1,0 +1,37 @@
+using OpenKh.Kh2;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Effects
+{
+    internal class M_EffectElements_VM
+    {
+        internal List<Pax.Element> OriginalElements;
+        public ObservableCollection<M_EffectElements_Wrapper> LoadedEntries { get; set; } = new ObservableCollection<M_EffectElements_Wrapper>();
+
+        public void LoadEntries(List<Pax.Element> paxElements)
+        {
+            OriginalElements = paxElements;
+
+            LoadedEntries.Clear();
+            foreach (Pax.Element element in OriginalElements)
+            {
+                LoadedEntries.Add(M_EffectElements_Wrapper.Wrap(element));
+            }
+        }
+
+        public void SaveEntries()
+        {
+            if(OriginalElements == null)
+            {
+                throw new System.Exception("[M_EffectElements_VM] original entries not loaded");
+            }
+
+            OriginalElements.Clear();
+            foreach (M_EffectElements_Wrapper wrapper in LoadedEntries)
+            {
+                OriginalElements.Add(wrapper.Unwrap());
+            }
+        }
+    }
+}

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectElements_Wrapper.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectElements_Wrapper.cs
@@ -1,0 +1,58 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using OpenKh.Kh2;
+using OpenKh.Tools.Kh2ObjectEditor.Utils;
+
+namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Effects
+{
+    public class M_EffectElements_Wrapper : ObservableObject
+    {
+        public ushort EffectNumber { get; set; }
+        public ushort Id { get; set; }
+        public byte Group { get; set; }
+        public byte FadeoutFrame { get; set; }
+        public short BoneId { get; set; }
+        public ulong Category { get; set; }
+        //public Pax.Element.ElementFlags Flags { get; set; }
+        public bool FlagBind { get; set; }
+        public bool FlagBindOnlyStart { get; set; }
+        public bool FlagBindOnlyPos { get; set; }
+        public bool FlagGetColor { get; set; }
+        public bool FlagGetBrightness { get; set; }
+        public bool FlagDestroyWhenMotionChange { get; set; }
+        public bool FlagDestroyFadeout { get; set; }
+        public bool FlagDestroyLoopend { get; set; }
+        public bool FlagBindScale { get; set; }
+        public bool FlagDestroyWhenObjectLeaves { get; set; }
+        public bool FlagDestroyWhenBindEffectOff { get; set; }
+        public bool FlagGetObjectFade { get; set; }
+        public bool FlagBonePos { get; set; }
+        public bool FlagBindCamera { get; set; }
+        public float StartWait { get; set; }
+        public int SoundEffectNumber { get; set; }
+        public float TranslationX { get; set; }
+        public float TranslationZ { get; set; }
+        public float TranslationY { get; set; }
+        public float RotationX { get; set; }
+        public float RotationZ { get; set; }
+        public float RotationY { get; set; }
+        public float ScaleX { get; set; }
+        public float ScaleZ { get; set; }
+        public float ScaleY { get; set; }
+        public Pax.Element.BonePos BonePosition { get; set; } = new Pax.Element.BonePos();
+
+        public static M_EffectElements_Wrapper Wrap(Pax.Element entry)
+        {
+            M_EffectElements_Wrapper wrapper = new M_EffectElements_Wrapper();
+            Property_Util.CopyProperties(entry, wrapper);
+            Property_Util.CopyProperties(entry.BonePosition, wrapper.BonePosition);
+            return wrapper;
+        }
+        public Pax.Element Unwrap()
+        {
+            Pax.Element entry = new Pax.Element();
+            Property_Util.CopyProperties(this, entry);
+            Property_Util.CopyProperties(this.BonePosition, entry.BonePosition);
+            return entry;
+        }
+    }
+}

--- a/OpenKh.Tools.Kh2ObjectEditor/OpenKh.Tools.Kh2ObjectEditor.csproj
+++ b/OpenKh.Tools.Kh2ObjectEditor/OpenKh.Tools.Kh2ObjectEditor.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\ModelingToolkit\ModelingToolkit\ModelingToolkit.csproj" />
     <ProjectReference Include="..\OpenKh.AssimpUtils\OpenKh.AssimpUtils.csproj" />
     <ProjectReference Include="..\OpenKh.Command.AnbMaker\OpenKh.Command.AnbMaker.csproj" />

--- a/OpenKh.Tools.Kh2ObjectEditor/Utils/Property_Util.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Utils/Property_Util.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+
+namespace OpenKh.Tools.Kh2ObjectEditor.Utils
+{
+    public class Property_Util
+    {
+        // Copies the properties of the source object into the target object given they share name and type
+        public static void CopyProperties<TSource, TTarget>(TSource source, TTarget target)
+        {
+            var sourceProps = typeof(TSource).GetProperties();
+            var targetProps = typeof(TTarget).GetProperties();
+
+            foreach (var sourceProp in sourceProps)
+            {
+                var targetProp = targetProps.FirstOrDefault(p => p.Name == sourceProp.Name && p.PropertyType == sourceProp.PropertyType);
+                if (targetProp != null && targetProp.CanWrite)
+                {
+                    targetProp.SetValue(target, sourceProp.GetValue(source));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the Effect Caster flags and allows returns in AI edit menu.

Note: Due to wrapping Effect Casters now have to be saved. A button has been added for that as well.

![image](https://github.com/user-attachments/assets/6d3a6a2f-7564-4d2d-bf93-fea8ac410aa1)