### PR TITLE
[ModsManager] Make it possible to fetch mods from any Git platform of choice.

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/ModsService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ModsService.cs
@@ -121,11 +121,12 @@ namespace OpenKh.Tools.ModsManager.Services
             bool isLuaFile,
             Action<string> progressOutput = null,
             Action<float> progressNumber = null,
+            string platformUrl = null,
             string branchName = null)
         {
             if (!isZipFile && !isLuaFile)
             {
-                return Task.Run(() => InstallModFromGithub(name, progressOutput, progressNumber, branchName));
+                return Task.Run(() => InstallModFromGit(name, progressOutput, progressNumber, platformUrl, branchName));
             }
             else if (isZipFile && !isLuaFile)
             {
@@ -277,10 +278,11 @@ namespace OpenKh.Tools.ModsManager.Services
             }
         }
 
-        public static async Task InstallModFromGithub(
+        public static async Task InstallModFromGit(
             string repositoryName,
             Action<string> progressOutput = null,
             Action<float> progressNumber = null,
+            string platformName = null,
             string branchName = null)
         {
             var parts = repositoryName.Split('/');
@@ -294,7 +296,7 @@ namespace OpenKh.Tools.ModsManager.Services
             if (!string.IsNullOrWhiteSpace(branchName))
             {
                 progressOutput?.Invoke($"Fetching file {ModMetadata} from branch {branchName}");
-                var isValidMod = await RepositoryService.IsFileExists(repositoryName, branchName, ModMetadata);
+                var isValidMod = await RepositoryService.IsFileExists(repositoryName, branchName, ModMetadata, platformName);
                 if (!isValidMod)
                     throw new BranchNotValidException(repositoryName, branchName);
             }
@@ -302,7 +304,7 @@ namespace OpenKh.Tools.ModsManager.Services
             {
                 branchName = DefaultGitBranch;
                 progressOutput?.Invoke($"Fetching file {ModMetadata} from {branchName}");
-                var isValidMod = await RepositoryService.IsFileExists(repositoryName, branchName, ModMetadata);
+                var isValidMod = await RepositoryService.IsFileExists(repositoryName, branchName, ModMetadata, platformName);
                 if (!isValidMod)
                 {
                     progressOutput?.Invoke($"{ModMetadata} not found, fetching default branch name");
@@ -311,7 +313,7 @@ namespace OpenKh.Tools.ModsManager.Services
                         throw new RepositoryNotFoundException(repositoryName);
 
                     progressOutput?.Invoke($"Fetching file {ModMetadata} from {branchName}");
-                    isValidMod = await RepositoryService.IsFileExists(repositoryName, branchName, ModMetadata);
+                    isValidMod = await RepositoryService.IsFileExists(repositoryName, branchName, ModMetadata, platformName);
                 }
 
                 if (!isValidMod)
@@ -363,7 +365,16 @@ namespace OpenKh.Tools.ModsManager.Services
                     return true;
                 };
 
-                Repository.Clone($"https://github.com/{repositoryName}", modPath, options);
+                var _fetchPlatformUrl = new Uri("https://github.com/");
+                var _fetchRelativeUri = new Uri(_fetchPlatformUrl, $"{repositoryName}");
+
+                if (!String.IsNullOrWhiteSpace(platformName))
+                {
+                    _fetchPlatformUrl = new Uri(platformName.Contains("http") ? platformName : "https://" + platformName);
+                    _fetchRelativeUri = new Uri(_fetchPlatformUrl, $"{repositoryName}");
+                }
+
+                Repository.Clone(_fetchRelativeUri.ToString(), modPath, options);
             });
             if (IsCollection(repositoryName))
                 await MoveToCollection(repositoryName);

--- a/OpenKh.Tools.ModsManager/Services/RepositoryService.cs
+++ b/OpenKh.Tools.ModsManager/Services/RepositoryService.cs
@@ -1,6 +1,8 @@
 using LibGit2Sharp;
 using Newtonsoft.Json;
 using System;
+using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -38,8 +40,52 @@ namespace OpenKh.Tools.ModsManager.Services
             return JsonConvert.DeserializeObject<ReposResponse>(await response.Content.ReadAsStringAsync())?.DefaultBranch;
         }
 
