### PR TITLE
Documentation fixes

### DIFF
--- a/docs/kh1/dictionary/wpn.md
+++ b/docs/kh1/dictionary/wpn.md
@@ -1,6 +1,7 @@
 # [Kingdom Hearts](index.md) - Models (Weapons)
 
 Sora's Weapons
+
 | Filename | Weapon | 
 |----------|-----------|
 | xw_dh_5000.wpn | Dream Sword |
@@ -14,7 +15,7 @@ Sora's Weapons
 | xw_ex_5050.wpn | Pumpkinhead |
 | xw_ex_5060.wpn | Crabclaw |
 | xw_ex_5070.wpn | Divine Rose |
-| xw_ex_5080.wpn | Spellbinder|
+| xw_ex_5080.wpn | Spellbinder |
 | xw_ex_5090.wpn | Olympia |
 | xw_ex_5100.wpn | Lionheart |
 | xw_ex_5110.wpn | Metal Chocobo |
@@ -29,6 +30,7 @@ Sora's Weapons
 | xw_ex_5200.wpn | One-Winged Angel |
 
 Donald's Weapons
+
 | Filename | Weapon | 
 |----------|-----------|
 | xw_ex_5210.wpn | Mage's Staff |
@@ -49,6 +51,7 @@ Donald's Weapons
 | xw_ex_5360.wpn | Fantasista |
 
 Goofy's Weapons
+
 | Filename | Weapon | 
 |----------|-----------|
 | xw_ex_5410.wpn | Knight's Shield |
@@ -70,6 +73,7 @@ Goofy's Weapons
 | xw_ex_5570.wpn | Seven Elements |
 
 Misc. Character's Weapons
+
 | Filename | Weapon | 
 |----------|-----------|
 | xw_al_5000.wpn | Aladdin's Sword/Scimitar |

--- a/docs/kh1/index.md
+++ b/docs/kh1/index.md
@@ -8,6 +8,7 @@
 
 ## Dictionaries
 
-  * [Mdls](dictionary/mdls.md)
+  * [Character models (MDLS files)](dictionary/mdls.md)
+  * [Weapon models (WPN files)](dictionary/wpn.md)
   * [Inventory](dictionary/inventory.md)
   * [Commands](dictionary/command.md)

--- a/docs/kh1/worlds.md
+++ b/docs/kh1/worlds.md
@@ -2,27 +2,27 @@
 
 | Id | World |
 |----|-------|
-| AL | Agrabah
-| AW | Wonderland
-| DC | Disney Castle
-| DH | Dive to the Heart
-| DI | Destiny Islands
-| EW | End of the World
-| GB | Unknown
-| HE | Olympus Coliseum
-| LM | Atlantica
-| NM | Halloween Town
-| PC | Hollow Bastion
-| PI | Monstro
-| PO | 100 Acre Wood
-| PP | Neverland
-| TW | Traverse Town
-| TZ | Deep Jungle
-| ZZ | Miscellaneous
+| AL | Agrabah |
+| AW | Wonderland |
+| DC | Disney Castle |
+| DH | Dive to the Heart |
+| DI | Destiny Islands |
+| EW | End of the World |
+| GB | Unknown |
+| HE | Olympus Coliseum |
+| LM | Atlantica |
+| NM | Halloween Town |
+| PC | Hollow Bastion |
+| PI | Monstro |
+| PO | 100 Acre Wood |
+| PP | Neverland |
+| TW | Traverse Town |
+| TZ | Deep Jungle |
+| ZZ | Miscellaneous |
 
 Agrabah
 
-| Filename | Area | 
+| Filename | Area |
 |----------|-----------|
 | al00_01.bin | Desert |
 | al00_02.bin | Agrabah |
@@ -36,7 +36,7 @@ Agrabah
 
 Wonderland
 
-| Filename | Area | 
+| Filename | Area |
 |----------|-----------|
 | aw00_01.bin | Rabbit Hole |
 | aw00_02.bin | Bizzare Room |
@@ -49,7 +49,7 @@ Wonderland
 
 Disney Castle
 
-| Filename | Area | 
+| Filename | Area |
 |----------|-----------|
 | dc00_01.bin | Audience Chamber |
 | dc00_02.bin | Courtyard |
@@ -58,7 +58,7 @@ Disney Castle
 
 Dive to the Heart
 
