### PR TITLE
Fix Kh2LocalSetEditor to use `net8.0-windows` framework.

### DIFF
--- a/Openkh.Tools.Kh2LocalSetEditor/Openkh.Tools.Kh2LocalSetEditor.csproj
+++ b/Openkh.Tools.Kh2LocalSetEditor/Openkh.Tools.Kh2LocalSetEditor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <RootNamespace>KH2FM_Localset_Editor</RootNamespace>
     <AssemblyName>OpenKh.Tools.Kh2LocalSetEditor</AssemblyName>
     <UseWPF>true</UseWPF>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded the application to target .NET 8 for Windows.

- Impact
  - Improved stability and performance on supported systems.
  - Aligns compatibility with the latest Windows/.NET runtime.
  - No changes to user-facing features or workflows.

- Notes
  - Minimum requirement may change: users might need the .NET 8 Desktop Runtime installed.
  - If distributing binaries, ensure packaging includes or references the .NET 8 runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->