### PR TITLE
Optimize icon bitmap conversion

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/DownloadableModsService.cs
+++ b/OpenKh.Tools.ModsManager/Services/DownloadableModsService.cs
@@ -553,7 +553,7 @@ namespace OpenKh.Tools.ModsManager.Services
                             using (var ms = new MemoryStream(imageData))
                             {
                                 bitmap.BeginInit();
-                                bitmap.CreateOptions = BitmapCreateOptions.None;
+                                bitmap.CreateOptions = BitmapCreateOptions.IgnoreColorProfile;
                                 bitmap.CacheOption = BitmapCacheOption.OnLoad;
                                 bitmap.StreamSource = ms;
                                 bitmap.EndInit();


### PR DESCRIPTION
In its current state, loading mod icons for KH2 takes an incredibly long time. This is largely due to the conversion from PNG to bitmap, although why exactly that is I am unable to say.

This fix sacrifices some color accuracy but vastly improves the load time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image rendering for downloaded mods by adjusting how color profiles are handled during image decoding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->