### PR TITLE
Update CodeQL workflow to use MSBuild (and also fix fix CS1579 and CS0023 errors)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,8 +64,22 @@ jobs:
         
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+    #- name: Autobuild
+    #  uses: github/codeql-action/autobuild@v3
+
+    # Note that direct use of `github/codeql-action/autobuild@v3` is not recommended. Try to use `dotnet build` or `msbuild` instead.
+
+    - name: Setup NuGet
+      uses: NuGet/setup-nuget@v2
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Restore NuGet packages
+      run: nuget restore OpenKh.sln
+
+    - name: Build solution (MSBuild)
+      run: msbuild OpenKh.sln /m /t:Build /p:Configuration=Release /p:Platform="Any CPU"
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/OpenKh.Command.IdxImg/EpicGamesAssets.cs
+++ b/OpenKh.Command.IdxImg/EpicGamesAssets.cs
@@ -138,7 +138,7 @@ namespace OpenKh.Command.IdxImg
 
                     var map = new ConcurrentDictionary<string, string>();
                     var patcher = new PatcherProcessor();
-                    foreach (var mod_name in enabled.Reverse())
+                    foreach (var mod_name in enabled.AsEnumerable().Reverse())
                     {
                         var mod_folder = Path.Combine(ModsFolder, mod_name);
                         var metadata = File.OpenRead(Path.Combine(mod_folder, "mod.yml")).Using(Metadata.Read);

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Usecases/SearchForKh2AssetFileUsecase.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Usecases/SearchForKh2AssetFileUsecase.cs
@@ -73,6 +73,7 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.Usecases
                             string.Join(
                                 Path.DirectorySeparatorChar,
                                 SplitToPathNodes(Path.GetDirectoryName(loadFrom)!)
+                                    .AsEnumerable()
                                     .Reverse()
                                     .Skip(numRelativeDepth - 1)
                                     .Reverse()


### PR DESCRIPTION
Commented out the Autobuild step and added instructions for using MSBuild instead.

Fix CodeQL Autobuild error:

> Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

And also fix CS1579 and CS0023 errors:

```
         D:\a\OpenKh\OpenKh\OpenKh.Command.IdxImg\EpicGamesAssets.cs(141,46): error CS1579: foreach statement cannot operate on variables of type 'void' because 'void' does not contain a public instance or extension definition for 'GetEnumerator' [D:\a\OpenKh\OpenKh\OpenKh.Command.IdxImg\OpenKh.Command.IdxImg.csproj]

         D:\a\OpenKh\OpenKh\OpenKh.Tools.Kh2MsetMotionEditor\Usecases\SearchForKh2AssetFileUsecase.cs(77,37): error CS0023: Operator '.' cannot be applied to operand of type 'void' [D:\a\OpenKh\OpenKh\OpenKh.Tools.Kh2MsetMotionEditor\OpenKh.Tools.Kh2MsetMotionEditor.csproj]
```
