### PR TITLE
Validate ConfigurationService.LaunchGame is valid else return "kh2"

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -86,7 +86,7 @@ namespace OpenKh.Tools.ModsManager.Services
         private static string EnabledCollectionModsPathKH3D = Path.Combine(StoragePath, "collection-mods-KH3D.json");
         private static readonly Config _config = Config.Open(ConfigPath);
         public static string PresetPath = Path.Combine(StoragePath, "presets");
-        private static List<string> _supportedGames = new List<string>()
+        private static readonly HashSet<string> _supportedGames = new HashSet<string>()
         {
             "kh2",
             "kh1",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Launch-target validation improved: unsupported selections now automatically revert to the supported default ("kh2") and the app updates the stored configuration.
  * Recognizes these launch targets: kh2, kh1, bbs, Recom, kh3d — preventing invalid launch settings from causing launch errors.



<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->