### PR TITLE
build.sh: update .NET framework version to net8.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -57,7 +57,7 @@ then
 fi
 
 # Publish solution
-dotnet publish $solution --configuration $configuration --verbosity $verbosity --framework net6.0 --output $output /p:DebugType=None /p:DebugSymbols=false
+dotnet publish $solution --configuration $configuration --verbosity $verbosity --framework net8.0 --output $output /p:DebugType=None /p:DebugSymbols=false
 
 rm $solution
 


### PR DESCRIPTION
Fix #1208 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build to target .NET 8.0 for published artifacts.
  * Users may notice improved performance and security benefits available in .NET 8.
  * System requirements: deployments now require a .NET 8–compatible environment/runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->