### PR TITLE
Fix emulator mod loader

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/OperationDispatcher.cs
+++ b/OpenKh.Tools.ModsManager/Services/OperationDispatcher.cs
@@ -54,11 +54,11 @@ namespace OpenKh.Tools.ModsManager.Services
                 return false;
             }
 
-            finalFileName = Path.Combine(ConfigurationService.GameModPath, ConfigurationService.LaunchGame, fileName);
+            finalFileName = Path.Combine(ConfigurationService.GameModPath, fileName);
             if (File.Exists(finalFileName))
                 return true;
 
-            finalFileName = Path.Combine(ConfigurationService.GameDataLocation, ConfigurationService.LaunchGame, fileName);
+            finalFileName = Path.Combine(ConfigurationService.GameDataLocation, fileName);
             if (File.Exists(finalFileName))
                 return true;
 
@@ -72,11 +72,11 @@ namespace OpenKh.Tools.ModsManager.Services
                     .Replace($"/{region}/", $"/{fallback}/")
                     .Replace($".a.{region}", $".a.{fallback}")
                     .Replace($".apdx", $".a.{fallback}");
-                finalFileName = Path.Combine(ConfigurationService.GameModPath, ConfigurationService.LaunchGame, temptativeRegionalFallbackFileName);
+                finalFileName = Path.Combine(ConfigurationService.GameModPath, temptativeRegionalFallbackFileName);
                 if (File.Exists(finalFileName))
                     return true;
 
-                finalFileName = Path.Combine(ConfigurationService.GameDataLocation, ConfigurationService.LaunchGame, temptativeRegionalFallbackFileName);
+                finalFileName = Path.Combine(ConfigurationService.GameDataLocation, temptativeRegionalFallbackFileName);
                 if (File.Exists(finalFileName))
                     return true;
             }

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -545,7 +545,10 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         PanaceaInstalled = ConfigurationService.PanaceaInstalled;
                     }
                     else
+                    {
                         PC = false;
+                        GametoLaunch = 0;
+                    }
                     ConfigurationService.WizardVersionNumber = _wizardVersionNumber;
                 }
             });


### PR DESCRIPTION
 and prevent various launchgame variables having the possibility of being wrong if the user switched from PC to emulator for some reason

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined game file detection by adjusting the search path logic to focus on relevant directories for more accurate lookups.
  * Improved post-wizard configuration to ensure all game launch settings are properly initialized when completing setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->