-| Filename | Area | 
+| Filename | Area |
 |----------|-----------|
 | dh00_01.bin | Awakening |
 | dh00_02.bin | Awakening (Boss) |
@@ -66,7 +66,7 @@ Dive to the Heart
 
 Destiny Islands
 
-| Filename | Area | 
+| Filename | Area |
 |----------|-----------|
 | di00_01.bin | Seashore |
 | di00_02.bin | Cove |
@@ -79,7 +79,7 @@ Destiny Islands
 
 End of the World
 
-| Filename | Area | 
+| Filename | Area |
 |----------|-----------|
 | ew00_01.bin | Gate to the Dark |
 | ew00_02.bin | Giant Crevasse |
@@ -90,12 +90,12 @@ End of the World
 | ew00_07.bin | Deep Jungle (World Terminus) |
 | ew00_08.bin | Agrabah (World Terminus) |
 | ew00_09.bin | Atlantica (World Terminus) |
-| ew00_10.bin | Halloweentown (World Terminus) |
+| ew00_10.bin | Halloween Town (World Terminus) |
 | ew00_11.bin | Neverland (World Terminus) |
 | ew00_12.bin | 100 Acre Wood (World Terminus) |
 | ew00_13.bin | Laboratory (World Terminus) |
 | ew00_14.bin | Volcanic Crater |
-| ew00_15.bin | Homecoming (Boss)-Destroyed Islands |
+| ew00_15.bin | Homecoming (Boss) - Destroyed Islands |
 | ew00_16.bin | Seashore |
 | ew00_17.bin | Door to Darkness |
 | ew00_18.bin | The Void (Final Boss) |
@@ -103,7 +103,7 @@ End of the World
 
 Olympus Coliseum
 
-| Filename | Area | 
+| Filename | Area |
 |----------|-----------|
 | he00_01.bin | Coliseum Gates |
 | he00_02.bin | Coliseum: Arena |
@@ -113,7 +113,7 @@ Olympus Coliseum
 
 Atlantica
 
-| Filename | Area | 
+| Filename | Area |
 |----------|-----------|
 | lm00_01.bin | Undersea Valley |
 | lm00_02.bin | Undersea Gorge |
@@ -135,7 +135,7 @@ Atlantica
 
 Halloween Town
 
-| Filename | Area | 
+| Filename | Area |
 |----------|-----------|
 | nm00_01.bin | Guillotine Square |
 | nm00_02.bin | Moonlight Hill |
@@ -147,7 +147,7 @@ Halloween Town
 
 Hollow Bastion
 
-| Filename | Area | 
+| Filename | Area |
 |----------|-----------|
 | pc00_01.bin | Rising Falls |
 | pc00_02.bin | Castle Gates |
@@ -164,7 +164,7 @@ Hollow Bastion
 
 Monstro
 
-| Filename | Area | 
+| Filename | Area |
 |----------|-----------|
 | pi00_01.bin | Mouth |
 | pi00_02.bin | Mouth (Low Water) |
@@ -173,7 +173,7 @@ Monstro
 
 100 Acre Wood
 
-| Filename | Area | 
+| Filename | Area |
 |----------|-----------|
 | po00_01.bin | Pooh's House |
 | po00_02.bin | Rabbit's House |
@@ -187,7 +187,7 @@ Monstro
 
 Neverland
 
-| Filename | Area | 
+| Filename | Area |
 |----------|-----------|
 | pp00_01.bin | Ship: Hold |
 | pp00_02.bin | Pirate Ship |
@@ -196,7 +196,7 @@ Neverland
 
 Traverse Town
 
-| Filename | Area | 
+| Filename | Area |
 |----------|-----------|
 | tw00_01.bin | 1st District |
 | tw00_02.bin | 2nd District |
@@ -214,7 +214,7 @@ Traverse Town
 
 Deep Jungle
 
-| Filename | Area | 
+| Filename | Area |
 |----------|-----------|
 | tz00_01.bin | Tree House |
 | tz00_02.bin | Camp |

--- a/docs/kh1/worlds.md
+++ b/docs/kh1/worlds.md
@@ -5,13 +5,13 @@
 | AL | Agrabah
 | AW | Wonderland
 | DC | Disney Castle
