### PR TITLE
Fix `If` parser of `Spawn Script compiler`

### DIFF
--- a/OpenKh.Tests/kh2/ArdTests.cs
+++ b/OpenKh.Tests/kh2/ArdTests.cs
@@ -1,6 +1,7 @@
 using OpenKh.Common;
 using OpenKh.Kh2;
 using OpenKh.Kh2.Ard;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -141,6 +142,28 @@ StatusFlag5";
 
                 Assert.Equal(0x123, script[1].ProgramId);
                 Assert.Single(script[1].Functions);
+            }
+
+            [Fact]
+            public void CreateProgramWithIfCorrectly()
+            {
+                const string Input = @"
+Program 0xBE
+Party NO_FRIEND
+If Entrance 5
+	Mission 0x15F ""HE_COLOSSEUM_2""
+	Spawn ""b_b5""
+	Spawn ""b_z0""
+
+If Entrance 6
+	Mission 0x15F ""HE_COLOSSEUM_2""
+	Spawn ""b_b6""
+	Spawn ""b_z0""
+";
+                var script = AreaDataScript.Compile(Input).ToArray();
+                var output = AreaDataScript.Decompile(script);
+                string Normalize(string str) => str.Replace("\r\n", "\n").Trim();
+                Assert.Equal(expected: Normalize(Input), actual: Normalize(output));
             }
 
             [Theory]


### PR DESCRIPTION
Fix `If` parser of `Spawn Script compiler`

- Implement `If` parser
- Fix GetToken may throw ArgumentOutOfRangeException, which is not inherited from SpawnScriptParserException

Fix #1211

`he09` script can be compiled now:

<img width="1002" height="832" alt="2025-10-15_17h26_15" src="https://github.com/user-attachments/assets/a9489383-20aa-4e7b-8c48-ba888cc48462" />

Fix: giving `If Entrance` to the compiler threw `ArgumentOutOfRangeException` (not inherited from `SpawnScriptParserException`), which causes a silent crash of Map Studio immediately.

<img width="1002" height="832" alt="2025-10-15_17h25_56" src="https://github.com/user-attachments/assets/d84b0e7d-4621-4fdd-8061-01ed75b4f429" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly nests commands within “If Entrance” blocks based on indentation.
  * Preserves expected blank lines when decompiling scripts for consistent output.
  * More robust parsing with clear, descriptive errors when scripts are invalid or tokens are missing.

* **Tests**
  * Added a round-trip test verifying scripts with multiple “If Entrance” blocks compile and decompile correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->