### PR TITLE
Kh2ObjectEditor - Fix - Allow editing particle effect ids

### DIFF
--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectElements_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectElements_Control.xaml
@@ -16,7 +16,7 @@
                   AutoGenerateColumns="False"
                   CanUserAddRows="False">
             <DataGrid.Columns>
-                <DataGridTextColumn IsReadOnly="True" Binding="{Binding Path=Id}" Header="Id" />
+                <DataGridTextColumn Binding="{Binding Path=Id}" Header="Id" />
                 <DataGridTextColumn Binding="{Binding Path=EffectNumber}" Header="Effect Number" />
                 <DataGridTextColumn Binding="{Binding Path=BoneId}" Header="Bone Id" />
                 <DataGridTextColumn Binding="{Binding Path=SoundEffectNumber}" Header="Sound Effect Id" />

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectParticles_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectParticles_Control.xaml
@@ -11,7 +11,7 @@
                 AutoGenerateColumns="False"
                 CanUserAddRows="False">
             <DataGrid.Columns>
-                <DataGridTextColumn IsReadOnly="True" Binding="{Binding Path=EffectNumber}" Header="Number" />
+                <DataGridTextColumn Binding="{Binding Path=EffectNumber}" Header="Number" />
                 <DataGridTextColumn Binding="{Binding Path=DpdId}" Header="DPD Id" />
                 <DataGridTextColumn Binding="{Binding Path=ParticleDataId}" Header="Particle Data Id" />
             </DataGrid.Columns>


### PR DESCRIPTION
Simple fix to allow editing these 2 fields. They being read only was probably a copy-paste error.