-| DH | Dive to Heart
-| DI | Destiny Island
+| DH | Dive to the Heart
+| DI | Destiny Islands
 | EW | End of the World
 | GB | Unknown
 | HE | Olympus Coliseum
 | LM | Atlantica
-| NM | Halloweentown
+| NM | Halloween Town
 | PC | Hollow Bastion
 | PI | Monstro
 | PO | 100 Acre Wood
@@ -21,6 +21,7 @@
 | ZZ | Miscellaneous
 
 Agrabah
+
 | Filename | Area | 
 |----------|-----------|
 | al00_01.bin | Desert |
@@ -34,6 +35,7 @@ Agrabah
 | al00_09.bin | Cave: Escape |
 
 Wonderland
+
 | Filename | Area | 
 |----------|-----------|
 | aw00_01.bin | Rabbit Hole |
@@ -46,6 +48,7 @@ Wonderland
 | aw00_08.bin | Tiny Party Garden |
 
 Disney Castle
+
 | Filename | Area | 
 |----------|-----------|
 | dc00_01.bin | Audience Chamber |
@@ -53,14 +56,16 @@ Disney Castle
 | dc00_03.bin | Gummi Hangar |
 | dc00_04.bin | Epilogue |
 
-Dive to Heart
+Dive to the Heart
+
 | Filename | Area | 
 |----------|-----------|
 | dh00_01.bin | Awakening |
 | dh00_02.bin | Awakening (Boss) |
 | dh00_03.bin | Seashore |
 
-Destiny Island
+Destiny Islands
+
 | Filename | Area | 
 |----------|-----------|
 | di00_01.bin | Seashore |
@@ -73,6 +78,7 @@ Destiny Island
 | di00_08.bin | Secret Place (Past) |
 
 End of the World
+
 | Filename | Area | 
 |----------|-----------|
 | ew00_01.bin | Gate to the Dark |
@@ -96,6 +102,7 @@ End of the World
 | ew00_19.bin | Homecoming (Purple Dark Water) |
 
 Olympus Coliseum
+
 | Filename | Area | 
 |----------|-----------|
 | he00_01.bin | Coliseum Gates |
@@ -105,6 +112,7 @@ Olympus Coliseum
 | he00_05.bin | Coliseum: Arena (Boss)  |
 
 Atlantica
+
 | Filename | Area | 
 |----------|-----------|
 | lm00_01.bin | Undersea Valley |
@@ -125,7 +133,8 @@ Atlantica
 | lm00_16.bin | Undersea Valley (Beta) |
 | lm00_17.bin | Undersea Valley (Beta) |
 
-Halloweentown
+Halloween Town
+
 | Filename | Area | 
 |----------|-----------|
 | nm00_01.bin | Guillotine Square |
@@ -137,6 +146,7 @@ Halloweentown
 | nm00_07.bin | Research Lab |
 
 Hollow Bastion
+
 | Filename | Area | 
 |----------|-----------|
 | pc00_01.bin | Rising Falls |
@@ -153,6 +163,7 @@ Hollow Bastion
 | pc00_12.bin | Castle Chapel (Cutscene) |
 
 Monstro
+
 | Filename | Area | 
 |----------|-----------|
 | pi00_01.bin | Mouth |
@@ -161,6 +172,7 @@ Monstro
 | pi00_04.bin | Chambers |
 
 100 Acre Wood
+
 | Filename | Area | 
 |----------|-----------|
 | po00_01.bin | Pooh's House |
@@ -174,6 +186,7 @@ Monstro
 | po00_09.bin | 100 Acre Wood (Opened Book) |
 
 Neverland
+
 | Filename | Area | 
 |----------|-----------|
 | pp00_01.bin | Ship: Hold |
@@ -182,6 +195,7 @@ Neverland
 | pp00_04.bin | Clock Tower (Beta) |
 
 Traverse Town
+
 | Filename | Area | 
 |----------|-----------|
 | tw00_01.bin | 1st District |
@@ -199,6 +213,7 @@ Traverse Town
 | tw00_13.bin | 3rd District (Small House) |
 
 Deep Jungle
+
 | Filename | Area | 
 |----------|-----------|
 | tz00_01.bin | Tree House |

