### PR TITLE
Change .NET version to 8.0.x in codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,10 +42,16 @@ jobs:
 
     - name: Checkout submodules
       run: git submodule update --init --recursive
+    
+    # Try to force .NET 6 build, this doesn't work atm well because we have projects that uses .net2.0 standard
+    #- name: Setup .NET
+    #  uses: actions/setup-dotnet@v1
+    #  with:
+    #    dotnet-version: '6.0'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,23 +62,10 @@ jobs:
         # queries: security-extended,security-and-quality
 
         
-    # Use the same .NET setup instruction used at dotnet.yml
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: '8.0.x'
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: setup-msbuild
-      uses: microsoft/setup-msbuild@v1.1.3
-    - name: msbuild
-      run: |
-        msbuild OpenKh.sln /p:Configuration=Release
-
-    ## Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    ## If this step fails, then you should remove it and run the build manually (see below)
-    #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v4
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -85,4 +78,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Updated .NET setup to use version 8.0.x in CodeQL workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded CodeQL workflow and analysis tooling to v4.
  * Replaced legacy autobuild placeholder with an explicit .NET build sequence in CI.
  * Added .NET 8 SDK setup, dependency restore, and project build steps in CI.
  * Pinned SDK via a configuration file to ensure consistent .NET 8.x usage across environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->