### PR TITLE
Fix mod manager not opening sometimes

### DIFF
--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -377,8 +377,24 @@ namespace OpenKh.Tools.ModsManager.ViewModels
 
             AutoUpdateMods = ConfigurationService.AutoUpdateMods;
 
-            Log.OnLogDispatch += (long ms, string tag, string message) =>
-                _debuggingWindow.Log(ms, tag, message);
+            try
+            {
+                Log.OnLogDispatch += (long ms, string tag, string message) =>
+                    _debuggingWindow.Log(ms, tag, message);
+            }
+            catch
+            {
+                Process[] runningProcesses = Process.GetProcesses();
+                foreach (Process process in runningProcesses)
+                {
+                    if (process.ProcessName == "OpenKh.Tools.ModsManager" && process.Id != Process.GetCurrentProcess().Id)
+                    {
+                        process.Kill(true);
+                    }
+                }
+                System.Windows.Forms.Application.Restart();
+                Process.GetCurrentProcess().Kill();
+            }
 
             ReloadModsList();
             SelectedValue = ModsList.FirstOrDefault();


### PR DESCRIPTION
If mod manager cannot open due to the log file being in use it will kill all processes of mod manager then restart to properly load the log file. (allowing the debug window to show up properly since that relies on the log)