### PR TITLE
KH2 Object Editor - Updated look to ModernWpf

### DIFF
--- a/OpenKh.Kh2/Models/ModelCommon.cs
+++ b/OpenKh.Kh2/Models/ModelCommon.cs
@@ -1,3 +1,4 @@
+using OpenKh.Common.Utils;
 using OpenKh.Kh2.Models.VIF;
 using System.Collections.Generic;
 using System.IO;
@@ -147,6 +148,19 @@ namespace OpenKh.Kh2.Models
              * not_joint > On when the bone has no rigged vertices
              * The rest is unused
              */
+
+
+            public bool NoEnvelop
+            {
+                get => BitsUtil.Int.GetBit(Flags, 0);
+                set => Flags = (int)BitsUtil.Int.SetBit(Flags, 0, value);
+            }
+
+            public bool NoJoint
+            {
+                get => BitsUtil.Int.GetBit(Flags, 1);
+                set => Flags = (int)BitsUtil.Int.SetBit(Flags, 1, value);
+            }
 
             public override string ToString()
             {

--- a/OpenKh.Kh2/MotionSet.cs
+++ b/OpenKh.Kh2/MotionSet.cs
@@ -1,9 +1,30 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace OpenKh.Kh2
 {
     public class MotionSet
     {
+        private static List<int> _validMotionValues;
+        private static List<int> ValidMotionValues
+        {
+            get
+            {
+                if (_validMotionValues == null)
+                {
+                    _validMotionValues = ((MotionName[])Enum.GetValues(typeof(MotionName)))
+                                                                .Select(e => (int)e)
+                                                                .ToList();
+                }
+                return _validMotionValues;
+            }
+        }
+        public static bool IsNamedMotion(int motionId)
+        {
+            return ValidMotionValues.Contains(motionId);
+        }
+
         public enum MotionName
         {
             IDLE = 0,

--- a/OpenKh.Tools.Kh2MdlxEditor/Views/Main2_Window.xaml.cs
+++ b/OpenKh.Tools.Kh2MdlxEditor/Views/Main2_Window.xaml.cs
@@ -15,7 +15,7 @@ namespace OpenKh.Tools.Kh2MdlxEditor.Views
     {
         // VIEW MODEL
         //-----------------------------------------------------------------------
-        Main2_VM mainVM { get; set; }
+        Main2_VM mainVM { get; set; } = new Main2_VM();
 
         // CONSTRUCTOR
         //-----------------------------------------------------------------------

--- a/OpenKh.Tools.Kh2ObjectEditor/App.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/App.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:OpenKh.Tools.Kh2ObjectEditor"
+             xmlns:ui="http://schemas.modernwpf.com/2019"
              StartupUri="Views/Main_Window.xaml">
 
     <Application.Resources>
@@ -9,6 +10,10 @@
             <!--<ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Themes/Fluent.xaml" />
             </ResourceDictionary.MergedDictionaries>-->
+            <ResourceDictionary.MergedDictionaries>
+                <ui:ThemeResources />
+                <ui:XamlControlsResources />
+            </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
 
     </Application.Resources>

--- a/OpenKh.Tools.Kh2ObjectEditor/Classes/MotionSelector_Wrapper.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Classes/MotionSelector_Wrapper.cs
@@ -9,6 +9,10 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Classes
         public BinaryArchive.Entry Entry { get; set; }
         public string Name { get; set; }
         public bool IsDummy { get { return Name.Contains("DUMM") || LinkedSubfile.Length == 0; } }
+        public string IndexString => "[" + Index + "]";
+        public bool IsSet => Entry.Type == BinaryArchive.EntryType.Motionset;
+        public string Tags { get; set; }
+        public MotionSet.MotionName? MotionName { get; set; }
         public byte[] LinkedSubfile
         {
             get
@@ -31,13 +35,21 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Classes
         public void setName()
         {
             int motionIndex = (MsetService.Instance.MsetBinarc.MSetType == BinaryArchive.MotionsetType.Player) ? Index / 4 : Index;
-            Name = "[" + Index + "] " + Entry.Name + " [" + (MotionSet.MotionName)motionIndex + "]";
-             
+            MotionName = (MotionSet.IsNamedMotion(motionIndex)) ? (MotionSet.MotionName)motionIndex : null;
+            Name = "[" + Index + "] " + Entry.Name + " [" + MotionName + "]";
+            Tags = ""; 
+
             // Tags
             if (Entry.Type == BinaryArchive.EntryType.Motionset)
+            {
                 Name += "<SET>";
+                Tags += "<SET>";
+            }
             if (LinkedSubfile.Length == 0)
+            {
                 Name += "<DUMMY>";
+                Tags += "<DUMMY>";
+            }
         }
     }
 }

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Collisions/Collisions_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Collisions/Collisions_Control.xaml
@@ -18,9 +18,10 @@
         </Grid>
 
         <DataGrid Name="DataTable"
-                AutoGenerateColumns="False"
-                ItemsSource="{Binding Collisions}"
-                CanUserAddRows="False">
+                  AutoGenerateColumns="False"
+                  ItemsSource="{Binding Collisions}"
+                  CanUserAddRows="False"
+                  SelectionChanged="DataTable_SelectionChanged" GridLinesVisibility="All" HeadersVisibility="Column">
             <DataGrid.ContextMenu>
                 <ContextMenu>
                     <MenuItem Header="Add collision" Click="Collision_Add"/>
@@ -35,11 +36,6 @@
             <DataGrid.Resources>
                 <local:CollisionTypeConverter x:Key="CollisionType_Converter" />
                 <local:CollisionShapeConverter x:Key="CollisionShape_Converter" />
-
-                <Style TargetType="DataGridRow">
-                    <EventSetter Event="MouseLeftButtonUp" Handler="DataGridRow_MouseLeftButtonUp"/>
-                </Style>
-
             </DataGrid.Resources>
 
             <DataGrid.Columns>

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Collisions/Collisions_Control.xaml.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Collisions/Collisions_Control.xaml.cs
@@ -62,7 +62,7 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Collisions
             ThisVM.TestCollisionsIngame();
         }
 
-        private void DataGridRow_MouseLeftButtonUp(object sender, MouseEventArgs e)
+        private void DataTable_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             List<int> selectedIndices = new List<int>();
             foreach (var selectedItem in DataTable.SelectedItems)

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdTexture_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdTexture_Control.xaml
@@ -17,7 +17,7 @@
             <Canvas.Background>
                 <DrawingBrush TileMode="Tile" Viewport="0,0,32,32" ViewportUnits="Absolute">
                     <DrawingBrush.Drawing>
-                        <GeometryDrawing Geometry="M0,0 H16 V16 H32 V32 H16 V16 H0Z" Brush="#10000000"/>
+                        <GeometryDrawing Geometry="M0,0 H16 V16 H32 V32 H16 V16 H0Z" Brush="#80555555"/>
                     </DrawingBrush.Drawing>
                 </DrawingBrush>
             </Canvas.Background>
@@ -30,7 +30,16 @@
 
         <GridSplitter Grid.Column="1" Background="LightGray" HorizontalAlignment="Center" VerticalAlignment="Stretch" ShowsPreview="True" Width="5"/>
 
-        <ListView Grid.Column="2" x:Name="List_Textures" ItemsSource="{Binding TextureWrappers}" SelectedItem="{Binding SelectedTexture}" MouseDoubleClick="List_Textures_MouseDoubleClick">
+        <ListView Grid.Column="2" x:Name="List_Textures" ItemsSource="{Binding TextureWrappers}" SelectedItem="{Binding SelectedTexture}" SelectionChanged="EffectImage_Selected">
+
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="ListBoxItem">
+                    <Setter Property="BorderBrush" Value="#22FFFFFF"/>
+                    <Setter Property="BorderThickness" Value="0,0,0,1"/>
+                    <Setter Property="Padding" Value="5"/>
+                </Style>
+            </ListBox.ItemContainerStyle>
+
             <ListView.ContextMenu>
                 <ContextMenu>
                     <MenuItem Header="Export as PNG" Click="EffectImage_Export"/>

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdTexture_Control.xaml.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdTexture_Control.xaml.cs
@@ -27,12 +27,6 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Effects
             ImageFrame.Source = BitmapImage;
         }
 
-        private void List_Textures_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
-        {
-            if (List_Textures.SelectedItem != null)
-                loadImage(List_Textures.SelectedIndex);
-        }
-
         public void EffectImage_Export(object sender, RoutedEventArgs e)
         {
             if (List_Textures.SelectedItem != null)
@@ -53,6 +47,12 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Effects
                 ThisVM.ReplaceTexture(List_Textures.SelectedIndex);
                 loadImage(List_Textures.SelectedIndex);
             }
+        }
+
+        private void EffectImage_Selected(object sender, SelectionChangedEventArgs e)
+        {
+            if (List_Textures.SelectedItem != null)
+                loadImage(List_Textures.SelectedIndex);
         }
     }
 }

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdVoice.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdVoice.xaml
@@ -20,7 +20,7 @@
         <DataGrid Name="DataTable"
                   AutoGenerateColumns="False"
                   ItemsSource="{Binding Indices}"
-                  CanUserAddRows="True">
+                  CanUserAddRows="True" GridLinesVisibility="All" HeadersVisibility="Column">
             <DataGrid.Columns>
                 <DataGridTextColumn Binding="{Binding Index}" Header="Index" />
             </DataGrid.Columns>

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdVoiceList_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdVoiceList_Control.xaml
@@ -17,7 +17,16 @@
 
         <GridSplitter Grid.Column="1" Background="LightGray" HorizontalAlignment="Center" VerticalAlignment="Stretch" ShowsPreview="True" Width="5"/>
 
-        <ListView Grid.Column="2" x:Name="ListView_Vsf" ItemsSource="{Binding VsfWrappers}" MouseDoubleClick="ListView_Vsf_MouseDoubleClick">
+        <ListView Grid.Column="2" x:Name="ListView_Vsf" ItemsSource="{Binding VsfWrappers}" SelectionChanged="ListView_Vsf_SelectionChanged">
+
+            <ListView.ItemContainerStyle>
+                <Style TargetType="ListViewItem">
+                    <Setter Property="BorderBrush" Value="#22FFFFFF"/>
+                    <Setter Property="BorderThickness" Value="0,0,0,1"/>
+                    <Setter Property="Padding" Value="5"/>
+                </Style>
+            </ListView.ItemContainerStyle>
+
             <ListView.ItemTemplate>
                 <DataTemplate>
                     <StackPanel Orientation="Vertical">

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdVoiceList_Control.xaml.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpdVoiceList_Control.xaml.cs
@@ -22,11 +22,6 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Effects
             DataContext = this;
         }
 
-        private void ListView_Vsf_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
-        {
-            Frame_Voice.Content = new M_EffectDpdVoice_Control(VsfWrappers[ListView_Vsf.SelectedIndex].VoiceEffect);
-        }
-
         public class VsfWrapper
         {
             public int Index { get; set; }
@@ -39,6 +34,15 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Effects
                 VoiceEffect = vsf;
                 Name = "Vsf " + Index;
             }
+        }
+
+        private void ListView_Vsf_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if(ListView_Vsf.SelectedIndex == null)
+            {
+                return;
+            }
+            Frame_Voice.Content = new M_EffectDpdVoice_Control(VsfWrappers[ListView_Vsf.SelectedIndex].VoiceEffect);
         }
     }
 }

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpds_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpds_Control.xaml
@@ -17,7 +17,16 @@
 
         <GridSplitter Grid.Column="1" Background="LightGray" HorizontalAlignment="Center" VerticalAlignment="Stretch" ShowsPreview="True" Width="5"/>
 
-        <ListView Grid.Column="2" x:Name="List_Dpds" ItemsSource="{Binding DpdList}" SelectedItem="{Binding SelectedDpd}" MouseDoubleClick="list_doubleCLick">
+        <ListView Grid.Column="2" x:Name="List_Dpds" ItemsSource="{Binding DpdList}" SelectedItem="{Binding SelectedDpd}" SelectionChanged="Dpd_Selected">
+
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="ListBoxItem">
+                    <Setter Property="BorderBrush" Value="#22FFFFFF"/>
+                    <Setter Property="BorderThickness" Value="0,0,0,1"/>
+                    <Setter Property="Padding" Value="5"/>
+                </Style>
+            </ListBox.ItemContainerStyle>
+
             <ListView.ContextMenu>
                 <ContextMenu>
                     <MenuItem Header="Copy DPD" Click="Dpd_Copy"/>

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpds_Control.xaml.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectDpds_Control.xaml.cs
@@ -13,13 +13,6 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Effects
             ThisVM = new M_EffectDpds_VM();
             DataContext = ThisVM;
         }