--- a/docs/kh2/dictionary/commands.md
+++ b/docs/kh2/dictionary/commands.md
@@ -104,14 +104,14 @@
 | 116 | Last Howl |
 | 117 | Outcry |
 | 118 | Stalwart Fang |
-| 119 | Fire |
-| 120 | Fire |
-| 121 | Blizzard |
-| 122 | Blizzard |
-| 123 | Thunder |
-| 124 | Thunder |
-| 125 | Cure |
-| 126 | Cure |
+| 119 | Fira |
+| 120 | Firaga |
+| 121 | Blizzara |
+| 122 | Blizzaga |
+| 123 | Thundara |
+| 124 | Thundaga |
+| 125 | Cura |
+| 126 | Curaga |
 | 127 | - |
 | 128 | Shooting Star |
 | 129 | Banishing Blade |
@@ -155,11 +155,11 @@
 | 172 | >ID not found< |
 | 173 | Release |
 | 174 | Magnet |
-| 175 | Magnet |
-| 176 | Magnet |
+| 175 | Magnera |
+| 176 | Magnega |
 | 177 | Reflect |
-| 178 | Reflect |
-| 179 | Reflect |
+| 178 | Reflera |
+| 179 | Reflega |
 | 180 | Riku |
 | 181 | Riku |
 | 182 | >ID not found< |
@@ -222,7 +222,7 @@
 | 241 | Go To The Tournament |
 | 242 | Mega-Potion |
 | 243 | Mega-Ether |
-| 244 | Megaelixir |
+| 244 | Megalixir |
 | 245 | Charge |
 | 246 | Go To The Tournament |
 | 247 | Approach |

