### PR TITLE
Slct Listpatch

### DIFF
--- a/OpenKh.Kh2/Slct.cs
+++ b/OpenKh.Kh2/Slct.cs
@@ -1,0 +1,40 @@
+using OpenKh.Common;
+using OpenKh.Kh2.Extensions;
+using OpenKh.Kh2.Utils;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xe.BinaryMapper;
+
+namespace OpenKh.Kh2
+{
+
+    public class ChoiceEntry
+    {
+        [Data] public short Id { get; set; }
+        [Data] public short MessageId { get; set; }
+    }
+    public class Slct
+    {
+
+        [Data] public ushort Id { get; set; }
+        [Data] public byte ChoiceNum { get; set; }
+        [Data] public byte ChoiceDefault { get; set; }
+
+        [Data(Count = 4)] public ChoiceEntry[] Choice { get; set; }
+        [Data] public short BaseSequence { get; set; }
+        [Data] public short TitleSequence { get; set; }
+        [Data] public int Information { get; set; }
+        [Data] public int EntryId { get; set; }
+        [Data] public int Task { get; set; }
+        [Data] public byte PauseMode { get; set; }
+        [Data] public byte Flag { get; set; }
+        [Data] public byte SoundPause { get; set; }
+        [Data(Count = 25)] public byte[] Padding { get; set; }
+
+        public static List<Slct> Read(Stream stream) => BaseTable<Slct>.Read(stream);
+        public static void Write(Stream stream, IEnumerable<Slct> entries) =>
+            BaseTable<Slct>.Write(stream, 2, entries);
+    }
+}

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -940,6 +940,27 @@ namespace OpenKh.Patcher
                         Kh2.SystemData.Cmd.Write(stream.SetPosition(0), cmdList);
                         break;
 
+                    case "slct":
+                        var slctList = Kh2.Slct.Read(stream);
+                        var moddedSlct = deserializer.Deserialize<List<Kh2.Slct>>(sourceText);
+
+                        foreach (var entries in moddedSlct)
+                        {
+                            var existingEntry = slctList.FirstOrDefault(x => x.Id == entries.Id);
+
+                            if (existingEntry != null)
+                            {
+                                slctList[slctList.IndexOf(existingEntry)] = entries;
+                            }
+                            else
+                            {
+                                slctList.Add(entries);
+                            }
+                        }
+
+                        Kh2.Slct.Write(stream.SetPosition(0), slctList);
+                        break;
+                        
                     case "localset":
                         var localList = Kh2.Localset.Read(stream);
                         var moddedLocal = deserializer.Deserialize<List<Kh2.Localset>>(sourceText);
@@ -1627,3 +1648,4 @@ namespace OpenKh.Patcher
         }
     }
 }
+

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -3188,6 +3188,94 @@ namespace OpenKh.Tests.Patcher
         }
 
         [Fact]