-
-        private void list_doubleCLick(object sender, System.Windows.Input.MouseButtonEventArgs e)
-        {
-            DpdWrapper item = (DpdWrapper)(sender as ListView).SelectedItem;
-
-            DpdFrame.Content = new M_EffectsDpdTabs_Control(item.DpdItem);
-        }
         public void Dpd_Copy(object sender, RoutedEventArgs e)
         {
             if (List_Dpds.SelectedIndex != null)
@@ -48,6 +41,18 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Effects
         public void Dpd_Import(object sender, RoutedEventArgs e)
         {
             ThisVM.Dpd_Import();
+        }
+
+        private void Dpd_Selected(object sender, SelectionChangedEventArgs e)
+        {
+            if((DpdWrapper)(sender as ListView).SelectedItem == null)
+            {
+                return;
+            }
+
+            DpdWrapper item = (DpdWrapper)(sender as ListView).SelectedItem;
+
+            DpdFrame.Content = new M_EffectsDpdTabs_Control(item.DpdItem);
         }
     }
 }

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectElements_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectElements_Control.xaml
@@ -9,12 +9,12 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
-            <RowDefinition Height="30" />
+            <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
         <DataGrid Name="DataTable" Grid.Row="0"
                   ItemsSource="{Binding LoadedEntries, Mode=TwoWay}"
                   AutoGenerateColumns="False"
-                  CanUserAddRows="False">
+                  CanUserAddRows="False" GridLinesVisibility="All" HeadersVisibility="Column">
             <DataGrid.Columns>
                 <DataGridTextColumn Binding="{Binding Path=Id}" Header="Id" />
                 <DataGridTextColumn Binding="{Binding Path=EffectNumber}" Header="Effect Number" />
@@ -52,7 +52,7 @@
                 <DataGridTextColumn Binding="{Binding Path=BonePosition.Adjust}" Header="BP Adjust" />
             </DataGrid.Columns>
         </DataGrid>
-        <Button Grid.Row="1" Click="Button_Save">
+        <Button Margin="10" Grid.Row="1" Click="Button_Save" HorizontalAlignment="Right">
             Save Casters
         </Button>
     </Grid>

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectParticles_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectParticles_Control.xaml
@@ -9,7 +9,7 @@
     <Grid>
         <DataGrid Name="DataTable"
                 AutoGenerateColumns="False"
-                CanUserAddRows="False">
+                CanUserAddRows="False" GridLinesVisibility="All" HeadersVisibility="Column">
             <DataGrid.Columns>
                 <DataGridTextColumn Binding="{Binding Path=EffectNumber}" Header="Number" />
                 <DataGridTextColumn Binding="{Binding Path=DpdId}" Header="DPD Id" />

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectsDpdTabs_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_EffectsDpdTabs_Control.xaml
@@ -4,39 +4,55 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:OpenKh.Tools.Kh2ObjectEditor.Modules.Effects"
+             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
         <TabControl Grid.Column="0">
-            <TabItem Width="60">
+            <TabItem>
                 <TabItem.Header>
-                    <Label>Textures</Label>
+                    <StackPanel Orientation="Horizontal">
+                        <iconPacks:PackIconPhosphorIcons Kind="Image" Height="15"/>
+                        <Label FontWeight="Bold" Margin="5 0">Textures</Label>
+                    </StackPanel>
                 </TabItem.Header>
                 <ContentControl Name="Tab_Textures"/>
             </TabItem>
-            <TabItem Width="60">
+            <TabItem IsEnabled="False">
                 <TabItem.Header>
-                    <Label>Models</Label>
+                    <StackPanel Orientation="Horizontal">
+                        <iconPacks:PackIconPhosphorIcons Kind="Cube" Height="15"/>
+                        <Label FontWeight="Bold" Margin="5 0">Models</Label>
+                    </StackPanel>
                 </TabItem.Header>
                 <Label>Unimplemented</Label>
                 <!--<ContentControl Name="Tab_Models"/>-->
             </TabItem>
-            <TabItem Width="60">
+            <TabItem IsEnabled="False">
                 <TabItem.Header>
-                    <Label>Shapes</Label>
+                    <StackPanel Orientation="Horizontal">
+                        <iconPacks:PackIconMaterial Kind="Star" Height="15"/>
+                        <Label FontWeight="Bold" Margin="5 0">Shapes</Label>
+                    </StackPanel>
                 </TabItem.Header>
                 <Label>Unimplemented</Label>
                 <!--<ContentControl Name="Tab_Shapes"/>-->
             </TabItem>
-            <TabItem Width="60">
+            <TabItem>
                 <TabItem.Header>
-                    <Label>VSF</Label>
+                    <StackPanel Orientation="Horizontal">
+                        <iconPacks:PackIconPhosphorIcons Kind="SpeakerHighBold" Height="15"/>
+                        <Label FontWeight="Bold" Margin="5 0">VSF</Label>
+                    </StackPanel>
                 </TabItem.Header>
                 <ContentControl Name="Tab_Vsf"/>
             </TabItem>
-            <TabItem Width="60">
+            <TabItem IsEnabled="False">
                 <TabItem.Header>
-                    <Label>Data</Label>
+                    <StackPanel Orientation="Horizontal">
+                        <iconPacks:PackIconMaterial Kind="ScriptTextOutline" Height="20"/>
+                        <Label FontWeight="Bold" Margin="5 0">Data</Label>
+                    </StackPanel>
                 </TabItem.Header>
                 <Label>Unimplemented</Label>
                 <!--<ContentControl Name="Tab_Data"/>-->

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_Effects_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Effects/M_Effects_Control.xaml
@@ -4,38 +4,69 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:OpenKh.Tools.Kh2ObjectEditor.Modules.Effects"
+             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
-    <DockPanel>
-        <Grid DockPanel.Dock="Bottom" MaxHeight="50">
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="10">
-                <Button Margin="5,0,5,0" Padding="5,0,5,0"  Click="Button_ExportDpx">Export DPX</Button>
-                <Button Margin="5,0,5,0" Padding="5,0,5,0"  Click="Button_ImportDpx">Import DPX</Button>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="10">
-                <Button Margin="5,0,5,0" Padding="5,0,5,0" Width="50" Background="PaleVioletRed" Click="Button_Test">TEST</Button>
-            </StackPanel>
+    
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
 
-        </Grid>
-        <TabControl TabStripPlacement="Right">
+        <Border Grid.Row="0" DockPanel.Dock="Bottom" Margin="10" Padding="5" CornerRadius="5" Background="#555555" BorderBrush="White" BorderThickness="1">
+            <StackPanel Orientation="Vertical">
+                <Label FontWeight="Bold" FontSize="18">Effects</Label>
+                <Separator Margin="0 0 0 10"/>
+                <TextBlock TextWrapping="Wrap">
+                    Effects file > Contains the DPX file (Effects and Particles) and the Casters (These use effects) <LineBreak/>
+                    Effects > Uses a mix of particle effects defined by the given Particle DPD's data <LineBreak/>
+                    Particles > Each DPD contains various effects. The Data entries define which particles are called and how <LineBreak/>
+                    NOTE: These packages are vast and most of it is not currently editable
+                </TextBlock>
+
+                <Grid MaxHeight="50">
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="10">
+                        <Button Margin="5,0,5,0" Padding="5,0,5,0"  Click="Button_ExportDpx">Export DPX</Button>
+                        <Button Margin="5,0,5,0" Padding="5,0,5,0"  Click="Button_ImportDpx">Import DPX</Button>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="10">
+                        <Button Margin="5,0,5,0" Padding="5,0,5,0" Width="50" Background="PaleVioletRed" Click="Button_Test">TEST</Button>
+                    </StackPanel>
+                </Grid>
+            </StackPanel>
+        </Border>
+
+        
+
+        <TabControl Grid.Row="1" TabStripPlacement="Right">
             <TabItem>
                 <TabItem.Header>
-                    <Label>Casters</Label>
+                    <StackPanel Orientation="Horizontal">
+                        <iconPacks:PackIconMaterial Kind="AutoFix" Height="15"/>
+                        <Label FontWeight="Bold" Margin="5 0">Casters</Label>
+                    </StackPanel>
                 </TabItem.Header>
                 <local:M_EffectElements_Control/>
             </TabItem>
             <TabItem>
                 <TabItem.Header>
-                    <Label>Effects</Label>
+                    <StackPanel Orientation="Horizontal">
+                        <iconPacks:PackIconMaterial Kind="CreationOutline" Height="15"/>
+                        <Label FontWeight="Bold" Margin="5 0">Effects</Label>
+                    </StackPanel>
                 </TabItem.Header>
                 <local:M_EffectParticles_Control/>
             </TabItem>
             <TabItem>
                 <TabItem.Header>
-                    <Label>Particles</Label>
+                    <StackPanel Orientation="Horizontal">
+                        <iconPacks:PackIconMaterial Kind="Star" Height="15"/>
+                        <Label FontWeight="Bold" Margin="5 0">Particles</Label>
+                    </StackPanel>
                 </TabItem.Header>
                 <local:M_EffectDpds_Control/>
             </TabItem>
         </TabControl>
-    </DockPanel>
+    </Grid>
 </UserControl>

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Model/ModelBoneViewer_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Model/ModelBoneViewer_Control.xaml
@@ -10,7 +10,8 @@
     <DataGrid Name="DataTable"
                 AutoGenerateColumns="False"
                 ItemsSource="{Binding ModelFile.Bones}"
-                CanUserAddRows="True">
+                CanUserAddRows="True"
+                GridLinesVisibility="All" HeadersVisibility="Column">
         <DataGrid.Columns>
             <DataGridTextColumn Binding="{Binding Path=Index}" Header="Index" />
             <DataGridTextColumn Binding="{Binding Path=SiblingIndex}" Header="SiblingIndex" />
@@ -28,7 +29,9 @@
             <DataGridTextColumn Binding="{Binding Path=TranslationY}" Header="TranslationY" />
             <DataGridTextColumn Binding="{Binding Path=TranslationZ}" Header="TranslationZ" />
             <DataGridTextColumn Binding="{Binding Path=TranslationW}" Header="TranslationW" />
-            <DataGridTextColumn Binding="{Binding Path=Flags}" Header="Flags" />
+            <!--<DataGridTextColumn Binding="{Binding Path=Flags}" Header="Flags" />-->
+            <DataGridCheckBoxColumn Binding="{Binding Path=NoEnvelop}" Header="No Envelop" />
+            <DataGridCheckBoxColumn Binding="{Binding Path=NoJoint}" Header="No Joint" />
         </DataGrid.Columns>
     </DataGrid>
     

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Model/ModuleModelMesh_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Model/ModuleModelMesh_Control.xaml
@@ -7,49 +7,48 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
 
-    <Grid  Background="#1d1d1d">
-        <StackPanel Margin="30">
-            <StackPanel Orientation="Horizontal">
-                <Label VerticalAlignment="Center" Margin="0,0,5,0" Foreground="White">Polygon count:</Label>
-                <Label Content="{Binding Path=Header.PolygonCount}" Foreground="White"/>
+    <StackPanel Background="#333333">
+        <Border Margin="10" Padding="5" CornerRadius="5" Background="#555555" BorderBrush="White" BorderThickness="1">
+            <StackPanel>
+
+                <Label FontWeight="Bold" FontSize="18">Info</Label>
+                <Separator/>
+                <Border Padding="10">
+                    <StackPanel Orientation="Horizontal">
+                        <Label VerticalAlignment="Center" Margin="0,0,5,0" Foreground="White">Polygon count:</Label>
+                        <Label Content="{Binding Path=Header.PolygonCount}" Foreground="White"/>
+                    </StackPanel>
+                </Border>
+                <Border Padding="10">
+                    <StackPanel Orientation="Horizontal">
+                        <Label VerticalAlignment="Center" Margin="0,0,5,0" Foreground="White">Texture:</Label>
+                        <TextBox Width="70" Text="{Binding Path=Header.TextureIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Background="#3d3d3d" Foreground="White" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Border>
+                
             </StackPanel>
