### PR TITLE
[MapGen] Include Group & floorLevel support for DOCT files, fix disableBSPCollisionBuilder2 from not applying properly.

### DIFF
--- a/OpenKh.Command.MapGen/Utils/FlattenDoctBuilderAlt.cs
+++ b/OpenKh.Command.MapGen/Utils/FlattenDoctBuilderAlt.cs
@@ -70,8 +70,7 @@ namespace OpenKh.Command.MapGen.Utils
                     // Extract bounding box
                     var bbox = GetBoundingBoxOf(faces);
 
-                    // Determine flags:
-                    // - if group starts with "g", use it as special group (high bit set maybe?)
+                    // - if group starts with "g", use it as special group to be able to be hidden with MapVisibility.
                     // - else fallback to attribute flags
                     var key = group.Key;
                     uint flags;
@@ -80,8 +79,8 @@ namespace OpenKh.Command.MapGen.Utils
                     {
                         var groupId = int.Parse(key.Substring(1));
                         var floorLevel = faces[0].matDef.floorLevel;
-
-                        flags = 0x00000000 | ((uint)groupId << 8) | ((uint)floorLevel << 16); //Shift group to +0x01 position, since its stored as a 4-byte value and not 4, independent values.
+                        //What's known as "flags" is really a set of 4 bytes known as Visible, Group, floorLevel, & padding. Bitshift to accomodate the improper DOCT class.
+                        flags = 0x00000000 | ((uint)groupId << 8) | ((uint)floorLevel << 16); //Shift group to +0x01 & +0x02 position, since its stored as a 4-byte value and not 4, independent values.
                     }
                     else
                     {

--- a/OpenKh.Command.MapGen/Utils/FlattenDoctBuilderAlt.cs
+++ b/OpenKh.Command.MapGen/Utils/FlattenDoctBuilderAlt.cs
@@ -1,0 +1,110 @@
+using OpenKh.Command.MapGen.Interfaces;
+using OpenKh.Command.MapGen.Models;
+using OpenKh.Kh2;
+using OpenKh.Kh2.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenKh.Command.MapGen.Utils
+{
+    public class FlattenDoctBuilderAlt
+    {
+        private readonly Doct doct = new Doct();
+        private readonly List<SingleFace[]> vifPacketRenderingGroup = new List<SingleFace[]>();
+
+        public DoctBuilt GetBuilt() => new DoctBuilt
+        {
+            Doct = doct,
+            VifPacketRenderingGroup = vifPacketRenderingGroup,
+        };
+
+        public FlattenDoctBuilderAlt(
+            ISpatialNodeCutter cutter,
+            Func<MaterialDef, int> getAttributeFrom
+        )
+        {
+            var final = FlattenSpatialNode.From(cutter);
+
+            BoundingBox GetBoundingBoxOf(IEnumerable<SingleFace> faces)
+            {
+                return BoundingBox.FromManyPoints(
+                    faces
+                        .SelectMany(face => face.positionList)
+                        .Select(point => new Vector3(point.X, -point.Y, -point.Z)) // why -Y and -Z ?
+                );
+            }
+
+            var entry1 = new Doct.Entry1
+            {
+                BoundingBox = GetBoundingBoxOf(
+                    final
+                        .SelectMany(
+                            face => face.Faces
+                        )
+                ),
+            };
+            doct.Entry1List.Add(entry1);
+
+            var entry2FirstIdx = doct.Entry2List.Count;
+
+            foreach (var secondary in final)
+            {
+                // New: Group by explicit group number if defined, otherwise by attribute
+                var groupedFaces = secondary.Faces
+                    .GroupBy(face =>
+                    {
+                        var group = face.matDef?.group ?? -1;
+                        return group >= 0 ? $"g{group}" : $"a{getAttributeFrom(face.matDef)}";
+                    });
+
+                foreach (var group in groupedFaces)
+                {
+                    var faces = group.ToArray();
+                    if (faces.Length == 0)
+                        continue;
+
+                    // Extract bounding box
+                    var bbox = GetBoundingBoxOf(faces);
+
+                    // Determine flags:
+                    // - if group starts with "g", use it as special group (high bit set maybe?)
+                    // - else fallback to attribute flags
+                    var key = group.Key;
+                    uint flags;
+
+                    if (key.StartsWith("g"))
+                    {
+                        var groupId = int.Parse(key.Substring(1));
+                        var floorLevel = faces[0].matDef.floorLevel;
+
+                        flags = 0x00000000 | ((uint)groupId << 8) | ((uint)floorLevel << 16); //Shift group to +0x01 position, since its stored as a 4-byte value and not 4, independent values.
+                    }
+                    else
+                    {
+                        var attr = int.Parse(key.Substring(1));
+                        var floorLevel = faces[0].matDef.floorLevel;
+                        flags = (uint)attr | ((uint)floorLevel << 16);
+                    }
+
+                    // Add Entry2
+                    var entry2 = new Doct.Entry2
+                    {
+                        BoundingBox = bbox,
+                        Flags = flags,
+                    };
+
+                    doct.Entry2List.Add(entry2);
+                    vifPacketRenderingGroup.Add(faces);
+                }
+            }
+            var entry2LastIdx = doct.Entry2List.Count;
+
+            entry1.Entry2Index = Convert.ToUInt16(entry2FirstIdx);
+            entry1.Entry2LastIndex = Convert.ToUInt16(entry2LastIdx);
+        }
+    }
+}

--- a/OpenKh.Command.MapGen/Utils/MapBuilder.cs
+++ b/OpenKh.Command.MapGen/Utils/MapBuilder.cs
@@ -226,15 +226,30 @@ namespace OpenKh.Command.MapGen.Utils
                         }
                     );
 
