### PR TITLE
PCSX2 injection support for vanilla JP KH1, vanilla USA KH1 and JP ReCoM

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/GameDataExtractionService.cs
+++ b/OpenKh.Tools.ModsManager/Services/GameDataExtractionService.cs
@@ -90,7 +90,7 @@ namespace OpenKh.Tools.ModsManager.Services
             Action<float> onProgress)
         {
             using var stream = File.OpenRead(isoLocation);
-            var rdi_stream = IsoUtility.GetSectors(stream, 0x244, stream.SetPosition(0x244 * 0x800).ReadByte() + 1);
+            var rdi_stream = IsoUtility.GetSectors(stream, 0x244, stream.SetPosition(0x244 * 0x800 + 8).ReadInt16() + 1);
             var rdi = RootDirInfo.Read(rdi_stream);
             await Task.Run(() => {
                 rdi.ExtractFiles(stream, Path.Combine(gameDataLocation, "Recom"), onProgress);

--- a/OpenKh.Tools.ModsManager/Services/GameDataExtractionService.cs
+++ b/OpenKh.Tools.ModsManager/Services/GameDataExtractionService.cs
@@ -90,7 +90,7 @@ namespace OpenKh.Tools.ModsManager.Services
             Action<float> onProgress)
         {
             using var stream = File.OpenRead(isoLocation);
-            var rdi_stream = IsoUtility.GetSectors(stream, 0x244, stream.SetPosition(0x244 * 0x800).ReadByte());
+            var rdi_stream = IsoUtility.GetSectors(stream, 0x244, stream.SetPosition(0x244 * 0x800).ReadByte() + 1);
             var rdi = RootDirInfo.Read(rdi_stream);
             await Task.Run(() => {
                 rdi.ExtractFiles(stream, Path.Combine(gameDataLocation, "Recom"), onProgress);

--- a/OpenKh.Tools.ModsManager/Services/GameService.cs
+++ b/OpenKh.Tools.ModsManager/Services/GameService.cs
@@ -46,6 +46,7 @@ namespace OpenKh.Tools.ModsManager.Services
                 UniqueFileName = "CST_sora.pss",
                 Detectors = new()
                 {
+                    new GameDetectorModel { FileName = "SYSTEM.CNF;1", ProductId = "SLPM_666.76;1" },
                     new GameDetectorModel { FileName = "SYSTEM.CNF;1", ProductId = "SLUS_217.99;1" },
                 }
             }

--- a/OpenKh.Tools.ModsManager/Services/GameService.cs
+++ b/OpenKh.Tools.ModsManager/Services/GameService.cs
@@ -19,6 +19,8 @@ namespace OpenKh.Tools.ModsManager.Services
                 UniqueFileName = "btltbl.bin",
                 Detectors = new()
                 {
+                    new GameDetectorModel { FileName = "SYSTEM.CNF;1", ProductId = "SLPS_251.05;1" },
+                    new GameDetectorModel { FileName = "SYSTEM.CNF;1", ProductId = "SLUS_203.70;1" },
                     new GameDetectorModel { FileName = "SYSTEM.CNF;1", ProductId = "SLPS_251.97;1" },
                     new GameDetectorModel { FileName = "SYSTEM.CNF;1", ProductId = "SLPS_251.98;1" },
                 }

--- a/OpenKh.Tools.ModsManager/Services/Pcsx2Injector.cs
+++ b/OpenKh.Tools.ModsManager/Services/Pcsx2Injector.cs
@@ -21,8 +21,10 @@ namespace OpenKh.Tools.ModsManager.Services
             public int GetFileSize { get; init; }
             public int LoadFileTask { get; init; }
             public int LoadFileAsync { get; init; }
+            public int LoadFileAsyncJp { get; init; }
 
             public int GetFileSizeRecom { get; init; }
+            public int GetFileSizeRecomJp { get; init; }
             public int RegionInit { get; init; }
             public int BufferPointer { get; init; }
             public int RegionForce { get; init; }
@@ -482,6 +484,67 @@ namespace OpenKh.Tools.ModsManager.Services
             SW(V1, S1, 0x28),
         };
 
+        private static readonly uint[] LoadFileAsyncHookJp = new uint[]
+        {
+            // Input:
+            //
+            // Work:
+            //
+            LUI(T6, HookStack),
+            LW(T2, V0, 0x18B0),
+            LW(T3, V0, 0x189C),
+            ADDI(T4, V0, 0x18C8),
+            LW(T0, T4, 0),
+            ADDIU(T1, T3, 8),
+            LW(T4, T3, 0x38),
+            LW(T4, T4, 0),
+            SW(T0, T6, Param1), // FileDirID
+            BEQ(T2, T4, 9),
+            SW(T1, T6, Param2), // FileNamePtr
+            ADDIU(T4, Zero, (byte)Operation.GetFileSizeRecom),
+            SW(T4, T6, ParamOperator), // Operation
+            LW(T4, T6, ParamOperator),
+            BNE(T4, (byte)Operation.HookExit, -2),
+            LW(T4, T6, ParamReturn),
+            BEQ(T4, Zero, 7),
+            NOP(),
+            BEQ(Zero, Zero, 8),
+            SW(T2, T6, Param3), // MemDstPtr
+            SW(T5, T6, ParamOperator), // Operation
+            LW(T5, T6, ParamOperator),
+            BNE(T5, (byte)Operation.HookExit, -2),
+            LW(T4, T6, ParamReturn),
+            LUI(V1, 0x5B), // For Fallback
+            BEQ(T4, Zero, 5),
+            LW(A2, V0, 0x18CC),
+            ADD(T2, T2, T4),
+            SW(T2, V0, 0x18B0),
+            ADDIU(V0, Zero, 1),
+            ADDIU(RA, RA, 0x64),
+            JR(RA),
+            NOP(),
+        };
+
+        private static readonly uint[] GetFileSizeRecomHookJp = new uint[]
+        {
+            LUI(T6, HookStack),
+            LUI(V1, 0x5C),
+            ADDI(T4, V1, 0x18C8),
+            LW(T4, T4, 0),
+            SW(T4, T6, Param1), // FileDirID
+            SW(S2, T6, Param2), // FileNamePtr
+            SW(T5, T6, ParamOperator), // Operation
+            LW(T5, T6, ParamOperator),
+            BNE(T5, (byte)Operation.HookExit, -2),
+            LW(V1, T6, ParamReturn),
+            // For Fallback
+            BNE(V1, Zero, 2),
+            NOP(),
+            LW(V1, S2, 0x18),
+            JR(RA),
+            SW(V1, S1, 0x28),
+        };
+
 
 
         private static readonly uint[] RegionInitPatch = new uint[]
@@ -513,6 +576,11 @@ namespace OpenKh.Tools.ModsManager.Services
                 GameName = "SLUS_217.99;1",
                 LoadFileAsync = 0x1A0C6C,
                 GetFileSizeRecom = 0x1A11A0,
+            },
+            new Offsets {
+                GameName = "SLPM_666.76;1",
+                LoadFileAsyncJp = 0x1A0CFC,
+                GetFileSizeRecomJp = 0x1A1230,
             },
             new Offsets
             {
@@ -834,6 +902,14 @@ namespace OpenKh.Tools.ModsManager.Services
                         ADDIU(T5, Zero, (byte)Operation.LoadFileAsync));
                 }
 
+                if (offsets.LoadFileAsyncJp > 0)
+                {
+                    Log.Info("Injecting {0} function", nameof(offsets.LoadFileAsyncJp));
+                    WritePatch(stream, offsets.LoadFileAsyncJp,
+                        JAL(WriteHook(stream, LoadFileAsyncHookJp)),
+                        ADDIU(T5, Zero, (byte)Operation.LoadFileAsync));
+                }
+
                 if (offsets.LoadFile > 0)
                 {
                     Log.Info("Injecting {0} function", nameof(offsets.LoadFile));
@@ -866,6 +942,14 @@ namespace OpenKh.Tools.ModsManager.Services
                     Log.Info("Injecting {0} function", nameof(offsets.GetFileSizeRecom));
                     WritePatch(stream, offsets.GetFileSizeRecom,
                         JAL(WriteHook(stream, GetFileSizeRecomHook)),
+                        ADDIU(T5, Zero, (byte)Operation.GetFileSizeRecom));
+                }
+
+                if (offsets.GetFileSizeRecomJp > 0)
+                {
+                    Log.Info("Injecting {0} function", nameof(offsets.GetFileSizeRecomJp));
+                    WritePatch(stream, offsets.GetFileSizeRecomJp,
+                        JAL(WriteHook(stream, GetFileSizeRecomHookJp)),
                         ADDIU(T5, Zero, (byte)Operation.GetFileSizeRecom));
                 }
 

--- a/OpenKh.Tools.ModsManager/Services/Pcsx2Injector.cs
+++ b/OpenKh.Tools.ModsManager/Services/Pcsx2Injector.cs
@@ -20,6 +20,7 @@ namespace OpenKh.Tools.ModsManager.Services
             public int LoadFile { get; init; }
             public int GetFileSize { get; init; }
             public int LoadFileTask { get; init; }
+            public int LoadFileTaskVanilla { get; init; }
             public int LoadFileAsync { get; init; }
             public int LoadFileAsyncJp { get; init; }
 
@@ -423,6 +424,36 @@ namespace OpenKh.Tools.ModsManager.Services
             NOP(),
         };
 
