### PR TITLE
Cherry picked Linux fixes and improvements from pr #1096 and #1199

### DIFF
--- a/OpenKh.Bbs/Scd.cs
+++ b/OpenKh.Bbs/Scd.cs
@@ -41,7 +41,7 @@ namespace OpenKh.Bbs
             [Data] public uint StreamSize { get; set; }
             [Data] public uint ChannelCount { get; set; }
             [Data] public uint SampleRate { get; set; }
-            [Data] public uint Codec { get; set; } //6 = .ogg, everything else is msadpcm
+            [Data] public uint Codec { get; set; } //6 = .ogg, 12 = MSADPCM .wav
             [Data] public uint LoopStart { get; set; }
             [Data] public uint LoopEnd { get; set; }
             [Data] public uint ExtraDataSize { get; set; }
@@ -61,7 +61,7 @@ namespace OpenKh.Bbs
             [Data(Count = 16)] public string Name { get; set; }
         }
 
-        public Header header = new();
+        public Header FileHeader = new();
         public TableOffsetHeader tableOffsetHeader = new();
         public List<StreamHeader> StreamHeaders = [];
         public List<byte[]> StreamFiles = [];
@@ -69,24 +69,23 @@ namespace OpenKh.Bbs
 
         public static Scd Read(Stream stream)
         {
+            stream.Seek(0, SeekOrigin.Begin);
+            
             var scd = new Scd
             {
-                header = BinaryMapping.ReadObject<Header>(stream),
+                FileHeader = BinaryMapping.ReadObject<Header>(stream),
                 tableOffsetHeader = BinaryMapping.ReadObject<TableOffsetHeader>(stream),
             };
 
             stream.Seek(scd.tableOffsetHeader.Table1Offset, SeekOrigin.Begin);
 
-            var SoundOffsets = new List<uint>();
-            for (var i = 0; i < scd.tableOffsetHeader.Table1ElementCount; i++)
-            {
-                SoundOffsets.Add(stream.ReadUInt32());
-            }
+            var soundOffsets = new List<uint>();
+            for (var i = 0; i < scd.tableOffsetHeader.Table1ElementCount; i++) soundOffsets.Add(stream.ReadUInt32());
 
-            for (var index = 0; index < SoundOffsets.Count; index++)
+            for (var index = 0; index < soundOffsets.Count; index++)
             {
-                var off = SoundOffsets[index];
-                var next = (int)((index == SoundOffsets.Count - 1 ? stream.Length : SoundOffsets[index + 1]) - off);
+                var off = soundOffsets[index];
+                var next = (int)(index == soundOffsets.Count - 1 ? stream.Length : soundOffsets[index + 1] - off);
                 stream.Seek(off, SeekOrigin.Begin);
                 var streamInfo = BinaryMapping.ReadObject<StreamHeader>(stream);
                 scd.StreamHeaders.Add(streamInfo);
@@ -95,41 +94,59 @@ namespace OpenKh.Bbs
                 scd.StreamFiles.Add(st);
 
                 //https://github.com/Leinxad/KHPCSoundTools/blob/main/SCDInfo/Program.cs#L109
-                if (streamInfo.Codec == 6)
+                switch (streamInfo.Codec)
                 {
-                    var extradataOffset = 0u;
-                    if (streamInfo.AuxChunkCount > 0) extradataOffset += BitConverter.ToUInt32(st.Skip((int)extradataOffset).Take(4).ToArray(), 0);
-
-                    var encryptionKey = st[extradataOffset + 0x02];
-                    var seekTableSize = BitConverter.ToUInt32(st.Skip((int)extradataOffset + 0x10).Take(4).ToArray(), 0);
-                    var vorbHeaderSize = BitConverter.ToUInt32(st.Skip((int)extradataOffset + 0x14).Take(4).ToArray(), 0);
-                
-                    var startOffset = extradataOffset + 0x20 + seekTableSize;
-
-                    var decryptedFile = st.ToArray();
-
-                    var endPosition = startOffset + vorbHeaderSize;
-                
-                    for (var i = startOffset; i < endPosition; i++)
+                    case 6:
                     {
-                        decryptedFile[i] = (byte)(decryptedFile[i]^encryptionKey);
-                    }
-                    
-                    var oggSize = vorbHeaderSize + streamInfo.StreamSize;
-                    
-                    scd.MediaFiles.Add(decryptedFile.Skip((int)startOffset).Take((int)oggSize).ToArray());
-                }
-                else scd.MediaFiles.Add(Array.Empty<byte>());
+                        var extradataOffset = 0u;
+                        if (streamInfo.AuxChunkCount > 0) extradataOffset += BitConverter.ToUInt32(st.Skip(0x04).Take(4).ToArray(), 0);
+
+                        var encryptionKey = st[extradataOffset + 0x02];
+                        var seekTableSize = BitConverter.ToUInt32(st.Skip((int)extradataOffset + 0x10).Take(4).ToArray(), 0);
+                        var vorbHeaderSize = BitConverter.ToUInt32(st.Skip((int)extradataOffset + 0x14).Take(4).ToArray(), 0);
                 
+                        var startOffset = extradataOffset + 0x20 + seekTableSize;
 
+                        var decryptedFile = st.ToArray();
 
-                // Convert to VAG Streams.
-                /*VAGHeader vagHeader = new VAGHeader();
-                vagHeader.ChannelCount = (byte)streamInfo.ChannelCount;
-                vagHeader.SamplingFrequency = (byte)streamInfo.SampleRate;
-                vagHeader.Version = 3;
-                vagHeader.Magic = 0x70474156;
-                vagHeader.Name = p.ToString();*/
+                        var endPosition = startOffset + vorbHeaderSize;
+                
+                        for (var i = startOffset; i < endPosition; i++) decryptedFile[i] = (byte)(decryptedFile[i]^encryptionKey);
+                    
+                        var oggSize = vorbHeaderSize + streamInfo.StreamSize;
+                    
+                        scd.MediaFiles.Add(decryptedFile.Skip((int)startOffset).Take((int)oggSize).ToArray());
+                        break;
+                    }
+                    case 12:
+                    {
+                        var streamSize = streamInfo.StreamSize;
+                        var channelCount = streamInfo.ChannelCount;
+                        var sampleRate = streamInfo.SampleRate;
+
+                        var length = streamSize + (0x4e - 0x8);
+
+                        var msadpcm = Array.Empty<byte>()
+                            .Concat(BitConverter.GetBytes(0x46464952)) //"RIFF"
+                            .Concat(BitConverter.GetBytes(length)) //overall file size - 8
+                            .Concat(BitConverter.GetBytes(0x45564157)) //"WAVE"
+                            .Concat(BitConverter.GetBytes(0x20746D66)) //"fmt "
+                            .Concat(BitConverter.GetBytes(0x32))
+                            .Concat(st.Take(0x32))
+                            .Concat(BitConverter.GetBytes(0x61746164)) //"data"
+                            .Concat(BitConverter.GetBytes((int)streamSize))
+                            .Concat(st.Skip(0x32))
+                            .ToArray();
+                    
+                        scd.MediaFiles.Add(msadpcm);
+                        break;
+                    }
+                    default:
+                    {
+                        scd.MediaFiles.Add(null);
+                        break;
+                    }
+                }
             }
 
 