-            <StackPanel Orientation="Horizontal">
-                <Label VerticalAlignment="Center" Margin="0,0,5,0" Foreground="White">Texture:</Label>
-                <TextBox Width="70" Text="{Binding Path=Header.TextureIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Background="#3d3d3d" Foreground="White" VerticalAlignment="Center"/>
+        </Border>
+
+
+        <Border Margin="10" Padding="5" CornerRadius="5" Background="#555555" BorderBrush="White" BorderThickness="1">
+            <StackPanel>
+                <Label FontWeight="Bold" FontSize="18">Flags</Label>
+                <Separator/>
+                <Border Padding="10">
+                    <WrapPanel>
+                        <CheckBox Width="150" IsChecked="{Binding Path=Header.DrawAlphaPhase, Mode=TwoWay}" VerticalAlignment="Center">Draw Alpha Phase</CheckBox>
+                        <CheckBox Width="150" IsChecked="{Binding Path=Header.Alpha, Mode=TwoWay}" VerticalAlignment="Center">Alpha</CheckBox>
+                        <CheckBox Width="150" IsChecked="{Binding Path=Header.Multi, Mode=TwoWay}" VerticalAlignment="Center">Multi</CheckBox>
+                        <CheckBox Width="150" IsChecked="{Binding Path=Header.AlphaEx, Mode=TwoWay}" VerticalAlignment="Center">Alpha Ex</CheckBox>
+                        <CheckBox Width="150" IsChecked="{Binding Path=Header.AlphaAdd, Mode=TwoWay}" VerticalAlignment="Center">Alpha Add</CheckBox>
+                        <CheckBox Width="150" IsChecked="{Binding Path=Header.AlphaSub, Mode=TwoWay}" VerticalAlignment="Center">Alpha Sub</CheckBox>
+                        <CheckBox Width="150" IsChecked="{Binding Path=Header.Specular, Mode=TwoWay}" VerticalAlignment="Center">Specular</CheckBox>
+                        <CheckBox Width="150" IsChecked="{Binding Path=Header.NoLight, Mode=TwoWay}" VerticalAlignment="Center">No Light</CheckBox>
+                    </WrapPanel>
+                </Border>
             </StackPanel>
-            <StackPanel Orientation="Horizontal">
-                <CheckBox IsChecked="{Binding Path=Header.DrawAlphaPhase, Mode=TwoWay}" VerticalAlignment="Center"/>
-                <Label VerticalAlignment="Center" Content="DrawAlphaPhase" Foreground="White"/>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal">
-                <CheckBox IsChecked="{Binding Path=Header.Alpha, Mode=TwoWay}" VerticalAlignment="Center"/>
-                <Label VerticalAlignment="Center" Content="Alpha" Foreground="White"/>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal">
-                <CheckBox IsChecked="{Binding Path=Header.Multi, Mode=TwoWay}" VerticalAlignment="Center"/>
-                <Label VerticalAlignment="Center" Content="Multi" Foreground="White"/>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal">
-                <CheckBox IsChecked="{Binding Path=Header.AlphaEx, Mode=TwoWay}" VerticalAlignment="Center"/>
-                <Label VerticalAlignment="Center" Content="AlphaEx" Foreground="White"/>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal">
-                <CheckBox IsChecked="{Binding Path=Header.AlphaAdd, Mode=TwoWay}" VerticalAlignment="Center"/>
-                <Label VerticalAlignment="Center" Content="AlphaAdd" Foreground="White"/>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal">
-                <CheckBox IsChecked="{Binding Path=Header.AlphaSub, Mode=TwoWay}" VerticalAlignment="Center"/>
-                <Label VerticalAlignment="Center" Content="AlphaSub" Foreground="White"/>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal">
-                <CheckBox IsChecked="{Binding Path=Header.Specular, Mode=TwoWay}" VerticalAlignment="Center"/>
-                <Label VerticalAlignment="Center" Content="Specular" Foreground="White"/>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal">
-                <CheckBox IsChecked="{Binding Path=Header.NoLight, Mode=TwoWay}" VerticalAlignment="Center"/>
-                <Label VerticalAlignment="Center" Content="NoLight" Foreground="White"/>
-            </StackPanel>
-        </StackPanel>
-    </Grid>
+        </Border>
+
+    </StackPanel>
 
 </UserControl>

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Model/ModuleModelMeshes_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Model/ModuleModelMeshes_Control.xaml
@@ -6,35 +6,50 @@
              xmlns:local="clr-namespace:OpenKh.Tools.Kh2ObjectEditor.Views"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
-    <Grid>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="auto" />
-            <ColumnDefinition Width="200" />
-        </Grid.ColumnDefinitions>
 
-        <ContentControl x:Name="MeshFrame"/>
+    <Border BorderThickness="1" BorderBrush="LightGray">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="auto" />
+                <ColumnDefinition Width="200" />
+            </Grid.ColumnDefinitions>
 
-        <GridSplitter Grid.Column="1" Background="LightGray" HorizontalAlignment="Center" VerticalAlignment="Stretch" ShowsPreview="True" Width="5"/>
+            <ContentControl x:Name="MeshFrame"/>
 
-        <DockPanel Grid.Column="2">
-            <!-- Filters -->
-            <StackPanel Visibility="Collapsed" DockPanel.Dock="Bottom" Orientation="Vertical" Margin="10" HorizontalAlignment="Center">
-                <Button Width="100" Click="Button_MoveMeshUp">^</Button>
-                <Button Width="100" Click="Button_MoveMeshDown">V</Button>
-            </StackPanel>
+            <GridSplitter Grid.Column="1" Background="LightGray" HorizontalAlignment="Center" VerticalAlignment="Stretch" ShowsPreview="True" Width="2"/>
 
-            <ListView x:Name="List_Meshes" ItemsSource="{Binding Meshes}" SelectedItem="{Binding SelectedMesh}" MouseDoubleClick="list_doubleCLick">
-                <ListView.ItemTemplate>
-                    <DataTemplate>
-                        <StackPanel Orientation="Vertical">
-                            <TextBlock Text="{Binding Path=Name}"/>
-                            <TextBlock Text="{Binding Path=Group.Header.PolygonCount}"/>
-                        </StackPanel>
-                    </DataTemplate>
-                </ListView.ItemTemplate>
-            </ListView>
+            <DockPanel Grid.Column="2">
+                <!-- Filters -->
+                <StackPanel Visibility="Collapsed" DockPanel.Dock="Bottom" Orientation="Vertical" Margin="10" HorizontalAlignment="Center">
+                    <Button Width="100" Click="Button_MoveMeshUp">^</Button>
+                    <Button Width="100" Click="Button_MoveMeshDown">V</Button>
+                </StackPanel>
 
-        </DockPanel>
-    </Grid>
+                <ListView x:Name="List_Meshes" ItemsSource="{Binding Meshes}" SelectedItem="{Binding SelectedMesh}" SelectionChanged="Meshes_SelectionChanged" >
+                    <ListView.ItemContainerStyle>
+                        <Style TargetType="ListViewItem">
+                            <Setter Property="Margin" Value="0,0,0,1"/>
+                            <Setter Property="BorderBrush" Value="#22FFFFFF"/>
+                            <Setter Property="BorderThickness" Value="0,0,0,1"/>
+                            <Setter Property="Padding" Value="5"/>
+                        </Style>
+                    </ListView.ItemContainerStyle>
+                    <ListView.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Vertical">
+                                <TextBlock Text="{Binding Path=Name}" FontWeight="Bold"/>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="Polygon Count: " FontSize="12"/>
+                                    <TextBlock Text="{Binding Path=Group.Header.PolygonCount}" FontSize="12"/>
+                                </StackPanel>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+
+            </DockPanel>
+        </Grid>
+    </Border>
+    
 </UserControl>

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Model/ModuleModelMeshes_Control.xaml.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Model/ModuleModelMeshes_Control.xaml.cs
@@ -19,13 +19,6 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Views
             }
         }
 
-        private void list_doubleCLick(object sender, System.Windows.Input.MouseButtonEventArgs e)
-        {
-            MeshWrapper item = (MeshWrapper)(sender as ListView).SelectedItem;
-
-            MeshFrame.Content = new ModuleModelMesh_Control(item.Group);
-        }
-
         private void Button_MoveMeshUp(object sender, System.Windows.RoutedEventArgs e)
         {
             if (List_Meshes.SelectedItem == null)
@@ -49,6 +42,16 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Views
             {
                 List_Meshes.SelectedIndex = newIndex;
             }
+        }
+
+        private void Meshes_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if((MeshWrapper)(sender as ListView).SelectedItem == null) {
+                return;
+            }
+            MeshWrapper item = (MeshWrapper)(sender as ListView).SelectedItem;
+
+            MeshFrame.Content = new ModuleModelMesh_Control(item.Group);
         }
     }
 }

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Model/ModuleModel_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Model/ModuleModel_Control.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:OpenKh.Tools.Kh2ObjectEditor.Views"
+             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
              mc:Ignorable="d" 
              d:DesignHeight="800" d:DesignWidth="600">
     <Grid>
@@ -14,13 +15,19 @@
         <TabControl Grid.Column="0">
             <TabItem>
                 <TabItem.Header>
-                    <Label>Meshes</Label>
+                    <StackPanel Orientation="Horizontal">
+                        <iconPacks:PackIconPhosphorIcons Kind="Cube" Height="20"/>
+                        <Label FontWeight="Bold" Margin="5 0">Meshes</Label>
+                    </StackPanel>
                 </TabItem.Header>
                 <local:ModuleModelMeshes_Control/>
             </TabItem>
             <TabItem>
                 <TabItem.Header>
-                    <Label>Skeleton</Label>
+                    <StackPanel Orientation="Horizontal">
+                        <iconPacks:PackIconPhosphorIcons Kind="Bone" Height="20"/>
+                        <Label FontWeight="Bold" Margin="5 0">Bones</Label>
+                    </StackPanel>
                 </TabItem.Header>
                 <local:ModelBoneViewer_Control/>
             </TabItem>

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Motions/ModuleMotions_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Motions/ModuleMotions_Control.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:OpenKh.Tools.Kh2ObjectEditor.Views"
+             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
              mc:Ignorable="d" 
              d:DesignHeight="800" d:DesignWidth="600">
     <Grid>
@@ -16,13 +17,19 @@
         <TabControl Grid.Column="0">
             <TabItem>
                 <TabItem.Header>
-                    <Label>Metadata</Label>
+                    <StackPanel Orientation="Horizontal">
+                        <iconPacks:PackIconPhosphorIcons Kind="NoteLight" Height="20"/>
+                        <Label FontWeight="Bold" Margin="5 0">Metadata</Label>
+                    </StackPanel>
                 </TabItem.Header>
                 <ContentControl Name="Frame_Metadata"/>
             </TabItem>
             <TabItem>
                 <TabItem.Header>
-                    <Label>Triggers</Label>
+                    <StackPanel Orientation="Horizontal">
+                        <iconPacks:PackIconMaterial Kind="AutoFix" Height="20"/>
+                        <Label FontWeight="Bold" Margin="5 0">Triggers</Label>
+                    </StackPanel>
                 </TabItem.Header>
                 <ContentControl Name="Frame_Triggers"/>
                 <!--<local:DataViewer_Control Grid.Row="1"/>-->
@@ -38,21 +45,41 @@
             </Grid>
             <!-- Filters -->
             <StackPanel DockPanel.Dock="Bottom" Orientation="Vertical" Margin="10">