+        private static readonly uint[] LoadFileTaskHookVanilla = new uint[]
+        {
+            // Input:
+            // S0 DstPtr
+            // S1 Filename
+            // T4 return program counter
+            // T5 Operation
+            // V0 IdxFilePtr
+            //
+            // Work:
+            // T6 Hook stack
+            // V0 Return value
+            // 
+            LUI(T6, HookStack),
+            SW(S1, T6, Param1), // Filename
+            SW(S0, T6, Param2), // DstPtr
+            SW(V0, T6, Param3), // LoadFileTask
+            SW(T5, T6, ParamOperator), // Operation
+            LW(T5, T6, ParamOperator),
+            BNE(T5, (byte)Operation.HookExit, -2),
+            LW(V1, T6, ParamReturn),
+            BEQ(V1, Zero, 3),
+            MOVE(S2, V0),
+            BEQ(Zero, Zero, 2),
+            ADDIU(RA, RA, 0x64), // skip the remainder of the function
+            LI(V0, -1),
+            JR(RA),
+            NOP(),
+        };
+
         private static readonly uint[] LoadFileAsyncHook = new uint[]
         {
             // Input:
@@ -562,6 +593,16 @@ namespace OpenKh.Tools.ModsManager.Services
 
         private static readonly Offsets[] _offsets = new Offsets[]
         {
+            new Offsets
+            {
+                GameName = "SLPS_251.05;1",
+                LoadFileTaskVanilla = 0x120308,
+            },
+            new Offsets
+            {
+                GameName = "SLUS_203.70;1",
+                LoadFileTaskVanilla = 0x11FEA8,
+            },
             new Offsets
             {
                 GameName = "SLPS_251.97;1",
@@ -891,6 +932,15 @@ namespace OpenKh.Tools.ModsManager.Services
                     WritePatch(stream, offsets.LoadFileTask,
                         ADDIU(T4, RA, 0),
                         JAL(WriteHook(stream, LoadFileTaskHook)),
+                        ADDIU(T5, Zero, (byte)Operation.LoadFileTask));
+                }
+
+                if (offsets.LoadFileTaskVanilla > 0)
+                {
+                    Log.Info("Injecting {0} function", nameof(offsets.LoadFileTaskVanilla));
+                    WritePatch(stream, offsets.LoadFileTaskVanilla,
+                        ADDIU(T4, RA, 0),
+                        JAL(WriteHook(stream, LoadFileTaskHookVanilla)),
                         ADDIU(T5, Zero, (byte)Operation.LoadFileTask));
                 }
 

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -140,7 +140,7 @@
                     <StackPanel Margin="10 3 0 10">
                         <TextBlock>Kingdom Hearts I (Final Mix)</TextBlock>
                         <TextBlock>Kingdom Hearts II (JP, US, EU, Final Mix)</TextBlock>
-                        <TextBlock>Kingdom Hearts Re:Chain of Memories (US)</TextBlock>
+                        <TextBlock>Kingdom Hearts Re:Chain of Memories (JP, US)</TextBlock>
                     </StackPanel>
                     <TextBlock Margin="0 0 0 3">Please select the location of the PlayStation 2 ISO Images.</TextBlock>
                     <TextBlock Margin="0 0 0 3">Kingdom Hearts 2 PlayStation 2 ISO Image.</TextBlock>

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -138,7 +138,7 @@
                 <StackPanel>
                     <TextBlock>Supported games:</TextBlock>
                     <StackPanel Margin="10 3 0 10">
-                        <TextBlock>Kingdom Hearts I (Final Mix)</TextBlock>
+                        <TextBlock>Kingdom Hearts I (JP, US, Final Mix)</TextBlock>
                         <TextBlock>Kingdom Hearts II (JP, US, EU, Final Mix)</TextBlock>
                         <TextBlock>Kingdom Hearts Re:Chain of Memories (JP, US)</TextBlock>
                     </StackPanel>


### PR DESCRIPTION
I added the necessary changes to the Mod Managers code so the PCSX2 injection feature is compatible with the original Japanese PS2 release of ReCoM.
The 2 offsets had to be shifted with +0x90 while the negative instruction parameters in the 2 hook functions with +0x42C0.
I didn't want to touch the structure of the file so for now I duplicated the 2 hook functions but I propose an offset parameter based on the USA release since that was added first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded game detection to include additional KH1 and Re:CoM product variants.
  * Extended injector support to handle JP and vanilla variants for relevant file-loading flows.

* **Bug Fixes**
  * Adjusted ISO extraction logic for Re:Chain of Memories to correct sector sizing during file extraction.

* **UI Updates**
  * Setup wizard now lists JP alongside US and Final Mix for supported game selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->