### PR TITLE
Fix AnbMaker interpolation and rounding. (Smaller animations)

### DIFF
--- a/OpenKh.Command.AnbMaker/Utils/Builder/InterpolatedMotionBuilder.cs
+++ b/OpenKh.Command.AnbMaker/Utils/Builder/InterpolatedMotionBuilder.cs
@@ -35,7 +35,7 @@ namespace OpenKh.Command.AnbMaker.Utils.Builder
             Ipm.InterpolatedMotionHeader.TotalBoneCount = Convert.ToInt16(parm.BoneCount);
             Ipm.InterpolatedMotionHeader.FrameCount = (int)(frameCount * keyTimeMultiplier); // in 1/60 seconds
             Ipm.InterpolatedMotionHeader.FrameData.FrameStart = 0;
-            Ipm.InterpolatedMotionHeader.FrameData.FrameEnd = frameCount - 1;
+            Ipm.InterpolatedMotionHeader.FrameData.FrameEnd = frameCount;
             Ipm.InterpolatedMotionHeader.FrameData.FramesPerSecond = parm.TicksPerSecond;
             Ipm.InterpolatedMotionHeader.BoundingBox = new BoundingBox
             {
@@ -69,11 +69,11 @@ namespace OpenKh.Command.AnbMaker.Utils.Builder
 
             short AddKeyValue(float keyValue)
             {
-                var idx = Ipm.KeyValues.IndexOf(keyValue);
+                var idx = Ipm.KeyValues.IndexOf(GetLowerPrecisionValue2(keyValue));
                 if (idx < 0)
                 {
                     idx = Ipm.KeyValues.Count;
-                    Ipm.KeyValues.Add(keyValue);
+                    Ipm.KeyValues.Add(GetLowerPrecisionValue2(keyValue));
                 }
                 return (short)Convert.ToUInt16(idx);
             }
@@ -199,7 +199,7 @@ namespace OpenKh.Command.AnbMaker.Utils.Builder
                                     .Select(
                                         key => new Key
                                         {
-                                            Type = Interpolation.Hermite,
+                                            Type = Interpolation.Linear,
                                             Time = AddSourceKeyTime(key.Time),
                                             ValueId = AddKeyValue(channel.fixValue(key.Value)),
                                         }
@@ -354,6 +354,11 @@ namespace OpenKh.Command.AnbMaker.Utils.Builder
         private static float GetLowerPrecisionValue(float value)
         {
             return (float)Math.Round(value, 2);
+        }
+
+        private static float GetLowerPrecisionValue2(float value)
+        {
+            return (float)Math.Round(value, 3);
         }
 
         private class ChannelProvider


### PR DESCRIPTION
Changes interpolation type to linear for smoother animations (hermite shouldn't be used with anbmaker ever) and reduces the frequency of out of bounds errors for values by rounding them to 3 decimal places. There's no noticeable visual difference between 5.3459 and 5.3451 for example. It was just creating bigger animations than necessary and causing a lot of int16 overflows with animations with more keyframes or bones.