### PR TITLE
Minor fix for when updating a mod that was previously not a collectio…

### DIFF
--- a/OpenKh.Tools.ModsManager/ViewModels/ModViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/ModViewModel.cs
@@ -118,6 +118,12 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 view.DataContext = this;
                 if (view.ShowDialog() != true)
                 {
+                    if (!ConfigurationService.EnabledCollectionMods.ContainsKey(_model.Name))
+                    {
+                        var temp = ConfigurationService.EnabledCollectionMods;
+                        temp[_model.Name] = new Dictionary<string, bool> { };
+                        ConfigurationService.EnabledCollectionMods = temp;
+                    }
                     _model.CollectionOptionalEnabledAssets = ConfigurationService.EnabledCollectionMods[_model.Name];
                     FilesToPatch = string.Join('\n', GetFilesToPatch());
                     return;


### PR DESCRIPTION
for when updating a mod that was previously not a collection but was installed and updates to a collection. Would throw error due to key missing as the json file had not been constructed yet at that point.