### PR TITLE
Fix mapgen texture scrolling

### DIFF
--- a/OpenKh.Command.MapGen/Utils/MapBuilder.cs
+++ b/OpenKh.Command.MapGen/Utils/MapBuilder.cs
@@ -386,6 +386,14 @@ namespace OpenKh.Command.MapGen.Utils
                                         ?? config.textureOptions.addressV
                                         ?? "Repeat"
                                     );
+                                var originalMinU = gsInfo.AddressMode.Left;
+                                gsInfo.AddressMode.Left = gsInfo.AddressMode.Right;
+                                gsInfo.AddressMode.Right = originalMinU;
+
+                                var originalMinV = gsInfo.AddressMode.Top;
+                                gsInfo.AddressMode.Top = gsInfo.AddressMode.Bottom;
+                                gsInfo.AddressMode.Bottom = originalMinV;
+
                                 return gsInfo;
                             }
                         )

--- a/OpenKh.Kh2/ModelTexture.cs
+++ b/OpenKh.Kh2/ModelTexture.cs
@@ -686,6 +686,11 @@ namespace OpenKh.Kh2
             };
             _textureTransfer = texTransList;
             _gsInfo = gsInfoList;
+            if (build.footerData != null && build.footerData.Length > 0)
+            {
+                using (var stream = new MemoryStream(build.footerData))
+                    this.TextureFooterData = TextureFooterData.Read(stream);
+            }
         }
 
         private static int GetSizeRegister(int realSize) => (int)Math.Ceiling(Math.Log(realSize, 2));


### PR DESCRIPTION
Adds logic to MapBuilder.cs to correctly swap the MIN/MAX values for the CLAMP register's U and V coordinates.

Fixes a bug in the ModelTexture constructor where the footerData was not being processed, causing the texture footer to be omitted from the final file.