### PR TITLE
Fix emulator checkboxes being visible if a valid ISO is selected but you have selected the PC version

### DIFF
--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -232,7 +232,7 @@
                     <StackPanel Orientation="Horizontal" Visibility="{Binding PcRelease28Selected}">
                         <CheckBox IsChecked="{Binding Extractkh3d}" Content="KH3D-51GB" Margin="0 0 6 4"/>
                     </StackPanel>
-                    <StackPanel Orientation="Horizontal">
+                    <StackPanel Orientation="Horizontal" Visibility="{Binding Pcsx2ConfigVisibility}">
                         <CheckBox IsChecked="{Binding Extractkh1}" Content="KH1-4GB" Margin="0 0 6 4" Visibility="{Binding KH1RecognizedVisibility}"/>
                         <CheckBox IsChecked="{Binding Extractkh2}" Content="KH2-4GB" Margin="0 0 6 4" Visibility="{Binding KH2RecognizedVisibility}"/>
                         <CheckBox IsChecked="{Binding Extractrecom}" Content="ReCoM-5GB" Margin="0 0 6 4" Visibility="{Binding RecomRecognizedVisibility}"/>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the setup wizard to conditionally display emulator configuration option checks instead of always showing them.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->