-                <Button FontFamily="Marlett" FontSize="20" Content="5" IsEnabled="{Binding AllowMotionMove}" Click="Motion_MoveUp"/>
-                <Button FontFamily="Marlett" FontSize="20" Content="6" IsEnabled="{Binding AllowMotionMove}" Click="Motion_MoveDown"/>
-                <Label Foreground="White" FontWeight="Bold">Filters</Label>
-                <StackPanel Orientation="Horizontal">
-                    <Label Foreground="White" VerticalAlignment="Center" Margin="0,0,5,0">Name:</Label>
-                    <TextBox Name="FilterName" Text="{Binding FilterName}" Width="100" VerticalContentAlignment="Center" PreviewKeyDown="FilterName_PreviewKeyDown" TextChanged="FilterName_TextChanged"></TextBox>
-                </StackPanel>
-                <StackPanel Orientation="Horizontal">
-                    <Label Foreground="White" VerticalAlignment="Center" Margin="0,0,5,0">Hide Dummies:</Label>
-                    <CheckBox IsChecked="{Binding FilterHideDummies}" VerticalAlignment="Center" Checked="HideDummies_Checked" Unchecked="HideDummies_Unchecked"/>
-                </StackPanel>
+                <Button IsEnabled="{Binding AllowMotionMove}" Click="Motion_MoveUp" HorizontalAlignment="Stretch" BorderBrush="DarkGray" BorderThickness="1">
+                    <iconPacks:PackIconMaterialDesign Kind="ArrowDropUp" />
+                </Button>
+                <Button IsEnabled="{Binding AllowMotionMove}" Click="Motion_MoveDown" HorizontalAlignment="Stretch" BorderBrush="DarkGray" BorderThickness="1">
+                    <iconPacks:PackIconMaterialDesign Kind="ArrowDropDown" />
+                </Button>
+
+                <Border Margin="5" Padding="10" CornerRadius="5" Background="#555555" BorderBrush="White" BorderThickness="1">
+                    <StackPanel>
+                        <Label FontWeight="Bold">Filters</Label>
+                        <Separator Margin="0 0 0 10"/>
+                        <StackPanel Orientation="Horizontal">
+                            <Label Foreground="White" VerticalAlignment="Center" Margin="0,0,5,0">Name:</Label>
+                            <TextBox Name="FilterName" Text="{Binding FilterName}" Width="100" VerticalContentAlignment="Center" PreviewKeyDown="FilterName_PreviewKeyDown" TextChanged="FilterName_TextChanged"></TextBox>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <Label Foreground="White" VerticalAlignment="Center" Margin="0,0,5,0">Hide Dummies:</Label>
+                            <CheckBox IsChecked="{Binding FilterHideDummies}" VerticalAlignment="Center" Checked="HideDummies_Checked" Unchecked="HideDummies_Unchecked"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
             </StackPanel>
 
             <!-- Motion list -->
             <ListView Name="MotionList" ItemsSource="{Binding MotionsView}" SelectedItem="{Binding SelectedMotion}"  MouseDoubleClick="list_doubleCLick">
+
+                <ListView.ItemContainerStyle>
+                <Style TargetType="ListViewItem">
+                    <Setter Property="Margin" Value="0,0,0,1"/>
+                    <Setter Property="BorderBrush" Value="#22FFFFFF"/>
+                    <Setter Property="BorderThickness" Value="0,0,0,1"/>
+                    <Setter Property="Padding" Value="5"/>
+                </Style>
+                </ListView.ItemContainerStyle>
+
                 <ListView.ContextMenu>
                     <ContextMenu>
                         <MenuItem Header="Rename" Click="Motion_Rename"/>
@@ -75,7 +102,24 @@
                 </ListView.ContextMenu>
                 <ListView.ItemTemplate>
                     <DataTemplate>
-                        <TextBlock Grid.Column="0" Text="{Binding Path=Name}"/>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="40"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Label Grid.Column="0" FontWeight="Bold" Content="{Binding IndexString}" VerticalAlignment="Center"></Label>
+                            <StackPanel Grid.Column="1">
+                                <StackPanel Orientation="Horizontal">
+                                    <Label FontSize="12" FontWeight="Bold" Content="{Binding Entry.Name}"></Label>
+                                    <Label FontSize="8" Content="{Binding Tags}" Margin="5 0 0 0"></Label>
+                                </StackPanel>
+
+                                <StackPanel Orientation="Horizontal">
+                                    <Label FontSize="12" Content="{Binding MotionName}"></Label>
+                                </StackPanel>
+                            </StackPanel>
+                        </Grid>
+                        <!--<TextBlock Grid.Column="0" Text="{Binding Path=Name}"/>-->
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Motions/MotionMetadata_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Motions/MotionMetadata_Control.xaml
@@ -6,58 +6,106 @@
              xmlns:local="clr-namespace:OpenKh.Tools.Kh2ObjectEditor.Modules.Motions"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
-    <DockPanel Background="Black">
-        <StackPanel DockPanel.Dock="Top" Margin="20">
 
-            <StackPanel Orientation="Horizontal">
-                <Label Foreground="White" VerticalAlignment="Center">Bone Count:</Label>
-                <TextBox MinWidth="30" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.BoneCount}"></TextBox>
-            </StackPanel>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="50"/>
+        </Grid.RowDefinitions>
 
-            <StackPanel Orientation="Horizontal">
-                <Label Foreground="White" VerticalAlignment="Center">Frame count:</Label>
-                <TextBox MinWidth="30" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.FrameCount}"></TextBox>
-                <Label Foreground="White" VerticalAlignment="Center">Frames per second:</Label>
-                <TextBox MinWidth="30" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.FrameData.FramesPerSecond}"></TextBox>
-            </StackPanel>
+        <StackPanel Grid.Row="0" Margin="20">
 
-            <StackPanel Orientation="Horizontal">
-                <Label Foreground="White" VerticalAlignment="Center">Frame start:</Label>
-                <TextBox MinWidth="30" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.FrameData.FrameStart}"></TextBox>
-                <Label Foreground="White" VerticalAlignment="Center">Frame end:</Label>
-                <TextBox MinWidth="30" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.FrameData.FrameEnd}"></TextBox>
-                <Label Foreground="White" VerticalAlignment="Center">Frame return:</Label>
-                <TextBox MinWidth="30" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.FrameData.FrameReturn}"></TextBox>
-            </StackPanel>
-            <Label Foreground="White">Note: These 3 values above have to be proportional to 60 fps</Label>
-            <Label Foreground="White">30 fps = Halved | 60 fps = Normal | 120 fps = Doubled</Label>
-            <Separator Height="20"/>
-            <Label Foreground="White">BOUNDING BOX</Label>
-            <StackPanel Orientation="Horizontal">
-                <Label Foreground="White" VerticalAlignment="Center">Bound MinX:</Label>
-                <TextBox MinWidth="25" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.BoundingBox.BoundingBoxMinX}"></TextBox>
-                <Label Foreground="White" VerticalAlignment="Center">Bound MinY:</Label>
-                <TextBox MinWidth="25" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.BoundingBox.BoundingBoxMinY}"></TextBox>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal">
-                <Label Foreground="White" VerticalAlignment="Center">Bound MinZ:</Label>
-                <TextBox MinWidth="25" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.BoundingBox.BoundingBoxMinZ}"></TextBox>
-                <Label Foreground="White" VerticalAlignment="Center">Bound MinW:</Label>
-                <TextBox MinWidth="25" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.BoundingBox.BoundingBoxMinW}"></TextBox>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal">
-                <Label Foreground="White" VerticalAlignment="Center">Bound MaxX:</Label>
-                <TextBox MinWidth="25" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.BoundingBox.BoundingBoxMaxX}"></TextBox>
-                <Label Foreground="White" VerticalAlignment="Center">Bound MaxY:</Label>
-                <TextBox MinWidth="25" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.BoundingBox.BoundingBoxMaxY}"></TextBox>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal">
-                <Label Foreground="White" VerticalAlignment="Center">Bound MaxZ:</Label>
-                <TextBox MinWidth="25" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.BoundingBox.BoundingBoxMaxZ}"></TextBox>
-                <Label Foreground="White" VerticalAlignment="Center">Bound MaxW:</Label>
-                <TextBox MinWidth="25" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.BoundingBox.BoundingBoxMaxW}"></TextBox>
-            </StackPanel>
-            <Button Margin="10,0,10,0" Padding="5,0,5,0" Height="40px" Width="120" HorizontalAlignment="Left" Click="Button_SaveTriggers">Save Metadata</Button>
+            <Border DockPanel.Dock="Bottom" Padding="5" CornerRadius="5" Background="#555555" BorderBrush="White" BorderThickness="1">
+                <StackPanel Orientation="Vertical">
+                    <Label FontWeight="Bold" FontSize="18">Properties</Label>
+                    <Separator Margin="0 0 0 10"/>
+                    
+                    <StackPanel Orientation="Horizontal">
+                        <Label Foreground="White" VerticalAlignment="Center">Bone Count:</Label>
+                        <TextBox MinWidth="30" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.BoneCount}"></TextBox>
+                    </StackPanel>
+
+                    <StackPanel Orientation="Horizontal">
+                        <Label Foreground="White" VerticalAlignment="Center">Frame count:</Label>
+                        <TextBox MinWidth="30" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.FrameCount}"></TextBox>
+                        <Label Foreground="White" VerticalAlignment="Center">Frames per second:</Label>
+                        <TextBox MinWidth="30" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.FrameData.FramesPerSecond}"></TextBox>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
+            <Border DockPanel.Dock="Bottom" Margin="0 10 0 0" Padding="5" CornerRadius="5" Background="#555555" BorderBrush="White" BorderThickness="1">
+                <StackPanel Orientation="Vertical">
+                    <Label FontWeight="Bold" FontSize="18">Frame Data</Label>
+                    <Separator Margin="0 0 0 10"/>
+
+                    <StackPanel Orientation="Horizontal">
+                        <Label Foreground="White" VerticalAlignment="Center">Frame start:</Label>
+                        <TextBox MinWidth="30" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.FrameData.FrameStart}"></TextBox>
+                        <Label Foreground="White" VerticalAlignment="Center">Frame end:</Label>
+                        <TextBox MinWidth="30" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.FrameData.FrameEnd}"></TextBox>
+                        <Label Foreground="White" VerticalAlignment="Center">Frame return:</Label>
+                        <TextBox MinWidth="30" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.FrameData.FrameReturn}"></TextBox>
+                    </StackPanel>
+                    <Label Foreground="White">Note: These 3 values have to be proportional to 60 fps</Label>
+                    <Label Foreground="White">30 fps = Halved | 60 fps = Normal | 120 fps = Doubled</Label>
+                </StackPanel>
+            </Border>
+
+            <Border DockPanel.Dock="Bottom" Margin="0 10 0 0" Padding="5" CornerRadius="5" Background="#555555" BorderBrush="White" BorderThickness="1">
+                <StackPanel Orientation="Vertical">
+                    <Label FontWeight="Bold" FontSize="18">Bounding Box</Label>
+                    <Separator Margin="0 0 0 10"/>
+
+                    <WrapPanel>
+                        <StackPanel Orientation="Horizontal" Width="170">
+                            <Label Width="40" Foreground="White" VerticalAlignment="Center">Min X:</Label>
+                            <TextBox Width="100" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.BoundingBox.BoundingBoxMinX}"></TextBox>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Width="170">
+                            <Label Width="40" Foreground="White" VerticalAlignment="Center">Max X:</Label>
+                            <TextBox Width="100" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.BoundingBox.BoundingBoxMaxX}"></TextBox>
+                        </StackPanel>
+                    </WrapPanel>
+
+                    <WrapPanel>
+                        <StackPanel Orientation="Horizontal" Width="170">
+                            <Label Width="40" Foreground="White" VerticalAlignment="Center">Min Y:</Label>
+                            <TextBox Width="100" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.BoundingBox.BoundingBoxMinY}"></TextBox>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Width="170">
+                            <Label Width="40" Foreground="White" VerticalAlignment="Center">Max Y:</Label>
+                            <TextBox Width="100" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.BoundingBox.BoundingBoxMaxY}"></TextBox>
+                        </StackPanel>
+                    </WrapPanel>
+
+                    <WrapPanel>
+                        <StackPanel Orientation="Horizontal" Width="170">
+                            <Label Width="40" Foreground="White" VerticalAlignment="Center">Min Z:</Label>
+                            <TextBox Width="100" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.BoundingBox.BoundingBoxMinZ}"></TextBox>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Width="170">
+                            <Label Width="40" Foreground="White" VerticalAlignment="Center">Max Z:</Label>
+                            <TextBox Width="100" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.BoundingBox.BoundingBoxMaxZ}"></TextBox>
+                        </StackPanel>
+                    </WrapPanel>
+
+                    <WrapPanel>
+                        <StackPanel Orientation="Horizontal" Width="170">
+                            <Label Width="40" Foreground="White" VerticalAlignment="Center">Min W:</Label>
+                            <TextBox Width="100" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.BoundingBox.BoundingBoxMinW}"></TextBox>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Width="170">
+                            <Label Width="40" Foreground="White" VerticalAlignment="Center">Max W:</Label>
+                            <TextBox Width="100" Margin="10" Text="{Binding Path=MotionFile.InterpolatedMotionHeader.BoundingBox.BoundingBoxMaxW}"></TextBox>
+                        </StackPanel>
+                    </WrapPanel>
+                    
+                </StackPanel>
+            </Border>
+
         </StackPanel>