+        public void ListPatchSlctTest()
+        {
+            var patcher = new PatcherProcessor();
+            var serializer = new Serializer();
+            var patch = new Metadata()
+            {
+                Assets = new List<AssetFile>()
+                {
+                    new AssetFile()
+                    {
+                        Name = "14mission.bar",
+                        Method = "binarc",
+                        Source = new List<AssetFile>()
+                        {
+                            new AssetFile()
+                            {
+                                Name = "slct",
+                                Method = "listpatch",
+                                Type = "List",
+                                Source = new List<AssetFile>()
+                                {
+                                    new AssetFile()
+                                    {
+                                        Name = "SlctList.yml",
+                                        Type = "slct"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            File.Create(Path.Combine(AssetsInputDir, "14mission.bar")).Using(stream =>
+            {
+                var slctEntry = new List<Kh2.Slct>()
+                {
+                    new Kh2.Slct
+                    {
+                        Id = 1,
+                        ChoiceNum = 2,
+                        ChoiceDefault = 3,
+                        Choice = Enumerable.Range(0, 4).Select(_ => new Kh2.ChoiceEntry { Id = 0, MessageId = 0 }).ToArray(),
+                        Padding = new byte[25]
+                    }
+                    };
+                using var slctStream = new MemoryStream();
+                Kh2.Slct.Write(slctStream, slctEntry);
+                Bar.Write(stream, new Bar() {
+                    new Bar.Entry()
+                    {
+                        Name = "slct",
+                        Type = Bar.EntryType.List,
+                        Stream = slctStream
+                    }
+                });
+            });
+
+            File.Create(Path.Combine(ModInputDir, "SlctList.yml")).Using(stream =>
+            {
+                var writer = new StreamWriter(stream);
+                writer.WriteLine("- Id: 1");
+                writer.WriteLine("  ChoiceNum: 2");
+                writer.WriteLine("  ChoiceDefault: 3");
+                writer.WriteLine("  Choice:");
+                writer.WriteLine("  - Id: 0");
+                writer.WriteLine("    MessageId: 0");
+                writer.WriteLine("  Padding:");
+                writer.WriteLine("    - 0");
+                writer.Flush();
+            });
+
+            patcher.Patch(AssetsInputDir, ModOutputDir, patch, ModInputDir, Tests: true);
+
+            AssertFileExists(ModOutputDir, "14mission.bar");
+
+            File.OpenRead(Path.Combine(ModOutputDir, "14mission.bar")).Using(stream =>
+            {
+                var binarc = Bar.Read(stream);
+                var slctStream = Kh2.Slct.Read(binarc[0].Stream);
+                Assert.Equal(1, slctStream[0].Id);
+                Assert.Equal(2, slctStream[0].ChoiceNum);
+                Assert.Equal(3, slctStream[0].ChoiceDefault);
+            });
+        }
+
+
+        [Fact]
         public void ListPatchPlacesTest()
         {
             var patcher = new PatcherProcessor();

--- a/docs/tool/GUI.ModsManager/creatingMods.md
+++ b/docs/tool/GUI.ModsManager/creatingMods.md
@@ -41,6 +41,7 @@ This document will focus on teaching you how to create mods using the OpenKH Mod
       * [soundinfo](#soundinfo-source-example)
       * [place](#place-source-example)
       * [jigsaw](#jigsaw-source-example)
+      * [slct](#slct-source-example)
   * [bbsarc](#bbsarc-bbs)
   * [Example of a Fully Complete `mod.yml` File](#an-example-of-a-fully-complete-modyml-can-be-seen-below-and-the-full-source-of-the-mod-can-be-seen-here)
 * [Generating a Simple `mod.yml` for New Mod Authors](#generating-a-simple-modyml-for-new-mod-authors)
@@ -332,6 +333,7 @@ Asset Example
  * `soundinfo`
  * `place`
  * `jigsaw`
+ * `slct`
 
 Asset Example
 ```
@@ -862,6 +864,31 @@ Sora:
   JigsawIdWorld: 99
   Unk07: 0
   Unk08: 0
+```
+### `slct` Source Example
+```
+- Id: 1
+  ChoiceNum: 4 #Amount of options
+  ChoiceDefault: 3 #Option to default to
+  Choice:
+  - Id: 0 #Choice "Function"
+    MessageId: 0 #MessageID to assign to the Choice
+  - Id: 1
+    MessageId: 1
+  - Id: 2
+    MessageId: 2
+  - Id: 3
+    MessageId: 3
+  BaseSequence: 12 #Signed short, can be negative
+  TitleSequence: 13 #Signed short, can be negative
+  Information: 14
+  EntryId: 15
+  Task: 16
+  PauseMode: 17
+  Flag: 18
+  SoundPause: 19
+  Padding: #There are 25 padding bytes in total
+  - 0
 ```
 
 * `synthpatch` (KH2) - Modifies Mixdata.bar, a file used for various properties related to synthesis in KH2. 

--- a/docs/tool/GUI.ModsManager/creatingMods.md
+++ b/docs/tool/GUI.ModsManager/creatingMods.md
@@ -881,11 +881,11 @@ Sora:
     MessageId: 3
   BaseSequence: 12 #Signed short, can be negative
   TitleSequence: 13 #Signed short, can be negative
-  Information: 14
-  EntryId: 15
+  Information: 14 #Value tends to always be 0?
+  EntryId: 15 #
   Task: 16
-  PauseMode: 17
-  Flag: 18
+  PauseMode: 0 #6 possible values. 0 = Null, 1 = Battle, 2 = Form, 3 = Mission, 4 = Event, 5 = Musical
+  Flag: 1 #Two possible flags. 0 Allows you to unpause, 1 disables unpausing to get out of the menu.
   SoundPause: 19
   Padding: #There are 25 padding bytes in total
   - 0


### PR DESCRIPTION
Adds Slct Listpatching for the file 14mission.bar, documentation, & tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added serialization support for Kingdom Hearts II select menu entries, enabling read/write of menu definitions.
  * Added mod patching capability to merge and apply select menu configurations.

* **Documentation**
  * Added guide and YAML examples for creating and modifying select menu assets.

* **Tests**
  * Added tests covering select menu list patching workflows and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->