--- a/OpenKh.Bbs/Scd.cs
+++ b/OpenKh.Bbs/Scd.cs
@@ -65,7 +65,7 @@ namespace OpenKh.Bbs
         public TableOffsetHeader tableOffsetHeader = new();
         public List<StreamHeader> StreamHeaders = [];
         public List<byte[]> StreamFiles = [];
-        public List<byte[]> MediaFiles = [];
+        public List<byte[]> MediaFiles = []; //6 = .ogg file, everything else is a .wav with msadpcm codec, throw it at ffmpeg /shrug
 
         public static Scd Read(Stream stream)
         {

--- a/OpenKh.Bbs/Scd.cs
+++ b/OpenKh.Bbs/Scd.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Xe.BinaryMapper;
 using System.IO;
+using System.Linq;
 using OpenKh.Common;
 
 namespace OpenKh.Bbs

--- a/OpenKh.Bbs/Scd.cs
+++ b/OpenKh.Bbs/Scd.cs
@@ -41,7 +41,7 @@ namespace OpenKh.Bbs
             [Data] public uint StreamSize { get; set; }
             [Data] public uint ChannelCount { get; set; }
             [Data] public uint SampleRate { get; set; }
-            [Data] public uint Codec { get; set; }
+            [Data] public uint Codec { get; set; } //6 = .ogg, everything else is msadpcm
             [Data] public uint LoopStart { get; set; }
             [Data] public uint LoopEnd { get; set; }
             [Data] public uint ExtraDataSize { get; set; }
@@ -61,32 +61,67 @@ namespace OpenKh.Bbs
             [Data(Count = 16)] public string Name { get; set; }
         }
 