-    </DockPanel>
+
+        <Button Grid.Row="1" Margin="10" Padding="5,0,5,0" Height="40px" Width="120" HorizontalAlignment="Right" Click="Button_SaveTriggers">Save Metadata</Button>
+    </Grid>
 </UserControl>

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Motions/MotionTriggers_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Motions/MotionTriggers_Control.xaml
@@ -7,6 +7,12 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
 
+
+    <UserControl.Resources>
+        <local:RangeTriggerConverter x:Key="RangeTriggerConverter" />
+        <local:FrameTriggerConverter x:Key="FrameTriggerConverter" />
+    </UserControl.Resources>
+
     <Grid>
         
         <Grid.RowDefinitions>
@@ -22,71 +28,89 @@
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
 
-            <DockPanel Grid.Row="0">
-                <Label DockPanel.Dock="Top" HorizontalAlignment="Center" Foreground="White">Range Triggers</Label>
-                <DataGrid ItemsSource="{Binding RangeTriggerList}" AutoGenerateColumns="False" CanUserAddRows="True">
 
-                    <DataGrid.Resources>
-                        <local:RangeTriggerConverter x:Key="RangeTriggerConverter" />
-                    </DataGrid.Resources>
+            <Border Grid.Row="0" Margin="10" Padding="5" CornerRadius="5" Background="#555555" BorderBrush="White" BorderThickness="1">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+
+                    <StackPanel Grid.Row="0">
+                        <Label FontWeight="Bold" FontSize="18">Range Triggers</Label>
+                        <Separator Margin="0 0 0 10"/>
+                    </StackPanel>
+
+                    <DataGrid Grid.Row="1" ItemsSource="{Binding RangeTriggerList}" AutoGenerateColumns="False" CanUserAddRows="True"
+                                  GridLinesVisibility="All" HeadersVisibility="Column" Background="#222222">
+
+                        <DataGrid.Columns>
+
+                            <DataGridTemplateColumn Header="Trigger">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <ComboBox HorizontalAlignment="Stretch"
+                              SelectedItem="{Binding Trigger, Converter={StaticResource RangeTriggerConverter}, Mode=TwoWay}"
+                              ItemsSource="{Binding DataContext.RangeTriggerOptions2, RelativeSource={RelativeSource AncestorType=UserControl}}" />
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+
+                            <DataGridTextColumn Binding="{Binding Path=StartFrame}" Header="Start Frame" />
+                            <DataGridTextColumn Binding="{Binding Path=EndFrame}" Header="End Frame" />
+                            <DataGridTextColumn Binding="{Binding Path=ParamSize}" Header="Param Size"/>
+                            <DataGridTextColumn Binding="{Binding Path=Param1}" Header="Param 1" />
+                            <DataGridTextColumn Binding="{Binding Path=Param2}" Header="Param 2" />
+                            <DataGridTextColumn Binding="{Binding Path=Param3}" Header="Param 3" />
+                            <DataGridTextColumn Binding="{Binding Path=Param4}" Header="Param 4" />
+                        </DataGrid.Columns>
+                    </DataGrid>
+
+                </Grid>
+            </Border>
+
+            <GridSplitter Grid.Row="1" Background="LightGray" VerticalAlignment="Center" HorizontalAlignment="Stretch" ShowsPreview="True" Height="2"/>
+
+            <Border Grid.Row="2" Margin="10" Padding="5" CornerRadius="5" Background="#555555" BorderBrush="White" BorderThickness="1">
+
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+
+                    <StackPanel Grid.Row="0">
+                        <Label FontWeight="Bold" FontSize="18">Frame Triggers</Label>
+                        <Separator Margin="0 0 0 10"/>
+                    </StackPanel>
                     
-                    <DataGrid.Columns>
+                    <DataGrid Grid.Row="1" AutoGenerateColumns="False"
+                              ItemsSource="{Binding FrameTriggerList}"
+                              CanUserAddRows="True"
+                              GridLinesVisibility="All" HeadersVisibility="Column" Background="#222222">
 
-                        <DataGridTemplateColumn Header="Trigger">
-                            <DataGridTemplateColumn.CellTemplate>
-                                <DataTemplate>
-                                    <ComboBox HorizontalAlignment="Stretch"
-                                      SelectedItem="{Binding Trigger, Converter={StaticResource RangeTriggerConverter}, Mode=TwoWay}"
-                                      ItemsSource="{Binding DataContext.RangeTriggerOptions2, RelativeSource={RelativeSource AncestorType=UserControl}}" />
-                                </DataTemplate>
-                            </DataGridTemplateColumn.CellTemplate>
-                        </DataGridTemplateColumn>
+                        <DataGrid.Columns>
 
-                        <DataGridTextColumn Binding="{Binding Path=StartFrame}" Header="Start Frame" />
-                        <DataGridTextColumn Binding="{Binding Path=EndFrame}" Header="End Frame" />
-                        <DataGridTextColumn Binding="{Binding Path=ParamSize}" Header="Param Size"/>
-                        <DataGridTextColumn Binding="{Binding Path=Param1}" Header="Param 1" />
-                        <DataGridTextColumn Binding="{Binding Path=Param2}" Header="Param 2" />
-                        <DataGridTextColumn Binding="{Binding Path=Param3}" Header="Param 3" />
-                        <DataGridTextColumn Binding="{Binding Path=Param4}" Header="Param 4" />
-                    </DataGrid.Columns>
-                </DataGrid>
-            </DockPanel>
+                            <DataGridTemplateColumn Header="Trigger">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <ComboBox HorizontalAlignment="Stretch"
+                                                  SelectedItem="{Binding Trigger, Converter={StaticResource FrameTriggerConverter}, Mode=TwoWay}"
+                                                  ItemsSource="{Binding DataContext.FrameTriggerOptions2, RelativeSource={RelativeSource AncestorType=UserControl}}" />
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
 
-            <GridSplitter Grid.Row="1" Background="LightGray" VerticalAlignment="Center" HorizontalAlignment="Stretch" ShowsPreview="True" Height="5"/>
-
-            <DockPanel Grid.Row="2">
-                <Label DockPanel.Dock="Top" HorizontalAlignment="Center" Foreground="White">Frame Triggers</Label>
-                <DataGrid
-                  AutoGenerateColumns="False"
-                  ItemsSource="{Binding FrameTriggerList}"
-                  CanUserAddRows="True">
-
-                    <DataGrid.Resources>
-                        <local:FrameTriggerConverter x:Key="FrameTriggerConverter" />
-                    </DataGrid.Resources>
-                    
-                    <DataGrid.Columns>
-
-                        <DataGridTemplateColumn Header="Trigger">
-                            <DataGridTemplateColumn.CellTemplate>
-                                <DataTemplate>
-                                    <ComboBox HorizontalAlignment="Stretch"
-                                      SelectedItem="{Binding Trigger, Converter={StaticResource FrameTriggerConverter}, Mode=TwoWay}"
-                                      ItemsSource="{Binding DataContext.FrameTriggerOptions2, RelativeSource={RelativeSource AncestorType=UserControl}}" />
-                                </DataTemplate>
-                            </DataGridTemplateColumn.CellTemplate>
-                        </DataGridTemplateColumn>
-
-                        <DataGridTextColumn Binding="{Binding Path=Frame}" Header="Frame" />
-                        <DataGridTextColumn Binding="{Binding Path=ParamSize}" Header="ParamSize"/>
-                        <DataGridTextColumn Binding="{Binding Path=Param1}" Header="Param 1" />
-                        <DataGridTextColumn Binding="{Binding Path=Param2}" Header="Param 2" />
-                        <DataGridTextColumn Binding="{Binding Path=Param3}" Header="Param 3" />
-                        <DataGridTextColumn Binding="{Binding Path=Param4}" Header="Param 4" />
-                    </DataGrid.Columns>
-                </DataGrid>
-            </DockPanel>
+                            <DataGridTextColumn Binding="{Binding Path=Frame}" Header="Frame" />
+                            <DataGridTextColumn Binding="{Binding Path=ParamSize}" Header="ParamSize"/>
+                            <DataGridTextColumn Binding="{Binding Path=Param1}" Header="Param 1" />
+                            <DataGridTextColumn Binding="{Binding Path=Param2}" Header="Param 2" />
+                            <DataGridTextColumn Binding="{Binding Path=Param3}" Header="Param 3" />
+                            <DataGridTextColumn Binding="{Binding Path=Param4}" Header="Param 4" />
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </Grid>
+            </Border>
 
         </Grid>
 

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Textures/ModuleTextures_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Textures/ModuleTextures_Control.xaml
@@ -4,14 +4,27 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:OpenKh.Tools.Kh2ObjectEditor.Modules.Textures"
+             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
         <TabControl>
-            <TabItem Header="Textures">
+            <TabItem>
+                <TabItem.Header>
+                    <StackPanel Orientation="Horizontal">
+                        <iconPacks:PackIconPhosphorIcons Kind="Image" Height="20"/>
+                        <Label FontWeight="Bold" Margin="5 0">Textures</Label>
+                    </StackPanel>
+                </TabItem.Header>
                 <local:TextureImages_Control/>
             </TabItem>
-            <TabItem Header="Animations">
+            <TabItem>
+                <TabItem.Header>
+                    <StackPanel Orientation="Horizontal">
+                        <iconPacks:PackIconMaterial Kind="AnimationPlay" Height="20"/>
+                        <Label FontWeight="Bold" Margin="5 0">Animations</Label>
+                    </StackPanel>
+                </TabItem.Header>
                 <local:TextureAnimations_Control/>
             </TabItem>
         </TabControl>

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Textures/TextureAnimations_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Textures/TextureAnimations_Control.xaml
@@ -29,7 +29,7 @@
                 Stretch="Uniform"/>
         </Canvas> -->
 
-        <GridSplitter Grid.Column="1" Background="LightGray" HorizontalAlignment="Center" VerticalAlignment="Stretch" ShowsPreview="True" Width="5"/>
+        <GridSplitter Grid.Column="1" Background="LightGray" HorizontalAlignment="Center" VerticalAlignment="Stretch" ShowsPreview="True" Width="2"/>
 
         <DockPanel Grid.Column="2">
             <!-- Filters -->
@@ -38,7 +38,17 @@
                 <Button Width="100" Click="Button_MoveTextureDown">V</Button>
             </StackPanel> -->
 
-            <ListView x:Name="List_Textures" ItemsSource="{Binding TexAnims}" SelectedItem="{Binding SelectedAnim}" MouseDoubleClick="list_doubleCLick">
+            <ListView x:Name="List_Textures" ItemsSource="{Binding TexAnims}" SelectedItem="{Binding SelectedAnim}" SelectionChanged="Animation_SelectionChanged">
+
+                <ListView.ItemContainerStyle>
+                    <Style TargetType="ListViewItem">
+                        <Setter Property="Margin" Value="0,0,0,1"/>
+                        <Setter Property="BorderBrush" Value="#22FFFFFF"/>
+                        <Setter Property="BorderThickness" Value="0,0,0,1"/>
+                        <Setter Property="Padding" Value="5"/>
+                    </Style>
+                </ListView.ItemContainerStyle>
+
                 <ListView.ContextMenu>
                     <ContextMenu>
                         <MenuItem Header="Export as PNG" Click="Texture_Export"/>
@@ -50,8 +60,11 @@
                 <ListView.ItemTemplate>
                     <DataTemplate>
                         <StackPanel Orientation="Vertical">
