### PR TITLE
Fix emulator being unable to load files from extraction folder

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/OperationDispatcher.cs
+++ b/OpenKh.Tools.ModsManager/Services/OperationDispatcher.cs
@@ -58,7 +58,7 @@ namespace OpenKh.Tools.ModsManager.Services
             if (File.Exists(finalFileName))
                 return true;
 
-            finalFileName = Path.Combine(ConfigurationService.GameDataLocation, fileName);
+            finalFileName = Path.Combine(ConfigurationService.GameDataLocation, ConfigurationService.LaunchGame, fileName);
             if (File.Exists(finalFileName))
                 return true;
 
@@ -76,7 +76,7 @@ namespace OpenKh.Tools.ModsManager.Services
                 if (File.Exists(finalFileName))
                     return true;
 
-                finalFileName = Path.Combine(ConfigurationService.GameDataLocation, temptativeRegionalFallbackFileName);
+                finalFileName = Path.Combine(ConfigurationService.GameDataLocation, ConfigurationService.LaunchGame, temptativeRegionalFallbackFileName);
                 if (File.Exists(finalFileName))
                     return true;
             }


### PR DESCRIPTION
These two Configuration.LaunchGames should not have been removed in my emulator fix. Technically everything still worked but it would load the vanilla file from the ISO instead of the vanilla file from the extraction folder like its supposed to

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file resolution to search in additional directories when locating game data files and regional fallback variants. The system now properly checks the LaunchGame subdirectory during file lookups, expanding the search scope for better file discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->