-        public static Task<bool> IsFileExists(string repoName, string branch, string filePath) =>
-            IsFileExists($"https://raw.githubusercontent.com/{repoName}/{branch}/{filePath}");
+        public static Task<bool> IsFileExists(string repoName, string branch, string filePath, string platformUrl = null)
+        {
+            if (!string.IsNullOrEmpty(platformUrl))
+            {
+                var _fetchBaseUri = new Uri(platformUrl.Contains("http") ? platformUrl : "https://" + platformUrl);
+                var _fetchRelativeUri = new Uri(_fetchBaseUri, $"{repoName}");
+
+                var _fetchRepoDirectory = $"gitfetch/{repoName}/{branch}";
+
+                var _cloneOptions = new CloneOptions
+                {
+                    Checkout = false,
+                    IsBare = true,
+                    BranchName = branch
+                };
+
+                _cloneOptions.FetchOptions.Prune = true;
+
+                Repository.Clone(_fetchRelativeUri.ToString(), _fetchRepoDirectory, _cloneOptions);
+                var _fetchRepository = new Repository(_fetchRepoDirectory);
+
+                var _fetchCommit = _fetchRepository.Head.Tip;
+                var _doesModFileExist = _fetchCommit["mod.yml"] != null;
+
+                _fetchRepository.Dispose();
+
+                if (Directory.Exists(_fetchRepoDirectory))
+                {
+                    var _fetchAllFiles = Directory.GetFiles(_fetchRepoDirectory, "*", SearchOption.AllDirectories);
+                    var _fetchAllDirectories = Directory.GetDirectories(_fetchRepoDirectory, "*", SearchOption.AllDirectories);
+
+                    foreach (var _fetchFile in _fetchAllFiles)
+                        File.SetAttributes(_fetchFile, FileAttributes.Normal);
+
+                    foreach (string _fetchDirectory in _fetchAllDirectories)
+                        File.SetAttributes(_fetchDirectory, FileAttributes.Normal);
+
+                    Directory.Delete(_fetchRepoDirectory, true);
+                }
+
+                return Task.FromResult(_doesModFileExist);
+            }
+
+            else
+                return IsFileExists($"https://raw.githubusercontent.com/{repoName}/{branch}/{filePath}");
+        }
 
         public static async Task<bool> IsFileExists(string url)
         {

--- a/OpenKh.Tools.ModsManager/ViewModels/DownloadableModViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/DownloadableModViewModel.cs
@@ -71,7 +71,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 });
 
                 // Install mod with progress updates