-                            <TextBlock Text="{Binding Path=Name}"/>
-                            <TextBlock Text="{Binding Path=Group.Header.PolygonCount}"/>
+                            <Label FontWeight="Bold" Content="{Binding Path=Name}"/>
+                            <StackPanel Orientation="Horizontal">
+                                <Label FontSize="12">On Texture:</Label>
+                                <Label FontSize="12" Margin="3 0 0 0" Content="{Binding Path=TextureAnim.TextureIndex}"/>
+                            </StackPanel>
                         </StackPanel>
                     </DataTemplate>
                 </ListView.ItemTemplate>

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Textures/TextureAnimations_Control.xaml.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Textures/TextureAnimations_Control.xaml.cs
@@ -19,7 +19,7 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Textures
             }
         }
 
-        private void list_doubleCLick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        private void Animation_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if ((sender as ListView).SelectedItem == null)
                 return;

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Textures/TextureImages_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Textures/TextureImages_Control.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:OpenKh.Tools.Kh2ObjectEditor.Modules.Textures"
+             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
@@ -17,7 +18,7 @@
             <Canvas.Background>
                 <DrawingBrush TileMode="Tile" Viewport="0,0,32,32" ViewportUnits="Absolute">
                     <DrawingBrush.Drawing>
-                        <GeometryDrawing Geometry="M0,0 H16 V16 H32 V32 H16 V16 H0Z" Brush="#80000000"/>
+                        <GeometryDrawing Geometry="M0,0 H16 V16 H32 V32 H16 V16 H0Z" Brush="#80555555"/>
                     </DrawingBrush.Drawing>
                 </DrawingBrush>
             </Canvas.Background>
@@ -31,12 +32,27 @@
 
         <DockPanel Grid.Column="2">
             <!-- Filters -->
-            <StackPanel DockPanel.Dock="Bottom" Orientation="Vertical" Margin="10" HorizontalAlignment="Center">
-                <Button Width="100" Click="Button_MoveTextureUp">Move Up</Button>
-                <Button Width="100" Click="Button_MoveTextureDown">Move Down</Button>
+            <StackPanel DockPanel.Dock="Bottom" Orientation="Vertical" Margin="10">
+
+                <Button IsEnabled="{Binding AllowMotionMove}" Click="Button_MoveTextureUp" HorizontalAlignment="Stretch" BorderBrush="DarkGray" BorderThickness="1">
+                    <iconPacks:PackIconMaterialDesign Kind="ArrowDropUp" />
+                </Button>
+                <Button IsEnabled="{Binding AllowMotionMove}" Click="Button_MoveTextureDown" HorizontalAlignment="Stretch" BorderBrush="DarkGray" BorderThickness="1">
+                    <iconPacks:PackIconMaterialDesign Kind="ArrowDropDown" />
+                </Button>
             </StackPanel>
 
-            <ListView x:Name="List_Textures" ItemsSource="{Binding Textures}" SelectedItem="{Binding SelectedMesh}" MouseDoubleClick="list_doubleCLick">
+            <ListView x:Name="List_Textures" ItemsSource="{Binding Textures}" SelectedItem="{Binding SelectedMesh}" SelectionChanged="Texture_SelectionChanged">
+
+                <ListView.ItemContainerStyle>
+                    <Style TargetType="ListViewItem">
+                        <Setter Property="Margin" Value="0,0,0,1"/>
+                        <Setter Property="BorderBrush" Value="#22FFFFFF"/>
+                        <Setter Property="BorderThickness" Value="0,0,0,1"/>
+                        <Setter Property="Padding" Value="5"/>
+                    </Style>
+                </ListView.ItemContainerStyle>
+
                 <ListView.ContextMenu>
                     <ContextMenu>
                         <MenuItem Header="Export as PNG" Click="Texture_Export"/>
@@ -48,11 +64,11 @@
                 <ListView.ItemTemplate>
                     <DataTemplate>
                         <StackPanel Orientation="Vertical">
-                            <TextBlock Text="{Binding Path=Name}"/>
+                            <TextBlock Text="{Binding Path=Name}" FontWeight="Bold"/>
                             <StackPanel Orientation="Horizontal">
-                                <Label Content="{Binding Path=SizeX}"/>
-                                <Label>X</Label>
-                                <Label Content="{Binding Path=SizeY}"/>
+                                <Label FontSize="12" Content="{Binding Path=SizeX}"/>
+                                <Label FontSize="12">X</Label>
+                                <Label FontSize="12" Content="{Binding Path=SizeY}"/>
                             </StackPanel>
                         </StackPanel>
                     </DataTemplate>

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Textures/TextureImages_Control.xaml.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Textures/TextureImages_Control.xaml.cs
@@ -33,12 +33,6 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Textures
             ImageFrame.Source = mat.GetAsBitmapImage();
         }
 
-        private void list_doubleCLick(object sender, System.Windows.Input.MouseButtonEventArgs e)
-        {
-            TextureWrapper item = (TextureWrapper)(sender as ListView).SelectedItem;
-            loadImage(item.Id);
-        }
-
         private void Button_MoveTextureUp(object sender, System.Windows.RoutedEventArgs e)
         {
             int newIndex = ThisVM.fun_moveTextureUp((TextureWrapper)List_Textures.SelectedItem);
@@ -86,6 +80,15 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Modules.Textures
         public void Texture_Add(object sender, RoutedEventArgs e)
         {
             ThisVM.addImage();
+        }
+
+        private void Texture_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if ((sender as ListView).SelectedItem == null) {
+                return;
+            }
+            TextureWrapper item = (TextureWrapper)(sender as ListView).SelectedItem;
+            loadImage(item.Id);
         }
     }
 }

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/Textures/TextureSelectedAnimation_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/Textures/TextureSelectedAnimation_Control.xaml
@@ -18,7 +18,7 @@
                 <Canvas.Background>
                     <DrawingBrush TileMode="Tile" Viewport="0,0,32,32" ViewportUnits="Absolute">
                         <DrawingBrush.Drawing>
-                            <GeometryDrawing Geometry="M0,0 H16 V16 H32 V32 H16 V16 H0Z" Brush="#80000000"/>
+                            <GeometryDrawing Geometry="M0,0 H16 V16 H32 V32 H16 V16 H0Z" Brush="#80555555"/>
                         </DrawingBrush.Drawing>
                     </DrawingBrush>
                 </Canvas.Background>
@@ -29,44 +29,67 @@
             </Canvas>
         </ScrollViewer>
 
-        <GridSplitter Grid.Column="1" Background="LightGray" HorizontalAlignment="Center" VerticalAlignment="Stretch" ShowsPreview="True" Width="5"/>
+        <GridSplitter Grid.Column="1" Background="LightGray" HorizontalAlignment="Center" VerticalAlignment="Stretch" ShowsPreview="True" Width="2"/>
 
         <Grid Grid.Column="2">
             <Grid.RowDefinitions>
-                <RowDefinition Height="150" />
+                <RowDefinition Height="330" />
                 <RowDefinition Height="auto" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             
             <!-- Animation Properties -->
             <StackPanel Grid.Row="0"  Orientation="Vertical" Margin="4">
-                <StackPanel Orientation="Horizontal" Margin="3">
-                    <Label>Texture:</Label>
-                    <TextBox MinWidth="30" Text="{Binding Path=TexAnim.TextureIndex}"></TextBox>
-                </StackPanel>
-                <StackPanel Orientation="Horizontal" Margin="3">
-                    <Label>Offset Y:</Label>
-                    <TextBox MinWidth="30" Text="{Binding Path=TexAnim.VOffsetInBaseImage}"></TextBox>
-                    <Label>Offset X:</Label>
-                    <TextBox MinWidth="30" Text="{Binding Path=TexAnim.UOffsetInBaseImage}"></TextBox>
-                </StackPanel>
 
-                <StackPanel Orientation="Horizontal" Margin="3">
-                    <Label>Height:</Label>
-                    <TextBox MinWidth="30" Text="{Binding Path=TexAnim.SpriteHeight}"></TextBox>
-                    <Label>Width:</Label>
-                    <TextBox MinWidth="30" Text="{Binding Path=TexAnim.SpriteWidth}"></TextBox>
-                </StackPanel>
+                <Border Margin="10" Padding="10" CornerRadius="5" Background="#555555" BorderBrush="White" BorderThickness="1">
+                    <StackPanel>
+                        <Label FontWeight="Bold" FontSize="18">Over Texture</Label>
+                        <Separator/>
+                        <StackPanel Orientation="Horizontal" Margin="3">
+                            <Label VerticalAlignment="Center">Texture:</Label>
+                            <TextBox MinWidth="30" Margin="5 0 0 0" Text="{Binding Path=TexAnim.TextureIndex}"></TextBox>
+                        </StackPanel>
+                        <WrapPanel Margin="3">
+                            <Label VerticalAlignment="Center">Offset Y:</Label>
+                            <TextBox MinWidth="30" Margin="5 0 0 0" Text="{Binding Path=TexAnim.VOffsetInBaseImage}"></TextBox>
+                            <Label VerticalAlignment="Center" Margin="10 0 0 0">Offset X:</Label>
+                            <TextBox MinWidth="30" Margin="5 0 0 0" Text="{Binding Path=TexAnim.UOffsetInBaseImage}"></TextBox>
+                        </WrapPanel>
+                    </StackPanel>
+                </Border>
 
-                <StackPanel Orientation="Horizontal" Margin="3">
-                    <Label>Number of sprites:</Label>
-                    <TextBox MinWidth="30" Text="{Binding Path=TexAnim.NumSpritesInImageData}"></TextBox>
-                    <Label>Default sprite:</Label>
-                    <TextBox MinWidth="30" Text="{Binding Path=TexAnim.DefaultAnimationIndex}"></TextBox>
-                </StackPanel>
+                <Border Margin="10" Padding="10" CornerRadius="5" Background="#555555" BorderBrush="White" BorderThickness="1">
+                    <StackPanel>
+                        <Label FontWeight="Bold" FontSize="18">Sprite Data</Label>
+                        <Separator/>
+                        
+                        <WrapPanel Margin="3">
+                            <StackPanel Orientation="Horizontal">
+                                <Label VerticalAlignment="Center">Height:</Label>
+                                <TextBox MinWidth="30" Margin="5 0 0 0" Text="{Binding Path=TexAnim.SpriteHeight}"></TextBox>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="10 0 0 0">
+                                <Label VerticalAlignment="Center">Width:</Label>
+                                <TextBox MinWidth="30" Margin="5 0 0 0" Text="{Binding Path=TexAnim.SpriteWidth}"></TextBox>
+                            </StackPanel>
+                        </WrapPanel>
+
+                        <StackPanel Margin="3">
+                            <StackPanel Orientation="Horizontal">
+                                <Label VerticalAlignment="Center">Number of sprites:</Label>
+                                <TextBox MinWidth="30" Margin="5 0 0 0" Text="{Binding Path=TexAnim.NumSpritesInImageData}"></TextBox>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <Label VerticalAlignment="Center">Default sprite:</Label>
+                                <TextBox MinWidth="30" Margin="5 0 0 0" Text="{Binding Path=TexAnim.DefaultAnimationIndex}"></TextBox>
+                            </StackPanel>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+
             </StackPanel>
 
-            <GridSplitter Grid.Row="1" Background="LightGray" HorizontalAlignment="Stretch" VerticalAlignment="Center" ShowsPreview="True" Height="5"/>
+            <GridSplitter Grid.Row="1" Background="LightGray" HorizontalAlignment="Stretch" VerticalAlignment="Center" ShowsPreview="True" Height="2"/>
 
             <ListView Grid.Row="2" Name="ScriptList" ItemsSource="{Binding Animations}" SelectedItem="{Binding SelectedAnimation}">
                 <ListView.ContextMenu>

--- a/OpenKh.Tools.Kh2ObjectEditor/Modules/UI/M_UI_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Modules/UI/M_UI_Control.xaml
@@ -41,7 +41,7 @@
         </Grid>
         
         
-        <GridSplitter Grid.Column="1" Background="LightGray" HorizontalAlignment="Center" VerticalAlignment="Stretch" ShowsPreview="True" Width="5"/>
+        <GridSplitter Grid.Column="1" Background="LightGray" HorizontalAlignment="Center" VerticalAlignment="Stretch" ShowsPreview="True" Width="2"/>
 
         <Grid Grid.Column="2">
             <Grid.RowDefinitions>

