### PR TITLE
[Mod Manager] MainViewModel: Cleanup UpdatePanaceaSettings

### DIFF
--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -1353,7 +1353,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     configTargetPath = ConfigurationService.PcReleaseLocationKH3D;
                 else
                 {
-                    Log.Warn("Unable to update Panacea settings! Game installation directory is not configured or is invalid.")
+                    Log.Warn("Unable to update Panacea settings! Game installation directory is not configured or is invalid.");
 
                     return;
                 }


### PR DESCRIPTION
## Changes
- Update `mod_path` text to use the same flattened directory path as in #1215
  - In between that PR and now, whenever the mod manager updated Panacea's settings file in situations outside of Building and Running the game, it would write the old expected `mod_path` value rather than the new one.
- Minimized duplicate code in the function
  - The only difference between the code in the conditionals was the path to the game's installation directory. So I moved all that code outside of the conditionals and made the conditionals simply assign a target variable.