-                await Task.Run(() => ModsService.InstallModFromGithub(Repo,
+                await Task.Run(() => ModsService.InstallModFromGit(Repo,
                     progress => {
                         Application.Current.Dispatcher.Invoke(() => progressWindow.ProgressText = progress);
                     },

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -494,6 +494,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         var name = view.RepositoryName;
                         var isZipFile = view.IsZipFile;
                         var isLuaFile = view.IsLuaFile;
+                        var platformUrl = view.PlatformURL;
                         var branchName = view.BranchName;
                         progressWindow = Application.Current.Dispatcher.Invoke(() =>
                         {
@@ -512,7 +513,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         }, nProgress =>
                         {
                             Application.Current.Dispatcher.Invoke(() => progressWindow.ProgressValue = nProgress);
-                        }, branchName);
+                        }, platformUrl, branchName);
                         var repoName = name;
                         if (!isZipFile && !isLuaFile)
                         {

--- a/OpenKh.Tools.ModsManager/ViewModels/ModViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/ModViewModel.cs
@@ -1,3 +1,4 @@
+using LibGit2Sharp;
 using OpenKh.Common;
 using OpenKh.Tools.ModsManager.Models;
 using OpenKh.Tools.ModsManager.Services;
@@ -7,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Security.Policy;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media;
@@ -41,6 +43,14 @@ namespace OpenKh.Tools.ModsManager.ViewModels
             {
                 Author = Source[0..nameIndex];
                 Name = Source[(nameIndex + 1)..];
+
+                var _fetchRepository = new Repository(_model.Path);
+                var _fetchRemoteUrl = _fetchRepository.Network.Remotes.ElementAt(0).Url.TrimEnd('/');
+
+                SourceUrl = _fetchRemoteUrl;
+                ReportBugUrl = _fetchRemoteUrl += "/issues";
+
+                AuthorUrl = _fetchRemoteUrl.Substring(0, _fetchRemoteUrl.LastIndexOf('/') + 1);
             }
             else
             {
@@ -175,9 +185,9 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         public string Name { get; }
         public string Author { get; }
         public string Source => _model.Name;
-        public string AuthorUrl => $"https://github.com/{Author}";
-        public string SourceUrl => $"https://github.com/{Source}";
-        public string ReportBugUrl => $"https://github.com/{Source}/issues";
+        public string AuthorUrl { get; set; }
+        public string SourceUrl { get; set; }
+        public string ReportBugUrl { get; set; }
         public string FilesToPatch
         {
             get

--- a/OpenKh.Tools.ModsManager/ViewModels/ModViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/ModViewModel.cs
@@ -48,7 +48,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 var _fetchRemoteUrl = _fetchRepository.Network.Remotes.ElementAt(0).Url.TrimEnd('/');
 
                 SourceUrl = _fetchRemoteUrl;
-                ReportBugUrl = _fetchRemoteUrl += "/issues";
+                ReportBugUrl = _fetchRemoteUrl + "/issues";
 
                 AuthorUrl = _fetchRemoteUrl.Substring(0, _fetchRemoteUrl.LastIndexOf('/') + 1);
             }

--- a/OpenKh.Tools.ModsManager/Views/InstallModView.xaml
+++ b/OpenKh.Tools.ModsManager/Views/InstallModView.xaml
@@ -9,7 +9,7 @@
         WindowStartupLocation="CenterScreen"
         ResizeMode="NoResize"
          FocusManager.FocusedElement="{Binding ElementName=txtSourceModUrl}"
-        Title="Install a new mod or Lua Script..." Height="160" Width="300" SizeToContent="Height" Background="{Binding ColorTheme.BackgroundColor}" Foreground="{Binding ColorTheme.TextColor}">
+        Title="Install a new mod or Lua Script..." Height="238" Width="300" SizeToContent="Height" Background="{Binding ColorTheme.BackgroundColor}" Foreground="{Binding ColorTheme.TextColor}">
     <Window.InputBindings>
         <KeyBinding Key="Esc" Command="{Binding CloseCommand}"/>
     </Window.InputBindings>
@@ -30,11 +30,26 @@
                 <TextBox Name="txtSourceModUrl" Background="Transparent" Text="{Binding RepositoryName, UpdateSourceTrigger=PropertyChanged}" KeyUp="txtSourceModUrl_KeyUp" />
             </Grid>
 
+            <TextBlock Margin="0 0 0 3">Hosted Platform (optional)</TextBlock>
+            <Grid Margin="0 0 0 5" Background="White">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="211*"/>
+                    <ColumnDefinition Width="70*"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Margin="5,1,5,1" MinWidth="50" Text="eg. https://github.com/"
+                   Foreground="Gray" Visibility="{Binding ElementName=txtPlatformUrl, Path=Text.IsEmpty, Converter={StaticResource BooleanToVisibilityConverter}}" IsHitTestVisible="False" Grid.ColumnSpan="2"/>
+                <TextBox Name="txtPlatformUrl" Background="Transparent" Text="{Binding PlatformURL, UpdateSourceTrigger=PropertyChanged}" KeyUp="txtSourceModUrl_KeyUp" Grid.ColumnSpan="2" />
+            </Grid>
+
             <TextBlock Margin="0 0 0 3">Branch (optional)</TextBlock>
             <Grid Margin="0 0 0 5" Background="White">
-                <TextBlock Margin="5,1" MinWidth="50" Text="eg. main"
-                   Foreground="Gray" Visibility="{Binding ElementName=txtBranchName, Path=Text.IsEmpty, Converter={StaticResource BooleanToVisibilityConverter}}" IsHitTestVisible="False"/>
-                <TextBox Name="txtBranchName" Background="Transparent" Text="{Binding BranchName, UpdateSourceTrigger=PropertyChanged}" KeyUp="txtSourceModUrl_KeyUp" />
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="211*"/>
+                    <ColumnDefinition Width="70*"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Margin="5,1,5,1" MinWidth="50" Text="eg. main"
+                   Foreground="Gray" Visibility="{Binding ElementName=txtBranchName, Path=Text.IsEmpty, Converter={StaticResource BooleanToVisibilityConverter}}" IsHitTestVisible="False" Grid.ColumnSpan="2"/>
+                <TextBox Name="txtBranchName" Background="Transparent" Text="{Binding BranchName, UpdateSourceTrigger=PropertyChanged}" KeyUp="txtSourceModUrl_KeyUp" Grid.ColumnSpan="2" />
             </Grid>
 
             <TextBlock Margin="0 0 0 3">Install a Mod Archive or Lua Script</TextBlock>

--- a/OpenKh.Tools.ModsManager/Views/InstallModView.xaml
+++ b/OpenKh.Tools.ModsManager/Views/InstallModView.xaml
@@ -9,7 +9,7 @@
         WindowStartupLocation="CenterScreen"
         ResizeMode="NoResize"
          FocusManager.FocusedElement="{Binding ElementName=txtSourceModUrl}"
-        Title="Install a new mod or Lua Script..." Height="238" Width="300" SizeToContent="Height" Background="{Binding ColorTheme.BackgroundColor}" Foreground="{Binding ColorTheme.TextColor}">
+        Title="Install a new mod or Lua Script..." Height="183" Width="300" SizeToContent="Height" Background="{Binding ColorTheme.BackgroundColor}" Foreground="{Binding ColorTheme.TextColor}">
     <Window.InputBindings>
         <KeyBinding Key="Esc" Command="{Binding CloseCommand}"/>
     </Window.InputBindings>
@@ -29,31 +29,35 @@
                    Foreground="Gray" Visibility="{Binding ElementName=txtSourceModUrl, Path=Text.IsEmpty, Converter={StaticResource BooleanToVisibilityConverter}}" IsHitTestVisible="False"/>
                 <TextBox Name="txtSourceModUrl" Background="Transparent" Text="{Binding RepositoryName, UpdateSourceTrigger=PropertyChanged}" KeyUp="txtSourceModUrl_KeyUp" />
             </Grid>
-
-            <TextBlock Margin="0 0 0 3">Hosted Platform (optional)</TextBlock>
-            <Grid Margin="0 0 0 5" Background="White">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="211*"/>
-                    <ColumnDefinition Width="70*"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock Margin="5,1,5,1" MinWidth="50" Text="eg. https://github.com/"
-                   Foreground="Gray" Visibility="{Binding ElementName=txtPlatformUrl, Path=Text.IsEmpty, Converter={StaticResource BooleanToVisibilityConverter}}" IsHitTestVisible="False" Grid.ColumnSpan="2"/>
-                <TextBox Name="txtPlatformUrl" Background="Transparent" Text="{Binding PlatformURL, UpdateSourceTrigger=PropertyChanged}" KeyUp="txtSourceModUrl_KeyUp" Grid.ColumnSpan="2" />
-            </Grid>
-
-            <TextBlock Margin="0 0 0 3">Branch (optional)</TextBlock>
-            <Grid Margin="0 0 0 5" Background="White">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="211*"/>
-                    <ColumnDefinition Width="70*"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock Margin="5,1,5,1" MinWidth="50" Text="eg. main"
-                   Foreground="Gray" Visibility="{Binding ElementName=txtBranchName, Path=Text.IsEmpty, Converter={StaticResource BooleanToVisibilityConverter}}" IsHitTestVisible="False" Grid.ColumnSpan="2"/>
-                <TextBox Name="txtBranchName" Background="Transparent" Text="{Binding BranchName, UpdateSourceTrigger=PropertyChanged}" KeyUp="txtSourceModUrl_KeyUp" Grid.ColumnSpan="2" />
-            </Grid>
-
+            
             <TextBlock Margin="0 0 0 3">Install a Mod Archive or Lua Script</TextBlock>
             <Button Margin="0 0 0 5" Click="InstallLocalFile_Click">Select and install Mod Archive or Lua Script</Button>
+           
+            <Expander Header="More Options" Foreground="{Binding ColorTheme.TextColor}">
+                <StackPanel>
+                    <TextBlock Margin="0 0 0 3">Hosted Platform (optional)</TextBlock>
+                    <Grid Margin="0 0 0 5" Background="White">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="211*"/>
+                            <ColumnDefinition Width="70*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Margin="5,1,5,1" MinWidth="50" Text="eg. https://github.com/"
+                   Foreground="Gray" Visibility="{Binding ElementName=txtPlatformUrl, Path=Text.IsEmpty, Converter={StaticResource BooleanToVisibilityConverter}}" IsHitTestVisible="False" Grid.ColumnSpan="2"/>
+                        <TextBox Name="txtPlatformUrl" Background="Transparent" Text="{Binding PlatformURL, UpdateSourceTrigger=PropertyChanged}" KeyUp="txtSourceModUrl_KeyUp" Grid.ColumnSpan="2" />
+                    </Grid>
+
+                    <TextBlock Margin="0 0 0 3">Branch (optional)</TextBlock>
+                    <Grid Margin="0 0 0 5" Background="White">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="211*"/>
+                            <ColumnDefinition Width="70*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Margin="5,1,5,1" MinWidth="50" Text="eg. main"
+                   Foreground="Gray" Visibility="{Binding ElementName=txtBranchName, Path=Text.IsEmpty, Converter={StaticResource BooleanToVisibilityConverter}}" IsHitTestVisible="False" Grid.ColumnSpan="2"/>
+                        <TextBox Name="txtBranchName" Background="Transparent" Text="{Binding BranchName, UpdateSourceTrigger=PropertyChanged}" KeyUp="txtSourceModUrl_KeyUp" Grid.ColumnSpan="2" />
+                    </Grid>
+                </StackPanel>
+            </Expander>
         </StackPanel>
 
         <Grid Grid.Row="2">

--- a/OpenKh.Tools.ModsManager/Views/InstallModView.xaml.cs
+++ b/OpenKh.Tools.ModsManager/Views/InstallModView.xaml.cs
@@ -18,6 +18,7 @@ namespace OpenKh.Tools.ModsManager.Views
 
         public RelayCommand CloseCommand { get; }
         public string RepositoryName { get; set; }
+        public string PlatformURL { get; set; }
         public string BranchName { get; set; }
         public bool IsZipFile { get; private set; }
         public bool IsLuaFile { get; private set; } = false;


### PR DESCRIPTION
Exactly what it says on the tin. This makes it possible for the ModsManager to fetch and download mods from other Git vendors, breaking its sole reliability on GitHub.

## Why?
Why not! I won't be using GitHub much longer due to... issues, and I believe more and more people will choose not to also. So I believe this is a legit requirement in the ModsManager.

## Differences in Performance
Fetching the "mod.yml" file to check if the mod is valid takes longer on non-GitHub platforms due to having to use LibGit2Sharp's methods to fetch the file instead of relying on REST API calls. This is necessary because literally every Git platform does it's job differently. Other than that, non-GitHub platforms seem to fetch the mods **faster** (KH-ReFined/KH2-MAIN cloned from Codeberg in 10 seconds (exc. mod fetch). Same mod cloned from GitHub in 7 minutes and 35 seconds.)

## Screenshots
<img width="660" height="458" alt="image" src="https://github.com/user-attachments/assets/04fdbf6c-cf2d-40b6-be43-28737a6599e1" />
<img width="656" height="453" alt="image" src="https://github.com/user-attachments/assets/4c90806d-4045-467d-b52b-e731356aa393" />
<img width="655" height="451" alt="image" src="https://github.com/user-attachments/assets/561a9cbd-512e-4610-b4cd-782ba882615f" />
<img width="1261" height="887" alt="image" src="https://github.com/user-attachments/assets/ee61b084-2978-41c2-a76d-fb8da48c8a1e" />

## Testing
All the necessary testing was done on my end and I cannot see any issues with non-GitHub platforms nor any regression with GitHub. However, y'all are free to test and report issues to me as time goes.
