### PR TITLE
Fix ModCollectionPath folder nesting

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -273,7 +273,7 @@ namespace OpenKh.Tools.ModsManager.Services
 
         public static string GameModPath
         {
-            get => Path.Combine(_config.ModCollectionPath ?? Path.GetFullPath(StoragePath), "mod", LaunchGame);
+            get => Path.Combine(_config.GameModPath ?? Path.GetFullPath(Path.Combine(StoragePath, "mod")), LaunchGame);
             set
             {
                 _config.GameModPath = value;

--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -253,7 +253,7 @@ namespace OpenKh.Tools.ModsManager.Services
 
         public static string ModsGamePath
         {
-            get => Path.Combine(_config.ModCollectionPath ?? Path.GetFullPath(StoragePath), "mods", LaunchGame);
+            get => Path.Combine(_config.ModCollectionPath ?? Path.GetFullPath(Path.Combine(StoragePath, "mods")), LaunchGame);
             set
             {
                 _config.ModCollectionPath = value;


### PR DESCRIPTION
By default, the tool looks for mods in `<root>/mods`.

You can change the `modCollectionPath` option in `mods-manager.yml` to make it look somewhere else instead. However, currently this makes it look in `<path>/mods`, instead of just `<path>`.

This PR fixes this without affecting the default `<root>/mods` location.