-        public static Header header = new Header();
-        public static TableOffsetHeader tableOffsetHeader = new TableOffsetHeader();
-        public static List<byte[]> StreamFiles = new List<byte[]>();
+        public Header header = new();
+        public TableOffsetHeader tableOffsetHeader = new();
+        public List<StreamHeader> StreamHeaders = [];
+        public List<byte[]> StreamFiles = [];
+        public List<byte[]> MediaFiles = [];
 
         public static Scd Read(Stream stream)
         {
-            Scd scd = new Scd();
+            var scd = new Scd
+            {
+                header = BinaryMapping.ReadObject<Header>(stream),
+                tableOffsetHeader = BinaryMapping.ReadObject<TableOffsetHeader>(stream),
+            };
 
-            header = BinaryMapping.ReadObject<Header>(stream);
-            tableOffsetHeader = BinaryMapping.ReadObject<TableOffsetHeader>(stream);
+            stream.Seek(scd.tableOffsetHeader.Table1Offset, SeekOrigin.Begin);
 
-            stream.Seek(tableOffsetHeader.Table1Offset, SeekOrigin.Begin);
-
-            List<uint> SoundOffsets = new List<uint>();
-            for (int i = 0; i < tableOffsetHeader.Table1ElementCount; i++)
+            var SoundOffsets = new List<uint>();
+            for (var i = 0; i < scd.tableOffsetHeader.Table1ElementCount; i++)
             {
                 SoundOffsets.Add(stream.ReadUInt32());
             }
 
-            foreach(uint off in SoundOffsets)
+            for (var index = 0; index < SoundOffsets.Count; index++)
             {
+                var off = SoundOffsets[index];
+                var next = (int)((index == SoundOffsets.Count - 1 ? stream.Length : SoundOffsets[index + 1]) - off);
                 stream.Seek(off, SeekOrigin.Begin);
                 var streamInfo = BinaryMapping.ReadObject<StreamHeader>(stream);
+                scd.StreamHeaders.Add(streamInfo);
 
-                byte[] st = stream.ReadBytes((int)streamInfo.StreamSize);
-                StreamFiles.Add(st);
+                var st = stream.ReadBytes(next - 0x20);
+                scd.StreamFiles.Add(st);
+
+                //https://github.com/Leinxad/KHPCSoundTools/blob/main/SCDInfo/Program.cs#L109
+                if (streamInfo.Codec == 6)
+                {
+                    var extradataOffset = 0u;
+                    if (streamInfo.AuxChunkCount > 0) extradataOffset += BitConverter.ToUInt32(st.Skip((int)extradataOffset).Take(4).ToArray(), 0);
+
+                    var encryptionKey = st[extradataOffset + 0x02];
+                    var seekTableSize = BitConverter.ToUInt32(st.Skip((int)extradataOffset + 0x10).Take(4).ToArray(), 0);
+                    var vorbHeaderSize = BitConverter.ToUInt32(st.Skip((int)extradataOffset + 0x14).Take(4).ToArray(), 0);
+                
+                    var startOffset = extradataOffset + 0x20 + seekTableSize;
+
+                    var decryptedFile = st.ToArray();
+
+                    var endPosition = startOffset + vorbHeaderSize;
+                
+                    for (var i = startOffset; i < endPosition; i++)
+                    {
+                        decryptedFile[i] = (byte)(decryptedFile[i]^encryptionKey);
+                    }
+                    
+                    var oggSize = vorbHeaderSize + streamInfo.StreamSize;
+                    
+                    scd.MediaFiles.Add(decryptedFile.Skip((int)startOffset).Take((int)oggSize).ToArray());
+                }
+                else scd.MediaFiles.Add(Array.Empty<byte>());
+                
+
 
                 // Convert to VAG Streams.
                 /*VAGHeader vagHeader = new VAGHeader();
@@ -96,7 +131,6 @@ namespace OpenKh.Bbs
                 vagHeader.Magic = 0x70474156;
                 vagHeader.Name = p.ToString();*/
             }
-
 
 
             return scd;

--- a/OpenKh.Egs/EgsTools.cs
+++ b/OpenKh.Egs/EgsTools.cs
@@ -68,7 +68,13 @@ namespace OpenKh.Egs
 
         #region Extract
 
-        public static void Extract(string inputHed, string output, bool doNotExtractAgain = false)
+        public enum ExtractFileOutputMode
+        {
+            SeparateRoot,
+            Adjacent,
+        }
+
+        public static void Extract(string inputHed, string output, bool doNotExtractAgain = false, ExtractFileOutputMode outputMode = ExtractFileOutputMode.SeparateRoot)
         {
             var outputDir = output ?? Path.GetFileNameWithoutExtension(inputHed);
             using var hedStream = File.OpenRead(inputHed);
@@ -80,7 +86,11 @@ namespace OpenKh.Egs
                 if (!Names.TryGetValue(hash, out var fileName))
                     fileName = $"{hash}.dat";
 
-                var outputFileName = Path.Combine(outputDir, ORIGINAL_FILES_FOLDER_NAME, fileName);
+                var outputFileName = outputMode switch
+                {
+                    ExtractFileOutputMode.Adjacent => Path.Combine(outputDir, fileName),
+                    _ => Path.Combine(outputDir, ORIGINAL_FILES_FOLDER_NAME, fileName),
+                };
 
                 if (doNotExtractAgain && File.Exists(outputFileName))
                     continue;
@@ -92,7 +102,11 @@ namespace OpenKh.Egs
 
                 File.Create(outputFileName).Using(stream => stream.Write(hdAsset.OriginalData));
 
-                outputFileName = Path.Combine(outputDir, REMASTERED_FILES_FOLDER_NAME, fileName);
+                outputFileName = outputMode switch
+                {
+                    ExtractFileOutputMode.Adjacent => Path.Combine(outputDir, $"{fileName}.remastered.d"),
+                    _ => Path.Combine(outputDir, REMASTERED_FILES_FOLDER_NAME, fileName),
+                };
 
                 foreach (var asset in hdAsset.Assets)
                 {

--- a/OpenKh.Kh1/Cvbl.cs
+++ b/OpenKh.Kh1/Cvbl.cs
@@ -1,0 +1,368 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using OpenKh.Common;
+using Xe.BinaryMapper;
+
+namespace OpenKh.Kh1
+{
+    public class Cvbl
+    {
+        public class CvblHeader
+        {
+            [Data] public uint Unk1 { get; set; }
+            [Data] public uint NumMeshes { get; set; }
+            [Data] public ushort NumUnknownEntries { get; set; }
+            [Data] public ushort HasUnknownEntries { get; set; }
+            [Data] public uint Unk2 { get; set; }
+        }
+        public class MeshEntry
+        {
+            [Data] public ushort Unk1 { get; set; }
+            [Data] public ushort JointStyle { get; set; }
+            [Data] public int Material { get; set; }
+            [Data] public int Unk2 { get; set; }
+            [Data] public uint MeshOffset { get; set; }
+        }
+
+        public class VertexStyle8 : IVertex
+        {
+            [Data] public float NormalX { get; set; }
+            [Data] public float NormalY { get; set; }
+            [Data] public float NormalZ { get; set; }
+            [Data] public ushort JointSlotId { get; set; }
+            [Data] public byte FaceType { get; set; } // 1 = (-2, -1, 0), 2 = (0, -1, -2)
+            [Data] public byte UseFace { get; set; } // must == 0 for face
+            [Data] public float U { get; set; }
+            [Data] public float V { get; set; }
+            
+            [Data] public float Unk1 { get; set; } // is this the weird Y UV coordinate that mdls has?
+            [Data] public uint Unk2 { get; set; }
+            
+            [Data] public float PositionX { get; set; }
+            [Data] public float PositionY { get; set; }
+            [Data] public float PositionZ { get; set; }
+            [Data] public float Weight { get; set; }
+            
+
+
+            public Vector3 Position
+            {
+                get => new(PositionX, PositionY, PositionZ);
+                set
+                {
+                    PositionX = value.X;
+                    PositionY = value.Y;
+                    PositionZ = value.Z;
+                }
+            }
+            public Vector3 Normal => new(NormalX, NormalY, NormalZ);
+            public Vector2 UV => new(U, V);
+            public ushort[] Joints
+            {
+                get => [JointSlotId];
+                set
+                {
+                    if (value is null || value.Length == 0) return;
+                    JointSlotId = value.First();
+                }
+            }
+            public float[] Weights => [Weight];
+            
+            public int Face => UseFace == 0 ? FaceType : 0;
+            public int Size => 48;
+        }
+
+        public class VertexStyle9 : IVertex
+        {
+            [Data] public float NormalX { get; set; }
+            [Data] public float NormalY { get; set; }
+            [Data] public float NormalZ { get; set; }
+            [Data] public ushort JointCount { get; set; }
+            [Data] public byte FaceType { get; set; } // 1 = (-2, -1, 0), 2 = (0, -1, -2)
+            [Data] public byte UseFace { get; set; } // must == 0 for face
+            [Data] public float U { get; set; }
+            [Data] public float V { get; set; }
+            [Data(Count = 8)] public byte[] JointSlotIds { get; set; }
+            [Data] public float PositionX { get; set; }
+            [Data] public float PositionY { get; set; }
+            [Data] public float PositionZ { get; set; }
+            [Data] public float PositionW { get; set; } // ??? maybe unk?
+            [Data(Count = 8)] public float[] JointWeights { get; set; }
+            
+            public Vector3 Position
+            {
+                get => new(PositionX, PositionY, PositionZ);
+                set
+                {
+                    PositionX = value.X;
+                    PositionY = value.Y;
+                    PositionZ = value.Z;
+                }
+            }
+            public Vector3 Normal => new(NormalX, NormalY, NormalZ);
+            public Vector2 UV => new(U, V);
+            public ushort[] Joints
+            {
+                get => JointSlotIds.Select(i => (ushort)i).Take(JointCount).ToArray();
+                set
+                {
+                    if (value is null || value.Length != JointSlotIds.Length) return;
+                    JointSlotIds = value.Select(i => (byte)i).ToArray();
+                }
+            }
+            public float[] Weights => JointWeights.Take(JointCount).ToArray();
+            
+            public int Face => UseFace == 0 ? FaceType : 0;
+            public int Size => 80;
+        }
+
+        public class VertexStyle10 : IVertex
+        {
+            [Data] public float PositionX { get; set; }
+            [Data] public float PositionY { get; set; }
+            [Data] public float PositionZ { get; set; }
+            [Data] public ushort JointSlotId { get; set; }
+            [Data] public byte FaceType { get; set; } // 1 = (-2, -1, 0), 2 = (0, -1, -2)
+            [Data] public byte UseFace { get; set; } // must == 0 for face
+
+            public Vector3 Position
+            {
+                get => new(PositionX, PositionY, PositionZ);
+                set
+                {
+                    PositionX = value.X;
+                    PositionY = value.Y;
+                    PositionZ = value.Z;
+                }
+            }
+
+            public ushort[] Joints
+            {
+                get => [JointSlotId];
+                set
+                {
+                    if (value is null || value.Length == 0) return;
+                    JointSlotId = value.First();
+                }
+            }
+            public float[] Weights => [1];
+
+            public int Face => UseFace == 0 ? FaceType : 0;
+            public int Size => 16;
+        }
+
+        public interface IVertex
+        {
+            public Vector3 Position { get; set; }
+            public Vector3 Normal => Vector3.Zero;
+            public Vector2 UV => Vector2.Zero;
+            public ushort[] Joints { get; set; }
+            public float[] Weights => Array.Empty<float>();
+            public int Face => 0;
+            public int Size => 0;
+        }
+
+        public class Submesh
+        {
+            public int Material;
+            public ushort JointStyle;
+
+            public List<IVertex> Vertices = new();
+            public List<uint[]> Faces = new();
+            public Dictionary<uint, uint> JointSlots = new();
+            
+            public Dictionary<uint, List<uint>> ExtraJointData = new();
+        }
+
+        public CvblHeader Header;
+        public List<Submesh> Submeshes = new();
+
+        private static Dictionary<uint, Matrix4x4> MdlsJointsToDictionary(List<Mdls.MdlsJoint> joints)
+        {
+            if (joints is null) return null;
+            var dict = new Dictionary<uint, Matrix4x4>();
+            for (var i = 0u; i < joints.Count; i++)
+            {
+                var j = joints[(int)i];
+                
+                var scaleMatrix = Matrix4x4.CreateScale(new Vector3(j.ScaleX, j.ScaleY, j.ScaleZ));
+                
+                var rotationMatrixX = Matrix4x4.CreateRotationX(j.RotateX);
+                var rotationMatrixY = Matrix4x4.CreateRotationY(j.RotateY);
+                var rotationMatrixZ = Matrix4x4.CreateRotationZ(j.RotateZ);
+                var rotationMatrix = rotationMatrixX * rotationMatrixY * rotationMatrixZ;
+                
+                var translationMatrix = Matrix4x4.CreateTranslation(new Vector3(j.TranslateX, j.TranslateY, j.TranslateZ));
+
+                dict[i] = scaleMatrix * rotationMatrix * translationMatrix;
+            }
+            return dict;
+        }
+        
+        public Cvbl(Stream stream, List<Mdls.MdlsJoint> mdlsJoints)
+        {
+            var file = stream.ReadAllBytes();
+            var str = new MemoryStream(file);
+            var joints = MdlsJointsToDictionary(mdlsJoints);
+            
+            Header = BinaryMapping.ReadObject<CvblHeader>(str);
+
+            str.Position = 0;
+
+            if (Header.HasUnknownEntries is not (0 or 1)) return;
+            var meshEntries = new List<MeshEntry>();
+                
+            var meshEntriesOffset = 16 + (Header.HasUnknownEntries == 1 ? Header.NumUnknownEntries * 32 : 0);
+                
+            str.Seek(meshEntriesOffset, SeekOrigin.Begin);
+                
+            for (var i = 0; i < Header.NumMeshes; i++) meshEntries.Add(BinaryMapping.ReadObject<MeshEntry>(str));
+
+            foreach (var meshEntry in meshEntries)
+            {
+                var mesh = new Submesh
+                {
+                    Material = meshEntry.Material,
+                    JointStyle = meshEntry.JointStyle,
+                };
+                var jointStyle = meshEntry.JointStyle;
+                    
+                var jointSlots = new Dictionary<uint, (uint, Matrix4x4)>();
+                for (var i = 0u; i < 48; i++)
+                {
+                    jointSlots[i] = (0, Matrix4x4.Identity);
+                }
+                    
+                var extraJointData = new Dictionary<uint, List<uint>>();
+                    
+                    
+                var totalVertCount = 0u;
+                var run = true;
+                var subsectionOffset = meshEntry.MeshOffset + 16;
+                while (run && subsectionOffset < str.Length)
+                {
+                    var subsectionDataOffset = subsectionOffset + 8;
+                        
+                    str.Seek(subsectionOffset, SeekOrigin.Begin);
+                        
+                    var subsectionType = str.ReadUInt32();
+                    var subsectionLength = str.ReadUInt32();
+                        
+                    if (subsectionType == 1)
+                    {
+                        var numVerts = str.ReadUInt32();
+
+                        var submeshDataOffset = subsectionDataOffset + 24;
+                        
+                        str.Seek(submeshDataOffset, SeekOrigin.Begin);
+                            
+                        for (var i = 0u; i < numVerts; i++)
+                        {
+                            IVertex vert = meshEntry.JointStyle switch
+                            {
+                                8 => BinaryMapping.ReadObject<VertexStyle8>(str),
+                                9 => BinaryMapping.ReadObject<VertexStyle9>(str),
+                                10 => BinaryMapping.ReadObject<VertexStyle10>(str),
+                                _ => null,
+                            };
+
+                            if (vert is null) continue;
+                            
+                            var bones = vert.Joints.Select(j => (ushort)jointSlots[j].Item1).ToArray();
+                            vert.Joints = bones;
+                            
+                            if (joints != null)
+                                vert.Position = RelativeToGlobalVertex(vert.Position, joints, vert.Joints.Select(j => (uint)j).ToArray(), vert.Weights,
+                                    vert.Joints.Select(j => jointSlots[j].Item2).ToArray());
+                                    
+
+                            str.Seek(submeshDataOffset + ((i + 1) * vert.Size), SeekOrigin.Begin);
+                                
+                            switch (vert.Face)
+                            {
+                                case 1:
+                                    mesh.Faces.Add([totalVertCount + i - 2, totalVertCount + i - 1, totalVertCount + i]);
+                                    break;
+                                case 2:
+                                    mesh.Faces.Add([totalVertCount + i, totalVertCount + i - 1, totalVertCount + i - 2]);
+                                    break;
+                            }
+                            mesh.Vertices.Add(vert);
+                        }
+                        totalVertCount += numVerts;
+                    }
+                    else if (subsectionType == 17)
+                    {
+                        var jointId = str.ReadUInt32();
+                        var jointSlotId = str.ReadUInt32();
+                        
+                        jointSlots[jointSlotId] = (jointId, jointSlots[jointSlotId].Item2);
+
+                        switch (jointStyle)
+                        {
+                            case 8:
+                            {
+                                var data = new List<uint>();
+                                for (var i = 0; i < 28; i++) data.Add(str.ReadUInt32());
+                                extraJointData[jointSlotId] = data;
+
+                                break;
+                            }
+                            case 9:
+                            {
+                                var data = new List<uint>();
+                                for (var i = 0; i < 28; i++) data.Add(str.ReadUInt32());
+                                extraJointData[jointSlotId] = data;
+                                    
+                                jointSlots[jointSlotId] = (jointId, new Matrix4x4(
+                                    str.ReadSingle(), str.ReadSingle(), str.ReadSingle(), str.ReadSingle(),
+                                    str.ReadSingle(), str.ReadSingle(), str.ReadSingle(), str.ReadSingle(),
+                                    str.ReadSingle(), str.ReadSingle(), str.ReadSingle(), str.ReadSingle(),
+                                    str.ReadSingle(), str.ReadSingle(), str.ReadSingle(), str.ReadSingle()
+                                ));
+                                break;
+                            }
+                            case 10:
+                            {
+                                var data = new List<uint>();
+                                for (var i = 0; i < 16; i++) data.Add(str.ReadUInt32());
+                                extraJointData[jointSlotId] = data;
+                                break;
+                            }
+                            default:
+                                Console.WriteLine($"Warning: Unknown joint style: {jointStyle} @ {subsectionDataOffset}");
+                                return;
+                        }
+                    }
+                    else if (subsectionType == 32768) run = false;
+                    else break;
+                    subsectionOffset += subsectionLength;
+                }
+
+                mesh.JointSlots = jointSlots.ToDictionary(i => i.Key, i => i.Value.Item1);
+                mesh.ExtraJointData = extraJointData;
+                    
+                Submeshes.Add(mesh);
+            }
+        }
+        
+        private static Vector3 RelativeToGlobalVertex(Vector3 vertex, Dictionary<uint, Matrix4x4> joints, IReadOnlyList<uint> jointIds, IReadOnlyList<float> weights, IReadOnlyList<Matrix4x4> toLocalTransforms)
+        {
+            var vert = new Vector4(0, 0, 0, 0);
+            for (var i = 0; i < jointIds.Count; i++)
+            {
+                var jointId = jointIds[i];
+                var weight = weights[i];
+                var tlt = i < toLocalTransforms.Count ? toLocalTransforms[i] : Matrix4x4.Identity;
+                var npVert = new Vector4(vertex, 1) * weight;
+                var globalMat = joints[jointId] * tlt;
+                npVert = Vector4.Transform(npVert, globalMat);
+                vert += npVert;
+            }
+            return new Vector3(vert.X, vert.Y, vert.Z);
+        }
+    }
+}

--- a/OpenKh.Kh1/Cvbl.cs
+++ b/OpenKh.Kh1/Cvbl.cs
@@ -179,6 +179,7 @@ namespace OpenKh.Kh1
 
         public CvblHeader Header;
         public List<Submesh> Submeshes = new();
+        public List<MeshEntry> MeshEntries = new();
 
         private static Dictionary<uint, Matrix4x4> MdlsJointsToDictionary(List<Mdls.MdlsJoint> joints)
         {
@@ -220,6 +221,8 @@ namespace OpenKh.Kh1
             str.Seek(meshEntriesOffset, SeekOrigin.Begin);
                 
             for (var i = 0; i < Header.NumMeshes; i++) meshEntries.Add(BinaryMapping.ReadObject<MeshEntry>(str));
+
+            MeshEntries = meshEntries;
 
             foreach (var meshEntry in meshEntries)
             {

--- a/OpenKh.Kh2/Bgm.cs
+++ b/OpenKh.Kh2/Bgm.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using OpenKh.Common;
+using OpenKh.Kh2.SystemData;
+using Xe.BinaryMapper;
+
+namespace OpenKh.Kh2;
+
+public class Bgm
+{
+    [Data] public uint Identifier { get; set; }
+    [Data] public ushort SequenceID { get; set; }
+    [Data] public ushort SoundfontID { get; set; }
+    [Data] public byte TrackCount { get; set; }
+    [Data] public byte Unk0 { get; set; }
+    [Data] public byte Unk1 { get; set; }
+    [Data] public byte Unk2 { get; set; }
+    [Data] public sbyte Volume { get; set; }
+    [Data] public byte Unk3 { get; set; }
+    [Data] public ushort PartsPerQuarterNote { get; set; }
+    [Data] public uint FileSize { get; set; }
+        
+    [Data] public uint Reserved0 { get; set; }
+    [Data] public uint Reserved1 { get; set; }
+    [Data] public uint Reserved2 { get; set; }
+
+    public List<byte[]> Tracks = new();
+
+    public class BgmTrack
+    {
+        [Data] public byte[] Raw { get; set; }
+    }
+        
+    public static Bgm Read(Stream stream)
+    {
+        var bgm = BinaryMapping.ReadObject<Bgm>(stream);
+
+        bgm.Tracks = Enumerable.Range(0, bgm.TrackCount).Select(_ => stream.ReadBytes((int)stream.ReadUInt32())).ToList();
+
+        return bgm;
+    }
+}
+
+public enum BgmTrackCommandType
+{
+    EndOfTrack = 0x00,
+    LoopBegin = 0x02,
+    LoopEnd = 0x03,
+    SetTempo = 0x08,
+    Unk0 = 0x0A,
+    TimeSignature = 0x0C,
+    Unk1 = 0x0D,
+    NoteOnPreviousKeyVelocity = 0x10,
+    NoteOn = 0x11,
+    NoteOnPreviousVelocity = 0x12,
+    NoteOnPreviousKey = 0x13,
+    NoteOffPreviousNote = 0x18,
+    Unk2 = 0x19,
+    NoteOff = 0x1A,
+    ProgramChange = 0x20,
+    Volume = 0x22,
+    Expression = 0x24,
+    Pan = 0x26,
+    Unk3 = 0x28,
+    Unk4 = 0x31,
+    Unk5 = 0x34,
+    Unk6 = 0x35,
+    SustainPedal = 0x3C,
+    Unk7 = 0x3E,
+    Unk8 = 0x40,
+    Unk9 = 0x47,
+    Unk10 = 0x48,
+    Unk11 = 0x50,
+    Unk12 = 0x58,
+    Unk13 = 0x5C,
+    Portamento = 0x5D,
+}
+
+public static class BgmTrackCommandHelper
+{
+    public static int ArgumentByteReadCount(this BgmTrackCommandType command)
+    {
+        switch (command)
+        {
+            case BgmTrackCommandType.SetTempo:
+            case BgmTrackCommandType.Unk0:
+            case BgmTrackCommandType.Unk1:
+            case BgmTrackCommandType.NoteOnPreviousVelocity:
+            case BgmTrackCommandType.NoteOnPreviousKey:
+            case BgmTrackCommandType.NoteOff:
+            case BgmTrackCommandType.ProgramChange:
+            case BgmTrackCommandType.Volume:
+            case BgmTrackCommandType.Expression:
+            case BgmTrackCommandType.Pan:
+            case BgmTrackCommandType.Unk3:
+            case BgmTrackCommandType.Unk4:
+            case BgmTrackCommandType.Unk5:
+            case BgmTrackCommandType.Unk6:
+            case BgmTrackCommandType.SustainPedal:
+            case BgmTrackCommandType.Unk7:
+            case BgmTrackCommandType.Unk12:
+            case BgmTrackCommandType.Portamento:
+                return 1;
+            case BgmTrackCommandType.TimeSignature:
+            case BgmTrackCommandType.NoteOn:
+            case BgmTrackCommandType.Unk2:
+            case BgmTrackCommandType.Unk9:
+                return 2;
+            case BgmTrackCommandType.Unk8:
+            case BgmTrackCommandType.Unk10:
+            case BgmTrackCommandType.Unk11:
+                return 3;
+            default:
+                return 0;
+        }
+    }
+}

--- a/OpenKh.Kh2/Bop.cs
+++ b/OpenKh.Kh2/Bop.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using OpenKh.Common;
+using Xe.BinaryMapper;
+
+namespace OpenKh.Kh2
+{
+    public class Bop
+    {
+        public class BopEntry
+        {
+            [Data] public float PositionX { get; set; }
+            [Data] public float PositionY { get; set; }
+            [Data] public float PositionZ { get; set; }
+            
+            [Data] public float RotationX { get; set; }
+            [Data] public float RotationY { get; set; }
+            [Data] public float RotationZ { get; set; }
+            
+            [Data] public float ScaleX { get; set; }
+            [Data] public float ScaleY { get; set; }
+            [Data] public float ScaleZ { get; set; }
+            
+            [Data] public uint BobIndex { get; set; }
+            [Data] public uint Group { get; set; }
+            [Data] public int MotionIndex { get; set; }
+            [Data] public uint MotionOffset { get; set; }
+            [Data] public uint Flag { get; set; }
+            
+            [Data] public float ModelHUpper { get; set; }
+            [Data] public float ModelHLower { get; set; }
+            [Data] public float ModelMUpper { get; set; }
+            [Data] public float ModelMLower { get; set; }
+            [Data] public float ModelLUpper { get; set; }
+            [Data] public float ModelLLower { get; set; }
+            
+            [Data] public float PartsHUpper { get; set; }
+            [Data] public float PartsHLower { get; set; }
+            [Data] public float PartsMUpper { get; set; }
+            [Data] public float PartsMLower { get; set; }
+            [Data] public float PartsLUpper { get; set; }
+            [Data] public float PartsLLower { get; set; }
+        }
+
+        public List<BopEntry> Entries = new();
+        private Bop()
+        {
+            
+        }
+        public static Bop Read(Stream stream)
+        {
+            var bop = new Bop();
+
+            stream.ReadUInt32(); //the number 8
+            var fileSize = stream.ReadUInt32();
+            var count = (int)(fileSize / 0x68);
+            
+            bop.Entries = Enumerable.Range(0, count).Select(_ => BinaryMapping.ReadObject<BopEntry>(stream)).ToList();
+            
+            return bop;
+        }
+    }
+}

--- a/OpenKh.Kh2/Wd.cs
+++ b/OpenKh.Kh2/Wd.cs
@@ -1,0 +1,7 @@
+﻿namespace OpenKh.Kh2
+{
+    public class Wd
+    {
+        
+    }
+}

--- a/docs/kh2/file/model.md
+++ b/docs/kh2/file/model.md
@@ -61,7 +61,7 @@ Stored straight after the model [header](#header).
 | 0x0e   | uint8 | Unknown
 | 0x0f   | uint8 | Unknown
 
-UVSC option:
+[UVSC option](raw-texture.md#uvsc-uv-scroll):
 
 | Bit | Description |
 |-----|-------------|


### PR DESCRIPTION
This is a pull request going to merge changes in #1199.

> As that pr is still a draft, I have cherry picked all the non Godot code from the branch as it has some nice improvements for native Linux support and cleanups. Unfortunately I don't know how to do a partial cherry pick and keep Frozenreflex as the author of the other commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added CVBL parser for KH1, producing submeshes with vertices, faces, and skinning.
  - Introduced BGM reader for KH2 with track parsing and command utilities.
  - Added BOP reader for KH2 to load transformation entries.
  - Enhanced SCD handling with per-file media extraction, including OGG decryption and MSADPCM output.
  - Extraction tool now supports selectable output layout (adjacent or separate roots).

- Refactor
  - SCD processing moved from global to instance-based state for safer, isolated reads.

- Documentation
  - Updated KH2 model docs to link UVSC option for clarity.

- Chores
  - Added KH2 WD placeholder type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->