### PR TITLE
Fix `OpenKh.Tools.ModsManager` immediately hangs on its launch, when the current directory is read-only

### DIFF
--- a/OpenKh.Common/Log.cs
+++ b/OpenKh.Common/Log.cs
@@ -115,9 +115,9 @@ namespace OpenKh.Common
             {
                 return new StreamWriter(LogFileName, false, Encoding.UTF8, 65536);
             }
-            catch
+            catch (Exception ex) when (ex is UnauthorizedAccessException || ex is IOException)
             {
-                // For example: `System. UnauthorizedAccessException: Access to the path 'C:\WINDOWS\system32\OpenKh.Tools.ModsManager.log' is denied.`
+                // For example: `System.UnauthorizedAccessException: Access to the path 'C:\WINDOWS\system32\OpenKh.Tools.ModsManager.log' is denied.`
                 // Currently no need to inform the user about this failure.
 
                 return StreamWriter.Null;


### PR DESCRIPTION
Fix `new StreamWriter` throwing when the current directory is a non-writable location.

Fix #1221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging resilience: the app now silently guards against failures when creating the log writer (e.g., access or I/O errors), preventing crashes or disruption. If the log path is unavailable, logging will continue without writing to a file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->