--- a/OpenKh.Tools.Kh2ObjectEditor/OpenKh.Tools.Kh2ObjectEditor.csproj
+++ b/OpenKh.Tools.Kh2ObjectEditor/OpenKh.Tools.Kh2ObjectEditor.csproj
@@ -9,6 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="MahApps.Metro.IconPacks.Material" Version="5.1.0" />
+    <PackageReference Include="MahApps.Metro.IconPacks.MaterialDesign" Version="5.1.0" />
+    <PackageReference Include="MahApps.Metro.IconPacks.PhosphorIcons" Version="5.1.0" />
+    <PackageReference Include="ModernWpfUI" Version="0.9.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenKh.Tools.Kh2ObjectEditor/Services/MdlxService.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Services/MdlxService.cs
@@ -1,3 +1,4 @@
+using CommunityToolkit.Mvvm.ComponentModel;
 using OpenKh.Kh2;
 using OpenKh.Tools.Kh2ObjectEditor.Utils;
 using System;
@@ -6,10 +7,10 @@ using System.Windows.Forms;
 
 namespace OpenKh.Tools.Kh2ObjectEditor.Services
 {
-    public class MdlxService
+    public partial class MdlxService : ObservableObject
     {
         // Apdx File
-        public string MdlxPath { get; set; }
+        [ObservableProperty] public string mdlxPath;
         public Bar MdlxBar { get; set; }
         public Kh2.Models.ModelSkeletal ModelFile { get; set; }
         public ModelCollision CollisionFile { get; set; }
@@ -33,6 +34,10 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Services
             MsetService.Reset();
             ApdxService.Reset();
 
+            ModelFile = null;
+            TextureFile = null;
+            CollisionFile = null;
+            BdxFile = null;
             foreach (Bar.Entry barEntry in MdlxBar)
             {
                 switch (barEntry.Type)

--- a/OpenKh.Tools.Kh2ObjectEditor/Services/ViewerService.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Services/ViewerService.cs
@@ -21,6 +21,7 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Services
     {
         public ViewportController VpController { get; set; }
         public MtModel LoadedModel { get; set; }
+        public MdlxService ServiceMdlx { get; set; } = MdlxService.Instance;
         //-------------------------------------
         // Animation
         //-------------------------------------

--- a/OpenKh.Tools.Kh2ObjectEditor/Views/Main_Window.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Views/Main_Window.xaml
@@ -5,10 +5,12 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:OpenKh.Tools.Kh2ObjectEditor.Views"
         mc:Ignorable="d"
-        Title="KH2 Object Editor" Height="900" Width="1600">
+        Title="KH2 Object Editor" Height="900" Width="1600"
+        xmlns:ui="http://schemas.modernwpf.com/2019"
+        ui:WindowHelper.UseModernWindowStyle="True">
 
     <DockPanel>
-        <Menu DockPanel.Dock="Top" Height="20" >
+        <Menu DockPanel.Dock="Top" Height="40" >
             <MenuItem Header="TEST" Visibility="Collapsed">
                 <MenuItem Header="Check App Context" Click="Menu_Test"/>
                 <MenuItem Header="Run Code" Click="Menu_Test_RunCode"/>
@@ -35,23 +37,23 @@
 
         <Grid AllowDrop="True" Drop="Window_Drop">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="150" />
+                <ColumnDefinition Width="200" />
                 <ColumnDefinition Width="auto" />
-                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="500"/>
                 <ColumnDefinition Width="auto" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
             <!-- SELECTOR  -->
             <local:ObjectSelector_Control Grid.Column="0"/>
-            
-            <GridSplitter Grid.Column="1" Background="LightGray" HorizontalAlignment="Center" VerticalAlignment="Stretch" ShowsPreview="True" Width="5"/>
-            
-            <local:Viewport_Control Grid.Column="2" x:Name="Viewport" />
-            
-            <GridSplitter Grid.Column="3" Background="LightGray" HorizontalAlignment="Center" VerticalAlignment="Stretch" ShowsPreview="True" Width="5"/>
-            
+
+            <GridSplitter Grid.Column="1" Background="LightGray" HorizontalAlignment="Center" ShowsPreview="True" Width="2"/>
+
+            <local:Viewport_Control Grid.Column="2" x:Name="Viewport" Grid.ColumnSpan="2" />
+
+            <GridSplitter Grid.Column="3" Background="LightGray" HorizontalAlignment="Center" ShowsPreview="True" Width="2"/>
+
             <local:ModuleLoader_Control Grid.Column="4"/>
         </Grid>
     </DockPanel>
-    
+
 </Window>

--- a/OpenKh.Tools.Kh2ObjectEditor/Views/ModuleLoader_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Views/ModuleLoader_Control.xaml
@@ -4,34 +4,73 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:OpenKh.Tools.Kh2ObjectEditor.Views"
+             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     
     <Grid Background="Black">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="50" />
+            <ColumnDefinition Width="90" />
         </Grid.ColumnDefinitions>
 
         <!-- Content loader -->
         <ContentControl x:Name="contentFrame" Grid.Column="0" Background="#2d2d2d"/>
         <!-- <local:ModuleMotions_Control/> -->
 
-        <!-- Side menu -->
-        <StackPanel Grid.Column="1">
-            <Label Foreground="White" Visibility="Visible" x:Name="TabModel" MouseLeftButtonUp="TabClick_Model">Model</Label>
-            <Label Foreground="White" Visibility="Visible" x:Name="TabTextures" MouseLeftButtonUp="TabClick_Textures">Textures</Label>
-            <Label Foreground="White" Visibility="Visible" x:Name="TabUI" MouseLeftButtonUp="TabClick_UI">UI</Label>
-            <Label Foreground="White" Visibility="Visible" x:Name="TabCollisions" MouseLeftButtonUp="TabClick_Collisions">Collisions</Label>
-            <Label Foreground="White" Visibility="Visible" x:Name="TabMotions" MouseLeftButtonUp="TabClick_Motions">Motions</Label>
-            <Label Foreground="White" Visibility="Visible" x:Name="TabParticles" MouseLeftButtonUp="TabClick_Particles">Particles</Label>
-            <Label Foreground="White" Visibility="Visible" x:Name="TabAI" MouseLeftButtonUp="TabClick_AI">AI</Label>
-            <!-- 
-            <Image x:Name="sideModel" Visibility="Collapsed" Height="50" Source="../Assets/IconModelW.png" MouseLeftButtonUp="Side_Model"></Image>
-            <Image x:Name="sideTexture" Visibility="Collapsed" Height="50" Source="../Assets/IconTextureW.png" MouseLeftButtonUp="Side_Texture"></Image>
-            <Image x:Name="sideCollision" Visibility="Collapsed" Height="50" Source="../Assets/IconCollisionW.png" MouseLeftButtonUp="Side_Collision" MouseRightButtonUp="Side_CollisionTable"></Image>
-            -->
-        </StackPanel>
+        <ListBox Grid.Column="1" Background="LightGray">
+
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="ListBoxItem">
+                    <Setter Property="BorderBrush" Value="#22000000"/>
+                    <Setter Property="BorderThickness" Value="0,0,0,1"/>
+                    <Setter Property="Padding" Value="5"/>
+                </Style>
+            </ListBox.ItemContainerStyle>
+
+            <ListBoxItem Foreground="Black" Visibility="Visible" x:Name="TabModel" MouseLeftButtonUp="TabClick_Model">
+                <StackPanel Orientation="Horizontal">
+                    <iconPacks:PackIconPhosphorIcons Kind="Cube" Height="20"/>
+                    <Label Foreground="Black" Margin="5 0">Model</Label>
+                </StackPanel>
+            </ListBoxItem>
+            <ListBoxItem Foreground="Black" Visibility="Visible" x:Name="TabTextures" MouseLeftButtonUp="TabClick_Textures">
+                <StackPanel Orientation="Horizontal">
+                    <iconPacks:PackIconPhosphorIcons Kind="Image" Height="20"/>
+                    <Label Foreground="Black" Margin="5 0">Textures</Label>
+                </StackPanel>
+            </ListBoxItem>
+            <ListBoxItem Foreground="Black" Visibility="Visible" x:Name="TabUI" MouseLeftButtonUp="TabClick_UI">
+                <StackPanel Orientation="Horizontal">
+                    <iconPacks:PackIconMaterial Kind="AccountBox" Height="20"/>
+                    <Label Foreground="Black" Margin="5 0">UI</Label>
+                </StackPanel>
+            </ListBoxItem>
+            <ListBoxItem Foreground="Black" Visibility="Visible" x:Name="TabCollisions" MouseLeftButtonUp="TabClick_Collisions">
+                <StackPanel Orientation="Horizontal">
+                    <iconPacks:PackIconPhosphorIcons Kind="Sphere" Height="20"/>
+                    <Label Foreground="Black" Margin="5 0">Collisions</Label>
+                </StackPanel>
+            </ListBoxItem>
+            <ListBoxItem Foreground="Black" Visibility="Visible" x:Name="TabMotions" MouseLeftButtonUp="TabClick_Motions">
+                <StackPanel Orientation="Horizontal">
+                    <iconPacks:PackIconMaterial Kind="AnimationPlay" Height="20"/>
+                    <Label Foreground="Black" Margin="5 0">Motions</Label>
+                </StackPanel>
+            </ListBoxItem>
+            <ListBoxItem Foreground="Black" Visibility="Visible" x:Name="TabParticles" MouseLeftButtonUp="TabClick_Particles">
+                <StackPanel Orientation="Horizontal">
+                    <iconPacks:PackIconMaterialDesign Kind="Star" Height="20"/>
+                    <Label Foreground="Black" Margin="5 0">Effects</Label>
+                </StackPanel>
+            </ListBoxItem>
+            <ListBoxItem Foreground="Black" Visibility="Visible" x:Name="TabAI" MouseLeftButtonUp="TabClick_AI">
+                <StackPanel Orientation="Horizontal">
+                    <iconPacks:PackIconMaterial Kind="ScriptTextOutline" Height="20"/>
+                    <Label Foreground="Black" Margin="5 0">Script</Label>
+                </StackPanel>
+            </ListBoxItem>
+        </ListBox>
 
     </Grid>
     

--- a/OpenKh.Tools.Kh2ObjectEditor/Views/ObjectSelector_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Views/ObjectSelector_Control.xaml
@@ -6,36 +6,53 @@
              xmlns:local="clr-namespace:OpenKh.Tools.Kh2ObjectEditor.Views"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
-    
-    <DockPanel>
 
-        <!-- FILTERS AND OTHER CONTROLS -->
-        <StackPanel DockPanel.Dock="Bottom" Orientation="Vertical" Margin="10">
-            <Label FontWeight="Bold">Filters</Label>
-            <StackPanel Orientation="Horizontal">
-                <Label VerticalAlignment="Center" Margin="0,0,5,0">Name:</Label>
-                <TextBox Name="FilterName" Text="{Binding FilterName}" Width="80" VerticalContentAlignment="Center" PreviewKeyDown="FilterName_PreviewKeyDown" TextChanged="FilterName_TextChanged" />
-            </StackPanel>
-            <StackPanel Orientation="Horizontal">
-                <Label VerticalAlignment="Center" Margin="0,0,5,0">Has Moveset:</Label>
-                <CheckBox IsChecked="{Binding FilterHasMset}" VerticalAlignment="Center" Checked="CheckBox_Checked" Unchecked="CheckBox_Unchecked"/>
-            </StackPanel>
-            <!-- <Button Width="100" HorizontalAlignment="Left" Click="Button_ApplyFilters">Apply filters</Button> -->
-        </StackPanel>
+    <Border Background="#333333">
+        <DockPanel>
 
-        <!-- OBJECT LIST -->
-        <ListView ItemsSource="{Binding ObjectsView}" SelectedItem="{Binding SelectedObject}"  MouseDoubleClick="list_doubleCLick">
-            <ListView.ItemTemplate>
-                <DataTemplate>
+            <!-- FILTERS AND OTHER CONTROLS -->
+            <Border DockPanel.Dock="Bottom" Margin="10" Padding="5" CornerRadius="5" Background="#555555" BorderBrush="White" BorderThickness="1">
+                <StackPanel Orientation="Vertical">
+                    <Label FontWeight="Bold">Filters</Label>
+                    <Separator Margin="0 0 0 10"/>
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Grid.Column="0" Margin="0,0,5,0" Text="{Binding Path=FileName}" VerticalAlignment="Center"/>
-                        <CheckBox Grid.Column="1" Focusable="False" IsHitTestVisible="False"  IsChecked="{Binding Path=HasMset}" VerticalAlignment="Center" >
-                        </CheckBox>
+                        <Label VerticalAlignment="Center" Margin="0,0,5,0">Name:</Label>
+                        <TextBox Name="FilterName" Text="{Binding FilterName}" Width="120" VerticalContentAlignment="Center" PreviewKeyDown="FilterName_PreviewKeyDown" TextChanged="FilterName_TextChanged" />
                     </StackPanel>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
-        
-    </DockPanel>
-    
+                    <StackPanel Orientation="Horizontal">
+                        <Label VerticalAlignment="Center" Margin="0,0,5,0">Has Moveset:</Label>
+                        <CheckBox IsChecked="{Binding FilterHasMset}" VerticalAlignment="Center" Checked="CheckBox_Checked" Unchecked="CheckBox_Unchecked"/>
+                    </StackPanel>
+                    <!-- <Button Width="100" HorizontalAlignment="Left" Click="Button_ApplyFilters">Apply filters</Button> -->
+                </StackPanel>
+            </Border>
+
+            <!-- OBJECT LIST -->
+            <Border Margin="10" Padding="5" CornerRadius="5" Background="#777777" BorderBrush="White" BorderThickness="1">
+                <ListView ItemsSource="{Binding ObjectsView}" SelectedItem="{Binding SelectedObject}"  MouseDoubleClick="list_doubleCLick">
+
+                    <ListView.ItemContainerStyle>
+                        <Style TargetType="ListViewItem">
+                            <Setter Property="Margin" Value="0,0,0,1"/>
+                            <Setter Property="BorderBrush" Value="#22000000"/>
+                            <Setter Property="BorderThickness" Value="0,0,0,1"/>
+                            <Setter Property="Padding" Value="5"/>
+                        </Style>
+                    </ListView.ItemContainerStyle>
+                    
+                    <ListView.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Horizontal">
+                                <CheckBox Grid.Column="1" Focusable="False" IsHitTestVisible="False"  IsChecked="{Binding Path=HasMset}" VerticalAlignment="Center" >
+                                <TextBlock Grid.Column="0" Margin="0,0,5,0" Text="{Binding Path=FileName}" VerticalAlignment="Center"/>
+                                </CheckBox>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+            </Border>
+
+        </DockPanel>
+    </Border>
+
 </UserControl>

--- a/OpenKh.Tools.Kh2ObjectEditor/Views/Viewport_Control.xaml
+++ b/OpenKh.Tools.Kh2ObjectEditor/Views/Viewport_Control.xaml
@@ -5,53 +5,92 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:OpenKh.Tools.Kh2ObjectEditor.Views"
              xmlns:S3V="clr-namespace:Simple3DViewport.Controls;assembly=Simple3DViewport" xmlns:h="http://helix-toolkit.org/wpf"
+             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
 
-    <DockPanel Background="DarkGray" MouseEnter="DockPanel_MouseEnter" MouseLeave="DockPanel_MouseLeave" PreviewKeyDown="Window_KeyDown">
-        <StackPanel DockPanel.Dock="Bottom" Margin="10">
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                <Label Content="{Binding MotionMinFrame}" Width="50" HorizontalContentAlignment="Center"/>
-                <Slider Name="FrameSlider"
-                        Width="500" Orientation="Horizontal" HorizontalAlignment="Center" 
-                        Value="{Binding CurrentFrame}" Minimum="{Binding MotionMinFrame}" Maximum="{Binding MotionMaxFrame}" 
-                        SmallChange="5" LargeChange="5"
-                        TickPlacement="None" TickFrequency="5"
-                        Thumb.DragStarted="Slider_DragStarted"
-                        Thumb.DragCompleted="Slider_DragCompleted"/>
-                <Label Content="{Binding MotionMaxFrame}" Width="50" HorizontalContentAlignment="Center"/>
-            </StackPanel>
-            
-            <ContentControl HorizontalAlignment="Center" Height="30">
-                <StackPanel Orientation="Horizontal">
-                    <Button VerticalAlignment="Center" Click="Button_PreviousFrame" Width="20" Padding="0">&lt;</Button>
-                    <Label VerticalAlignment="Center" Content="{Binding CurrentFrame}" Width="50" HorizontalContentAlignment="Center"></Label>
-                    <Button VerticalAlignment="Center" Click="Button_NextFrame" Width="20" Padding="0">&gt;</Button>
-                </StackPanel>
-            </ContentControl>
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-                <StackPanel Orientation="Horizontal" Grid.Column="0">
-                    <StackPanel Orientation="Vertical">
-                        <CheckBox IsChecked="{Binding AnimationRunning}">Auto advance</CheckBox>
+    <DockPanel Background="#333333" MouseEnter="DockPanel_MouseEnter" MouseLeave="DockPanel_MouseLeave" PreviewKeyDown="Window_KeyDown">
+        <Border DockPanel.Dock="Bottom" Margin="10" Padding="10" CornerRadius="5" Background="#555555" BorderBrush="White" BorderThickness="1">
+            <StackPanel>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="100"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="100"/>
+                    </Grid.ColumnDefinitions>
+                    
+                    <WrapPanel Grid.Column="0" HorizontalAlignment="Center">
+                        <Button Click="Button_Play">
+                            <iconPacks:PackIconMaterialDesign Kind="PlayArrow" />
+                        </Button>
+                        <Button Margin="10 0 0 0" Click="Button_Pause">
+                            <iconPacks:PackIconMaterialDesign Kind="Pause" />
+                        </Button>
+                    </WrapPanel>
+
+                    <StackPanel Grid.Column="1">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="50"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="50"/>
+                            </Grid.ColumnDefinitions>
+                            <Label Grid.Column="0" Content="{Binding MotionMinFrame}" Width="50" HorizontalContentAlignment="Center" VerticalAlignment="Center"/>
+                            <Slider Grid.Column="1" Name="FrameSlider"
+                                    Orientation="Horizontal" HorizontalAlignment="Stretch" 
+                                    Value="{Binding CurrentFrame}" Minimum="{Binding MotionMinFrame}" Maximum="{Binding MotionMaxFrame}" 
+                                    SmallChange="5" LargeChange="5"
+                                    TickPlacement="None" TickFrequency="5"
+                                    Thumb.DragStarted="Slider_DragStarted"
+                                    Thumb.DragCompleted="Slider_DragCompleted"/>
+                            <Label Grid.Column="2" Content="{Binding MotionMaxFrame}" Width="50" HorizontalContentAlignment="Center" VerticalAlignment="Center"/>
+                        </Grid>
+
+                        <ContentControl HorizontalAlignment="Center" Height="30">
+                            <StackPanel Orientation="Horizontal">
+                                <Button VerticalAlignment="Center" Click="Button_PreviousFrame" Padding="4">
+                                    <iconPacks:PackIconMaterialDesign Kind="ChevronLeft" />
+                                </Button>
+                                <Label VerticalAlignment="Center" Content="{Binding CurrentFrame}" Width="50" HorizontalContentAlignment="Center"></Label>
+                                <Button VerticalAlignment="Center" Click="Button_NextFrame" Padding="4">
+                                    <iconPacks:PackIconMaterialDesign Kind="ChevronRight" />
+                                </Button>
+                            </StackPanel>
+                        </ContentControl>
+                    </StackPanel>
+                    
+                    <WrapPanel Grid.Column="2" HorizontalAlignment="Center">
+                        <Button Click="Button_Stop">
+                            <iconPacks:PackIconMaterialDesign Kind="Stop" />
+                        </Button>
+                    </WrapPanel>
+                    
+                </Grid>
+
+                <WrapPanel>
+                    <StackPanel Orientation="Vertical" Margin="10 0">
                         <CheckBox IsChecked="{Binding IsBoundingBoxVisible}">Bounding Box</CheckBox>
                     </StackPanel>
-                    <StackPanel Orientation="Vertical" Margin="10 0 0 0">
+                    <StackPanel Orientation="Vertical" Margin="10 0">
                         <CheckBox IsChecked="{Binding AutoCollisions}">Auto Collisions</CheckBox>
-                        <CheckBox IsChecked="{Binding AutoCollisionsAttack}">Auto Collisions - Attack</CheckBox>
-                        <CheckBox IsChecked="{Binding AutoCollisionsOther}">Auto Collisions - Other</CheckBox>
+                        <CheckBox IsChecked="{Binding AutoCollisionsAttack}" IsEnabled="{Binding AutoCollisions}">Auto Collisions - Attack</CheckBox>
+                        <CheckBox IsChecked="{Binding AutoCollisionsOther}" IsEnabled="{Binding AutoCollisions}">Auto Collisions - Other</CheckBox>
                     </StackPanel>
-                </StackPanel>
-                
-                <Button Grid.Column="1" HorizontalAlignment="Right" Click="Button_Reload">Reload</Button>
-            </Grid>
-            
-        </StackPanel>
+                </WrapPanel>
+
+            </StackPanel>
+        </Border>
 
         <!--<S3V:Simple3DViewport_Control Grid.Column="0" x:Name="Viewport"/>-->
-        <h:HelixViewport3D Name="HelixViewport" PreviewKeyDown="Viewport_KeyDown"> </h:HelixViewport3D>
+        <Border CornerRadius="10" Background="Black" Margin="10">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="30"/>
+                </Grid.RowDefinitions>
+                <h:HelixViewport3D Grid.Row="0" Name="HelixViewport" PreviewKeyDown="Viewport_KeyDown"/>
+                <Label Grid.Row="1" Content="{Binding ServiceMdlx.MdlxPath}" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="12"/>
+            </Grid>
+        </Border>
     </DockPanel>
 </UserControl>

--- a/OpenKh.Tools.Kh2ObjectEditor/Views/Viewport_Control.xaml.cs
+++ b/OpenKh.Tools.Kh2ObjectEditor/Views/Viewport_Control.xaml.cs
@@ -27,14 +27,6 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Views
             NextFrame();
         }
 
-        private void Button_Reload(object sender, System.Windows.RoutedEventArgs e)
-        {
-            if (MdlxService.Instance.ModelFile == null) {
-                return;
-            }
-            ViewerService.Instance.Render();
-        }
-
         private void Slider_DragStarted(object sender, DragStartedEventArgs e)
         {
             if (MsetService.Instance.LoadedMotion == null) {
@@ -113,6 +105,26 @@ namespace OpenKh.Tools.Kh2ObjectEditor.Views
             ViewerService.Instance.AnimationRunning = false;
             ViewerService.Instance.FrameIncrease(frameStep);
             ViewerService.Instance.LoadFrame();
+        }
+
+        private void Button_Play(object sender, System.Windows.RoutedEventArgs e)
+        {
+            ViewerService.Instance.AnimationRunning = true;
+        }
+
+        private void Button_Pause(object sender, System.Windows.RoutedEventArgs e)
+        {
+            ViewerService.Instance.AnimationRunning = false;
+        }
+
+        private void Button_Stop(object sender, System.Windows.RoutedEventArgs e)
+        {
+            if (MdlxService.Instance.ModelFile == null)
+            {
+                return;
+            }
+            ViewerService.Instance.AnimationRunning = false;
+            ViewerService.Instance.Render();
         }
     }
 }


### PR DESCRIPTION
Updated the Kh2 Object Editor to a modern look. It also fixes a bug where opening a file without collision after opening one that does crashes the tool.

![image](https://github.com/user-attachments/assets/886f890f-1537-4638-8048-2cae5979bde2)

![image](https://github.com/user-attachments/assets/d624d696-d5fc-48d8-9b81-1496310cff4c)

![image](https://github.com/user-attachments/assets/3bb14278-bd8e-4c4d-86e2-8b5cd16af0ef)

![image](https://github.com/user-attachments/assets/87f058c6-c09c-4305-96d2-15474c02d88d)

![image](https://github.com/user-attachments/assets/57d9794b-0e9b-4d78-8fe8-dfbdf476b242)

Previous version for the sake of comparison:

![image](https://github.com/user-attachments/assets/d94e1470-453a-4785-b987-ed03e9549464)