-                    return config.disableBSPCollisionBuilder
-                        ? new FlattenCollisionBuilder(
-                            splitter,
-                            matDef => matDef.surfaceFlags
-                        )
-                        : new HierarchicalCollisionBuilder(
+                    if (config.disableBSPCollisionBuilder2)
+                    {
+                        // Use the logic for the "group" value when disableBSPCollisionBuilder2 is set
+                        return new FlattenCollisionBuilderAlt(
                             splitter,
                             matDef => matDef.surfaceFlags
                         );
+                    }
+                    else if (config.disableBSPCollisionBuilder)
+                    {
+                        // Use the existing logic for disabling BSP collision builder
+                        return new FlattenCollisionBuilder(
+                            splitter,
+                            matDef => matDef.surfaceFlags
+                        );
+                    }
+                    else
+                    {
+                        // Default to the hierarchical collision builder
+                        return new HierarchicalCollisionBuilder(
+                            splitter,
+                            matDef => matDef.surfaceFlags
+                        );
+                    }
                 }
 
                 {

--- a/OpenKh.Command.MapGen/Utils/MapBuilder.cs
+++ b/OpenKh.Command.MapGen/Utils/MapBuilder.cs
@@ -51,7 +51,7 @@ namespace OpenKh.Command.MapGen.Utils
             }
             else if (config.disableBSPCollisionBuilder)
             {
-                logger.Debug($"Running flatten doct builder.");
+                logger.Debug($"Running flatten doct builder (Legacy.)");
 
                 doctBuilt = new FlattenDoctBuilder(
                     new BSPNodeSplitter(
@@ -68,9 +68,9 @@ namespace OpenKh.Command.MapGen.Utils
             }
             else if (config.disableBSPCollisionBuilder2)
             {
-                logger.Debug($"Running flatten doct builder.");
+                logger.Debug($"Running flatten doct builder (with group support.)");
 
-                doctBuilt = new FlattenDoctBuilder(
+                doctBuilt = new FlattenDoctBuilderAlt(
                     new BSPNodeSplitter(
                         singleFaces
                             .Where(it => !it.matDef.nodraw),


### PR DESCRIPTION
Title.

Using the disableBSPCollisionBuilder2 option now applies a new form of DOCT generation which allows you to assign specific faces into their own rendering nodes using the "group" tag on the material of said mesh. This allows you to hide and unhide the meshes using MapVisibility flags in the ARD.

This change also now allows you to flag specific material faces with a "floorLevel" value, which the game uses for shadow rendering.