--- a/docs/kh2/dictionary/icons.md
+++ b/docs/kh2/dictionary/icons.md
@@ -4,63 +4,63 @@ Icons can be seen using the ImageViewer tool on KH2/msg/*/fontimage.bar. Set "KH
 
 | ID | Icon | Description
 |------|------|------|
-| 0    | ![image](../../kh2/images/icons/item-consumable.png) | Consumable (Equippable)
-| 1    | ![image](../../kh2/images/icons/item-tent.png) | Consumable (Menu)
-| 2    | ![image](../../kh2/images/icons/item-key.png) | Document (Maps, recipes, reports, proofs, key items)
-| 3    | ![image](../../kh2/images/icons/ability-unequip.png) | Ability
-| 4    | ![image](../../kh2/images/icons/weapon-keyblade.png) | Keyblade
-| 5    | ![image](../../kh2/images/icons/weapon-staff.png) | Staff
-| 6    | ![image](../../kh2/images/icons/weapon-shield.png) | Shield
-| 7    | ![image](../../kh2/images/icons/armor.png) | Armor
-| 8    | ![image](../../kh2/images/icons/magic.png) | Magic
-| 9    | ![image](../../kh2/images/icons/material.png) | Synthesis item
-| 10   | ![image](../../kh2/images/icons/exclamation-mark.png) | Exclamation icon
-| 11   | ![image](../../kh2/images/icons/question-mark.png) | Interrogation icon
-| 12   | ![image](../../kh2/images/icons/auto-equip.png) | Consumable (Equippable, Autorefill)
-| 13   | ![image](../../kh2/images/icons/ability-equip.png) | Ability (Equipped)
-| 14   | ![image](../../kh2/images/icons/weapon-keyblade-equip.png) | Keyblade (Sparkles)
-| 15   | ![image](../../kh2/images/icons/weapon-staff-equip.png) | Staff (Sparkles)
-| 16   | ![image](../../kh2/images/icons/weapon-shield-equip.png) | Shield (Sparkles)
-| 17   | ![image](../../kh2/images/icons/accessory.png) | Accessory
-| 18   | ![image](../../kh2/images/icons/magic-nocharge.png) | Magic (Blocked)
-| 19   | ![image](../../kh2/images/icons/party.png) | Party
-| 20   | ![image](../../kh2/images/icons/button-select.png) | SELECT button
-| 21   | ![image](../../kh2/images/icons/button-start.png) | START button
-| 22   | ![image](../../kh2/images/icons/button-dpad.png) | D-Pad
-| 23   | ![image](../../kh2/images/icons/tranquil.png) | Synthesis Tranquil (Vanilla: File)
-| 24   | ![image](../../kh2/images/icons/remembrance.png) | Synthesis Remembrance (Vanilla: Ability (Equipped, blue))
-| 25   | ![image](../../kh2/images/icons/form.png) | Form
-| 26   | ![image](../../kh2/images/icons/ai-mode-frequent.png) | AI mode frequent
-| 27   | ![image](../../kh2/images/icons/ai-mode-moderate.png) | AI mode moderate
-| 28   | ![image](../../kh2/images/icons/ai-mode-rare.png) | AI mode rare
-| 29   | ![image](../../kh2/images/icons/ai-settings.png) | Summon / AI settings
-| 30   | ![image](../../kh2/images/icons/button-r1.png) | R1 button
-| 31   | ![image](../../kh2/images/icons/button-r2.png) | R2 button
-| 32   | ![image](../../kh2/images/icons/button-l1.png) | L1 button
-| 33   | ![image](../../kh2/images/icons/button-l2.png) | L2 button
-| 34   | ![image](../../kh2/images/icons/button-triangle.png) | Triangle button
-| 35   | ![image](../../kh2/images/icons/button-cross.png) | Cross button
-| 36   | ![image](../../kh2/images/icons/button-square.png) | Square button
-| 37   | ![image](../../kh2/images/icons/button-circle.png) | Circle button
-| 38   | ![image](../../kh2/images/icons/gem-dark.png) | Synthesis Dark
-| 39   | ![image](../../kh2/images/icons/gem-blazing.png) | Synthesis Blazing
-| 40   | ![image](../../kh2/images/icons/gem-frost.png) | Synthesis Frost
-| 41   | ![image](../../kh2/images/icons/gem-lightning.png) | Synthesis Lightning
-| 42   | ![image](../../kh2/images/icons/gem-power.png) | Synthesis Power
-| 43   | ![image](../../kh2/images/icons/gem-lucid.png) | Synthesis Lucid
-| 44   | ![image](../../kh2/images/icons/gem-dense.png) | Synthesis Dense
-| 45   | ![image](../../kh2/images/icons/gem-twilight.png) | Synthesis Twilight
-| 46   | ![image](../../kh2/images/icons/gem-mythril.png) | Synthesis Mythril
-| 47   | ![image](../../kh2/images/icons/gem-bright.png) | Synthesis Bright
-| 48   | ![image](../../kh2/images/icons/gem-energy.png) | Synthesis Energy
-| 49   | ![image](../../kh2/images/icons/gem-serenity.png) | Synthesis Serenity
-| 50   | ![image](../../kh2/images/icons/gem-orichalcum.png) | Synthesis Orichalcum / Illusion
-| 51   | ![image](../../kh2/images/icons/rank-s.png) | Synthesis S
-| 52   | ![image](../../kh2/images/icons/rank-a.png) | Synthesis A
-| 53   | ![image](../../kh2/images/icons/rank-b.png) | Synthesis B
-| 54   | ![image](../../kh2/images/icons/rank-c.png) | Synthesis C
-| 55   | ![image](../../kh2/images/icons/gumi-brush.png) | Gummi paint
-| 56   | ![image](../../kh2/images/icons/gumi-blueprint.png) | Gummi ability
-| 57   | ![image](../../kh2/images/icons/gumi-ship.png) | Gummi ship
-| 58   | ![image](../../kh2/images/icons/gumi-block.png) | Gummi block
-| 59   | ![image](../../kh2/images/icons/gumi-gear.png) | Gummi upgrade
+| 0    | ![image](../../kh2/images/icons/misc/item-consumable.png) | Consumable (Equippable)
+| 1    | ![image](../../kh2/images/icons/misc/item-tent.png) | Consumable (Menu)
+| 2    | ![image](../../kh2/images/icons/misc/item-key.png) | Document (Maps, recipes, reports, proofs, key items)
+| 3    | ![image](../../kh2/images/icons/misc/ability-unequip.png) | Ability
+| 4    | ![image](../../kh2/images/icons/misc/weapon-keyblade.png) | Keyblade
+| 5    | ![image](../../kh2/images/icons/misc/weapon-staff.png) | Staff
+| 6    | ![image](../../kh2/images/icons/misc/weapon-shield.png) | Shield
+| 7    | ![image](../../kh2/images/icons/misc/armor.png) | Armor
+| 8    | ![image](../../kh2/images/icons/misc/magic.png) | Magic
+| 9    | ![image](../../kh2/images/icons/misc/material.png) | Synthesis item
+| 10   | ![image](../../kh2/images/icons/misc/exclamation-mark.png) | Exclamation icon
+| 11   | ![image](../../kh2/images/icons/misc/question-mark.png) | Interrogation icon
+| 12   | ![image](../../kh2/images/icons/misc/auto-equip.png) | Consumable (Equippable, Autorefill)
+| 13   | ![image](../../kh2/images/icons/misc/ability-equip.png) | Ability (Equipped)
+| 14   | ![image](../../kh2/images/icons/misc/weapon-keyblade-equip.png) | Keyblade (Sparkles)
+| 15   | ![image](../../kh2/images/icons/misc/weapon-staff-equip.png) | Staff (Sparkles)
+| 16   | ![image](../../kh2/images/icons/misc/weapon-shield-equip.png) | Shield (Sparkles)
+| 17   | ![image](../../kh2/images/icons/misc/accessory.png) | Accessory
+| 18   | ![image](../../kh2/images/icons/misc/magic-nocharge.png) | Magic (Blocked)
+| 19   | ![image](../../kh2/images/icons/misc/party.png) | Party
+| 20   | ![image](../../kh2/images/icons/original/button-select.png) | SELECT button
+| 21   | ![image](../../kh2/images/icons/original/button-start.png) | START button
+| 22   | ![image](../../kh2/images/icons/original/button-dpad.png) | D-Pad
+| 23   | ![image](../../kh2/images/icons/misc/tranquil.png) | Synthesis Tranquil (Vanilla: File)
+| 24   | ![image](../../kh2/images/icons/misc/remembrance.png) | Synthesis Remembrance (Vanilla: Ability (Equipped, blue))
+| 25   | ![image](../../kh2/images/icons/misc/form.png) | Form
+| 26   | ![image](../../kh2/images/icons/misc/ai-mode-frequent.png) | AI mode frequent
+| 27   | ![image](../../kh2/images/icons/misc/ai-mode-moderate.png) | AI mode moderate
+| 28   | ![image](../../kh2/images/icons/misc/ai-mode-rare.png) | AI mode rare
+| 29   | ![image](../../kh2/images/icons/misc/ai-settings.png) | Summon / AI settings
+| 30   | ![image](../../kh2/images/icons/original/button-r1.png) | R1 button
+| 31   | ![image](../../kh2/images/icons/original/button-r2.png) | R2 button
+| 32   | ![image](../../kh2/images/icons/original/button-l1.png) | L1 button
+| 33   | ![image](../../kh2/images/icons/original/button-l2.png) | L2 button
+| 34   | ![image](../../kh2/images/icons/original/button-triangle.png) | Triangle button
+| 35   | ![image](../../kh2/images/icons/original/button-cross.png) | Cross button
+| 36   | ![image](../../kh2/images/icons/original/button-square.png) | Square button
+| 37   | ![image](../../kh2/images/icons/original/button-circle.png) | Circle button
+| 38   | ![image](../../kh2/images/icons/misc/gem-dark.png) | Synthesis Dark
+| 39   | ![image](../../kh2/images/icons/misc/gem-blazing.png) | Synthesis Blazing
+| 40   | ![image](../../kh2/images/icons/misc/gem-frost.png) | Synthesis Frost
+| 41   | ![image](../../kh2/images/icons/misc/gem-lightning.png) | Synthesis Lightning
+| 42   | ![image](../../kh2/images/icons/misc/gem-power.png) | Synthesis Power
+| 43   | ![image](../../kh2/images/icons/misc/gem-lucid.png) | Synthesis Lucid
+| 44   | ![image](../../kh2/images/icons/misc/gem-dense.png) | Synthesis Dense
+| 45   | ![image](../../kh2/images/icons/misc/gem-twilight.png) | Synthesis Twilight
+| 46   | ![image](../../kh2/images/icons/misc/gem-mythril.png) | Synthesis Mythril
+| 47   | ![image](../../kh2/images/icons/misc/gem-bright.png) | Synthesis Bright
+| 48   | ![image](../../kh2/images/icons/misc/gem-energy.png) | Synthesis Energy
+| 49   | ![image](../../kh2/images/icons/misc/gem-serenity.png) | Synthesis Serenity
+| 50   | ![image](../../kh2/images/icons/misc/gem-orichalcum.png) | Synthesis Orichalcum / Illusion
+| 51   | ![image](../../kh2/images/icons/misc/rank-s.png) | Synthesis S
+| 52   | ![image](../../kh2/images/icons/misc/rank-a.png) | Synthesis A
+| 53   | ![image](../../kh2/images/icons/misc/rank-b.png) | Synthesis B
+| 54   | ![image](../../kh2/images/icons/misc/rank-c.png) | Synthesis C
+| 55   | ![image](../../kh2/images/icons/misc/gumi-brush.png) | Gummi paint
+| 56   | ![image](../../kh2/images/icons/misc/gumi-blueprint.png) | Gummi ability
+| 57   | ![image](../../kh2/images/icons/misc/gumi-ship.png) | Gummi ship
+| 58   | ![image](../../kh2/images/icons/misc/gumi-block.png) | Gummi block
+| 59   | ![image](../../kh2/images/icons/misc/gumi-gear.png) | Gummi upgrade

--- a/docs/kh2/dictionary/inventory.md
+++ b/docs/kh2/dictionary/inventory.md
@@ -31,7 +31,7 @@
 | 27 | Wisdom Form |
 | 28 | Orichalcum Ring |
 | 29 | Final Form |
-| 30 | Anti-Form |
+| 30 | Antiform |
 | 31 | Master Form |
 | 32 | Torn Pages |
 | 34 | Master's Ring |
@@ -54,7 +54,7 @@
 | 52 | Cosmic Ring |
 | 53 | Medal |
 | 54 | Battlefields of War |
-| 55 | Sword of Ancestors |
+| 55 | Sword of the Ancestor |
 | 56 | Cosmic Arts |
 | 57 | Shadow Archive |
 | 58 | Shadow Archive+ |
@@ -70,15 +70,15 @@
 | 68 | Divine Bandanna |
 | 69 | Power Band |
 | 70 | Buster Band |
-| 71 | Anti-Form Dummy |
+| 71 | Antiform Dummy |
 | 72 | Scimitar |
-| 73 | Way of Dawn |
+| 73 | Way to the Dawn |
 | 74 | Identity Disk |
 | 75 | Mage's Staff |
 | 78 | Protect Belt |
 | 79 | Gaia Belt |
-| 80 | FAKE (looks like Sword of the Ancestors) |
-| 81 | FAKE (Keyblade,looks like Kingdom Key) |
+| 80 | FAKE (looks like Sword of the Ancestor) |
+| 81 | FAKE (Keyblade, looks like Kingdom Key) |
 | 82 | Guard |
 | 87 | Magnet Element |
 | 88 | Reflect Element |
@@ -505,10 +505,10 @@
 | 566 | Dodge Roll LV3 |
 | 567 | Dodge Roll MAX |
 | 568 | Auto Limit |
-| 569 | Sonic Rave |
-| 570 | Last Arcanum |
+| 569 | Sonic Blade |
+| 570 | Ars Arcanum |
 | 571 | Strike Raid |
-| 572 | Infinity |
+| 572 | Ragnarok |
 | 573 | Zantetsuken |
 | 574 | Ripple Drive |
 | 575 | Hurricane Period |

--- a/docs/kh2/unused.md
+++ b/docs/kh2/unused.md
@@ -3,6 +3,7 @@
 Unused Assets Are Sorted by [File Types](file-type.md)
 
 ## Models
+
 | File Name          | Description | Image(s) |
 |--------------------|-------------|----------|
 | B_EX340.mdlx       | Unused model of the head of Xemnas's Dragon's Head | ![image](./images/unused/unused_models/B_EX340.PNG) |


### PR DESCRIPTION
I fixed the broken tables for the KH1 and KH2 docs of the website. I also fixed numerous typos in the various files too.
I added the wpn dictionary to the KH1 index.
I fixed the broken image links for docs/kh2/icons.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spell and item names in game dictionaries for accuracy
  * Fixed world naming inconsistencies (e.g., "Destiny Islands", "Halloween Town", "Dive to the Heart")

* **Documentation**
  * Enhanced navigation with clearer and more descriptive category labels
  * Improved table formatting consistency across game guides
  * Updated asset reference paths in documentation files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->