### PR TITLE
Rename some configurationservicevariables.

### DIFF
--- a/OpenKh.Tests.ModsManager/ModsServiceTest.cs
+++ b/OpenKh.Tests.ModsManager/ModsServiceTest.cs
@@ -18,7 +18,7 @@ namespace OpenKh.Tests.ModsManager
         {
             try
             {
-                DeleteDir(Path.Combine(ConfigurationService.ModsGamePath, "test"));
+                DeleteDir(Path.Combine(ConfigurationService.InstalledModsPath, "test"));
             }
             catch (Exception e)
             {
@@ -26,7 +26,7 @@ namespace OpenKh.Tests.ModsManager
             }
             try
             {
-                DeleteDir(Path.Combine(ConfigurationService.ModCollectionsPath, "test"));
+                DeleteDir(Path.Combine(ConfigurationService.InstalledCollectionsPath, "test"));
             }
             catch (Exception e)
             {
@@ -45,7 +45,7 @@ namespace OpenKh.Tests.ModsManager
 
         private void AddMod()
         {
-            var modDir = ConfigurationService.ModsGamePath;
+            var modDir = ConfigurationService.InstalledModsPath;
             Directory.CreateDirectory(Path.Combine(modDir, "test/test"));
             using (File.Create(Path.Combine(modDir, "test/test/mod.yml"))) { }
         }
@@ -57,7 +57,7 @@ namespace OpenKh.Tests.ModsManager
 
         private void AddCollectionMod()
         {
-            var modDir = ConfigurationService.ModCollectionsPath;
+            var modDir = ConfigurationService.InstalledCollectionsPath;
             Directory.CreateDirectory(Path.Combine(modDir, "test/test"));
             using (File.Create(Path.Combine(modDir, "test/test/mod.yml")))
             { }

--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -11,6 +11,29 @@ namespace OpenKh.Tools.ModsManager.Services
 {
     public static class ConfigurationService
     {
+        private class LegacyConfigMigration
+        {
+            private static readonly IDeserializer _legacyvaluedeserializer =
+                new DeserializerBuilder()
+                .IgnoreFields()
+                .IgnoreUnmatchedProperties()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .Build();
+            public string ModCollectionPath { get; internal set; }
+            public string ModCollectionsPath { get; internal set; }
+            public string GameModPath { get; internal set; }
+            public string GameDataPath { get; internal set; }
+
+            public static LegacyConfigMigration Open(string fileName)
+            {
+                if (!File.Exists(fileName))
+                    return new LegacyConfigMigration();
+
+                using var reader = new StreamReader(fileName);
+                return _legacyvaluedeserializer.Deserialize<LegacyConfigMigration>(reader);
+            }
+        }
+
         private class Config
         {
             private static readonly IDeserializer _deserializer =
@@ -86,6 +109,7 @@ namespace OpenKh.Tools.ModsManager.Services
         private static string EnabledCollectionModsPathBBS = Path.Combine(StoragePath, "collection-mods-BBS.json");
         private static string EnabledCollectionModsPathRECOM = Path.Combine(StoragePath, "collection-mods-ReCoM.json");
         private static string EnabledCollectionModsPathKH3D = Path.Combine(StoragePath, "collection-mods-KH3D.json");
+        private static readonly LegacyConfigMigration _legacyconfig = LegacyConfigMigration.Open(ConfigPath);
         private static readonly Config _config = Config.Open(ConfigPath);
         public static string PresetPath = Path.Combine(StoragePath, "presets");
         private static readonly HashSet<string> _supportedGames = new HashSet<string>()
@@ -108,6 +132,16 @@ namespace OpenKh.Tools.ModsManager.Services
 
         static ConfigurationService()
         {
+            if (!string.IsNullOrEmpty(_legacyconfig.GameDataPath) && string.IsNullOrEmpty(_config.ExtractedGameDataPath))
+                _config.ExtractedGameDataPath = _legacyconfig.GameDataPath;
+            if (!string.IsNullOrEmpty(_legacyconfig.ModCollectionPath) && string.IsNullOrEmpty(_config.InstalledModsPath))
+                _config.InstalledModsPath = _legacyconfig.ModCollectionPath;
+            if (!string.IsNullOrEmpty(_legacyconfig.ModCollectionsPath) && string.IsNullOrEmpty(_config.InstalledCollectionsPath))
+                _config.InstalledCollectionsPath = _legacyconfig.ModCollectionsPath;
+            if (!string.IsNullOrEmpty(_legacyconfig.GameModPath) && string.IsNullOrEmpty(_config.CompiledModPath))
+                _config.CompiledModPath = _legacyconfig.GameModPath;
+
+
             string modsPath = Path.GetFullPath(Path.Combine(InstalledModsPath, ".."));
             if (!Directory.Exists(Path.Combine(InstalledCollectionsPath)))
                 Directory.CreateDirectory(InstalledCollectionsPath);

--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -26,10 +26,10 @@ namespace OpenKh.Tools.ModsManager.Services
                 .Build();
 
             public int WizardVersionNumber { get; set; }
-            public string ModCollectionPath { get; internal set; }
-            public string ModCollectionsPath { get; internal set; }
-            public string GameModPath { get; internal set; }
-            public string GameDataPath { get; internal set; }
+            public string ExtractedGameDataPath { get; internal set; }
+            public string InstalledModsPath { get; internal set; }
+            public string InstalledCollectionsPath { get; internal set; }
+            public string CompiledModPath { get; internal set; }
             public int GameEdition { get; internal set; } = 1;
             public string IsoLocationKH2 { get; internal set; }
             public string IsoLocationKH1 { get; internal set; }
@@ -108,9 +108,9 @@ namespace OpenKh.Tools.ModsManager.Services
 
         static ConfigurationService()
         {
-            string modsPath = Path.GetFullPath(Path.Combine(ModsGamePath, ".."));
-            if (!Directory.Exists(Path.Combine(modsPath, "collections")))
-                Directory.CreateDirectory(Path.Combine(modsPath, "collections"));
+            string modsPath = Path.GetFullPath(Path.Combine(InstalledModsPath, ".."));
+            if (!Directory.Exists(Path.Combine(InstalledCollectionsPath)))
+                Directory.CreateDirectory(InstalledCollectionsPath);
             if (!Directory.Exists(Path.Combine(modsPath, "kh2")))
                 Directory.CreateDirectory(Path.Combine(modsPath, "kh2"));
             if (!Directory.Exists(Path.Combine(modsPath, "kh1")))
@@ -250,43 +250,62 @@ namespace OpenKh.Tools.ModsManager.Services
                 _config.Save(ConfigPath);
             }
         }
-
-        public static string ModsGamePath
-        {
-            get => Path.Combine(_config.ModCollectionPath ?? Path.GetFullPath(StoragePath), "mods", LaunchGame);
-            set
-            {
-                _config.ModCollectionPath = value;
-                _config.Save(ConfigPath);
-            }
-        }
-
-        public static string ModCollectionsPath
-        {
-            get => _config.ModCollectionsPath ?? Path.GetFullPath(Path.Combine(StoragePath, "mods", "collections"));
-            set
-            {
-                _config.ModCollectionsPath = value;
-                _config.Save(ConfigPath);
-            }
-        }
-
-        public static string GameModPath
-        {
-            get => Path.Combine(_config.ModCollectionPath ?? Path.GetFullPath(StoragePath), "mod", LaunchGame);
-            set
-            {
-                _config.GameModPath = value;
-                _config.Save(ConfigPath);
-            }
-        }
-
         public static string GameDataLocation
         {
-            get => _config.GameDataPath ?? Path.GetFullPath(Path.Combine(StoragePath, "data"));
+            get => _config.ExtractedGameDataPath ?? Path.GetFullPath(Path.Combine(StoragePath, "data"));
             set
             {
-                _config.GameDataPath = value;
+                _config.ExtractedGameDataPath = value;
+                _config.Save(ConfigPath);
+            }
+        }
+
+        public static string InstalledModsPath
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(_config.InstalledModsPath) && _config.InstalledModsPath != _config.CompiledModPath)
+                    return Path.Combine(_config.InstalledModsPath, LaunchGame);
+                else
+                    return Path.Combine(_config.InstalledModsPath ?? Path.GetFullPath(StoragePath), "mods", LaunchGame);
+            }
+            set
+            {
+                _config.InstalledModsPath = value;
+                _config.Save(ConfigPath);
+            }
+        }
+
+        public static string InstalledCollectionsPath
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_config.InstalledCollectionsPath))
+                    return Path.GetFullPath(Path.Combine(StoragePath, "mods", "collections"));
+                else if (_config.InstalledCollectionsPath != _config.InstalledModsPath)
+                    return _config.InstalledCollectionsPath;
+                else
+                    return Path.Combine(_config.InstalledCollectionsPath, "collections");
+            }
+            set
+            {
+                _config.InstalledCollectionsPath = value;
+                _config.Save(ConfigPath);
+            }
+        }
+
+        public static string CompiledModPath
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(_config.CompiledModPath) && _config.CompiledModPath != _config.InstalledModsPath)
+                    return Path.Combine(_config.CompiledModPath, LaunchGame);
+                else
+                    return Path.Combine(_config.CompiledModPath ?? Path.GetFullPath(StoragePath), "mod", LaunchGame);
+            }
+            set
+            {
+                _config.CompiledModPath = value;
                 _config.Save(ConfigPath);
             }
         }

--- a/OpenKh.Tools.ModsManager/Services/ModsService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ModsService.cs
@@ -62,7 +62,7 @@ namespace OpenKh.Tools.ModsManager.Services
         {
             get
             {
-                var modsPath = ConfigurationService.ModsGamePath;
+                var modsPath = ConfigurationService.InstalledModsPath;
                 foreach (var dir in Directory.GetDirectories(modsPath))
                 {
                     var authorName = Path.GetFileName(dir);
@@ -76,7 +76,7 @@ namespace OpenKh.Tools.ModsManager.Services
                     if (File.Exists(Path.Combine(dir, ModMetadata)))
                         yield return authorName;
                 }
-                var collectionsPath = ConfigurationService.ModCollectionsPath;
+                var collectionsPath = ConfigurationService.InstalledCollectionsPath;
                 foreach (var dir in Directory.GetDirectories(collectionsPath))
                 {
                     var authorName = Path.GetFileName(dir);
@@ -447,11 +447,11 @@ namespace OpenKh.Tools.ModsManager.Services
         }
 
         public static string GetModPath(string repositoryName) =>
-            Path.Combine(ConfigurationService.ModsGamePath, repositoryName);
+            Path.Combine(ConfigurationService.InstalledModsPath, repositoryName);
         public static string GetModsGamePath(string repositoryName, string game) =>
-            Path.Combine(ConfigurationService.ModsGamePath, "..", game, repositoryName);
+            Path.Combine(ConfigurationService.InstalledModsPath, "..", game, repositoryName);
         public static string GetCollectionPath(string repositoryName) =>
-            Path.Combine(ConfigurationService.ModCollectionsPath, repositoryName);
+            Path.Combine(ConfigurationService.InstalledCollectionsPath, repositoryName);
 
         public static IEnumerable<ModModel> GetMods(IEnumerable<string> modNames)
         {
@@ -528,11 +528,11 @@ namespace OpenKh.Tools.ModsManager.Services
 
         public static Task<bool> RunPatcherAsync(bool fastMode) => Task.Run(() => Handle(() =>
         {
-            if (Directory.Exists(ConfigurationService.GameModPath))
+            if (Directory.Exists(ConfigurationService.CompiledModPath))
             {
                 try
                 {
-                    Directory.Delete(ConfigurationService.GameModPath, true);
+                    Directory.Delete(ConfigurationService.CompiledModPath, true);
                 }
                 catch (Exception ex)
                 {
@@ -540,7 +540,7 @@ namespace OpenKh.Tools.ModsManager.Services
                 }
             }
 
-            Directory.CreateDirectory(ConfigurationService.GameModPath);
+            Directory.CreateDirectory(ConfigurationService.CompiledModPath);
 
             var patcherProcessor = new PatcherProcessor();
             var modsList = GetMods(EnabledMods).ToList();
@@ -557,7 +557,7 @@ namespace OpenKh.Tools.ModsManager.Services
 
                 patcherProcessor.Patch(
                     Path.Combine(ConfigurationService.GameDataLocation, ConfigurationService.LaunchGame),
-                    ConfigurationService.GameModPath,
+                    ConfigurationService.CompiledModPath,
                     mod.Metadata,
                     mod.Path,
                     ConfigurationService.GameEdition,
@@ -569,7 +569,7 @@ namespace OpenKh.Tools.ModsManager.Services
                     enabledOptionalAssets);
             }
 
-            using var packageMapWriter = new StreamWriter(Path.Combine(ConfigurationService.GameModPath, "patch-package-map.txt"));
+            using var packageMapWriter = new StreamWriter(Path.Combine(ConfigurationService.CompiledModPath, "patch-package-map.txt"));
             foreach (var entry in packageMap)
                 packageMapWriter.WriteLine(entry.Key + " $$$$ " + entry.Value);
             packageMapWriter.Flush();

--- a/OpenKh.Tools.ModsManager/Services/OperationDispatcher.cs
+++ b/OpenKh.Tools.ModsManager/Services/OperationDispatcher.cs
@@ -90,7 +90,7 @@ namespace OpenKh.Tools.ModsManager.Services
                     return -1;  // Error Code -1: denied
                 }
 
-                basePath = ConfigurationService.GameModPath;
+                basePath = ConfigurationService.CompiledModPath;
                 finalFileName = Path.Combine(basePath, fileName);
                 if (File.Exists(finalFileName))
                 {
@@ -126,7 +126,7 @@ namespace OpenKh.Tools.ModsManager.Services
                         .Replace($"/{region}/", $"/{fallback}/")
                         .Replace($".a.{region}", $".a.{fallback}")
                         .Replace($".apdx", $".a.{fallback}");
-                    basePath = ConfigurationService.GameModPath;
+                    basePath = ConfigurationService.CompiledModPath;
                     finalFileName = Path.Combine(basePath, temptativeRegionalFallbackFileName);
                     if (File.Exists(finalFileName))
                     {

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -828,7 +828,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     {
                         FileName = ConfigurationService.OpenKhGameEngineLocation,
                         WorkingDirectory = Path.GetDirectoryName(ConfigurationService.OpenKhGameEngineLocation),
-                        Arguments = $"--data \"{ConfigurationService.GameDataLocation}\" --modpath \"{ConfigurationService.GameModPath}\"",
+                        Arguments = $"--data \"{ConfigurationService.GameDataLocation}\" --modpath \"{ConfigurationService.CompiledModPath}\"",
                         RedirectStandardOutput = true,
                         RedirectStandardError = true,
                         UseShellExecute = false,
@@ -887,7 +887,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                                 {
                                     File.WriteAllLines(Path.Combine(ConfigurationService.PcReleaseLocation, "panacea_settings.txt"),
                                     [
-                                    $"mod_path={Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath,".."))}",
+                                    $"mod_path={Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath,".."))}",
                                     $"show_console={false}",
                                     ]);
                                 }
@@ -922,7 +922,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                                 {
                                         File.WriteAllLines(Path.Combine(ConfigurationService.PcReleaseLocationKH3D, "panacea_settings.txt"),
                                         [
-                                        $"mod_path={Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath,".."))}",
+                                        $"mod_path={Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath,".."))}",
                                         $"show_console={false}",
                                         ]);
                                 }
@@ -957,7 +957,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                                 {
                                     File.WriteAllLines(Path.Combine(ConfigurationService.PcReleaseLocation, "panacea_settings.txt"),
                                     [
-                                    $"mod_path={Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath,".."))}",
+                                    $"mod_path={Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath,".."))}",
                                     $"show_console={false}",
                                     ]);
                                 }
@@ -992,7 +992,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                                 {
                                     File.WriteAllLines(Path.Combine(ConfigurationService.PcReleaseLocationKH3D, "panacea_settings.txt"),
                                     [
-                                    $"mod_path={Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath,".."))}",
+                                    $"mod_path={Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath,".."))}",
                                     $"show_console={false}",
                                     ]);
                                 }
@@ -1031,7 +1031,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                                     {
                                         File.WriteAllLines(Path.Combine(ConfigurationService.PcReleaseLocation, "panacea_settings.txt"),
                                         [
-                                        $"mod_path={Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath,".."))}",
+                                        $"mod_path={Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath,".."))}",
                                         $"show_console={false}",
                                         ]);
                                     }
@@ -1055,7 +1055,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                                     {
                                         File.WriteAllLines(Path.Combine(ConfigurationService.PcReleaseLocationKH3D, "panacea_settings.txt"),
                                         [
-                                        $"mod_path={Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath,".."))}",
+                                        $"mod_path={Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath,".."))}",
                                         $"show_console={false}",
                                         ]);
                                     }
@@ -1202,19 +1202,19 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 if (ConfigurationService.GameEdition == SetupWizardViewModel.PC)
                 {
                     // Use the package map file to rearrange the files in the structure needed by the patcher
-                    var packageMapLocation = Path.Combine(ConfigurationService.GameModPath, "patch-package-map.txt");
+                    var packageMapLocation = Path.Combine(ConfigurationService.CompiledModPath, "patch-package-map.txt");
                     var packageMap = File
                         .ReadLines(packageMapLocation)
                         .Select(line => line.Split(" $$$$ "))
                         .ToDictionary(array => array[0], array => array[1]);
 
-                    var patchStagingDir = Path.Combine(ConfigurationService.GameModPath, "patch-staging");
+                    var patchStagingDir = Path.Combine(ConfigurationService.CompiledModPath, "patch-staging");
                     if (Directory.Exists(patchStagingDir))
                         Directory.Delete(patchStagingDir, true);
                     Directory.CreateDirectory(patchStagingDir);
                     foreach (var entry in packageMap)
                     {
-                        var sourceFile = Path.Combine(ConfigurationService.GameModPath, entry.Key);
+                        var sourceFile = Path.Combine(ConfigurationService.CompiledModPath, entry.Key);
                         var destFile = Path.Combine(patchStagingDir, entry.Value);
                         if (File.Exists(sourceFile))
                         {
@@ -1223,7 +1223,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         }
                     }
 
-                    foreach (var directory in Directory.GetDirectories(Path.Combine(ConfigurationService.GameModPath)))
+                    foreach (var directory in Directory.GetDirectories(Path.Combine(ConfigurationService.CompiledModPath)))
                         if (!"patch-staging".Equals(Path.GetFileName(directory)))
                             Directory.Delete(directory, true);
 
@@ -1235,18 +1235,18 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         specialDirs = Directory.GetDirectories(specialStagingDir).Select(directory => Path.GetFileName(directory)).ToArray();
 
                     foreach (var packageName in stagingDirs)
-                        Directory.Move(Path.Combine(patchStagingDir, packageName), Path.Combine(ConfigurationService.GameModPath, packageName));
+                        Directory.Move(Path.Combine(patchStagingDir, packageName), Path.Combine(ConfigurationService.CompiledModPath, packageName));
                     foreach (var specialDir in specialDirs)
-                        Directory.Move(Path.Combine(ConfigurationService.GameModPath, "special", specialDir), Path.Combine(ConfigurationService.GameModPath, specialDir));
+                        Directory.Move(Path.Combine(ConfigurationService.CompiledModPath, "special", specialDir), Path.Combine(ConfigurationService.CompiledModPath, specialDir));
 
                     stagingDirs.Remove("special"); // Since it's not actually a real game package
                     Directory.Delete(patchStagingDir, true);
 
-                    var specialModDir = Path.Combine(ConfigurationService.GameModPath, "special");
+                    var specialModDir = Path.Combine(ConfigurationService.CompiledModPath, "special");
                     if (Directory.Exists(specialModDir))
                         Directory.Delete(specialModDir, true);
 
-                    foreach (var directory in stagingDirs.Select(packageDir => Path.Combine(ConfigurationService.GameModPath, packageDir)))
+                    foreach (var directory in stagingDirs.Select(packageDir => Path.Combine(ConfigurationService.CompiledModPath, packageDir)))
                     {
                         if (specialDirs.Contains(Path.GetDirectoryName(directory)))
                             continue;
@@ -1441,11 +1441,11 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         }
 
                     }
-                    if (Directory.Exists(ConfigurationService.GameModPath))
+                    if (Directory.Exists(ConfigurationService.CompiledModPath))
                     {
                         try
                         {
-                            Directory.Delete(ConfigurationService.GameModPath, true);
+                            Directory.Delete(ConfigurationService.CompiledModPath, true);
                         }
                         catch (Exception ex)
                         {
@@ -1550,7 +1550,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
 
                 string panaceaSettings = Path.Combine(configTargetPath, "panacea_settings.txt");
                 string[] lines = File.Exists(panaceaSettings) ? File.ReadAllLines(panaceaSettings) : Array.Empty<string>();
-                string textToWrite = $"mod_path={Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath,".."))}\r\n";
+                string textToWrite = $"mod_path={Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath,".."))}\r\n";
                 foreach (string entry in lines)
                 {
                     if (entry.Contains("dev_path"))

--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -1176,7 +1176,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         {
                             File.WriteAllLines(Path.Combine(PcReleaseLocation, "panacea_settings.txt"),
                                 [
-                                $"mod_path={Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath,".."))}",
+                                $"mod_path={Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath,".."))}",
                                 $"show_console={false}",
                                 ]);
                         }
@@ -1184,7 +1184,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                         {
                             File.WriteAllLines(Path.Combine(PcReleaseLocationKH3D, "panacea_settings.txt"),
                                 [
-                                $"mod_path={Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath,".."))}",
+                                $"mod_path={Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath,".."))}",
                                 $"show_console={false}",
                                 ]);
                         }
@@ -1376,27 +1376,27 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                                 if (LuaScriptPaths.Contains("kh1") && GameCollection == 0)
                                 {
                                     int index = config.IndexOf("true }", config.IndexOf("[kh1]")) + 6;
-                                    config = config.Insert(index, ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath, "..")), "kh1/scripts\" , relative = false}").Replace("\\", "/"));
+                                    config = config.Insert(index, ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath, "..")), "kh1/scripts\" , relative = false}").Replace("\\", "/"));
                                 }
                                 if (LuaScriptPaths.Contains("kh2") && GameCollection == 0)
                                 {
                                     int index = config.IndexOf("true }", config.IndexOf("[kh2]")) + 6;
-                                    config = config.Insert(index, ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath, "..")), "kh2/scripts\" , relative = false}").Replace("\\", "/"));
+                                    config = config.Insert(index, ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath, "..")), "kh2/scripts\" , relative = false}").Replace("\\", "/"));
                                 }
                                 if (LuaScriptPaths.Contains("bbs") && GameCollection == 0)
                                 {
                                     int index = config.IndexOf("true }", config.IndexOf("[bbs]")) + 6;
-                                    config = config.Insert(index, ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath, "..")), "bbs/scripts\" , relative = false}").Replace("\\", "/"));
+                                    config = config.Insert(index, ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath, "..")), "bbs/scripts\" , relative = false}").Replace("\\", "/"));
                                 }
                                 if (LuaScriptPaths.Contains("Recom") && GameCollection == 0)
                                 {
                                     int index = config.IndexOf("true }", config.IndexOf("[recom]")) + 6;
-                                    config = config.Insert(index, ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath, "..")), "Recom/scripts\" , relative = false}").Replace("\\", "/"));
+                                    config = config.Insert(index, ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath, "..")), "Recom/scripts\" , relative = false}").Replace("\\", "/"));
                                 }
                                 if (LuaScriptPaths.Contains("kh3d") && GameCollection == 1)
                                 {
                                     int index = config.IndexOf("true }", config.IndexOf("[kh3d]")) + 6;
-                                    config = config.Insert(index, ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath, "..")), "kh3d/scripts\" , relative = false}").Replace("\\", "/"));
+                                    config = config.Insert(index, ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath, "..")), "kh3d/scripts\" , relative = false}").Replace("\\", "/"));
                                 }
                                 if (ConfigurationService.PCVersion == "Steam")
                                 {
@@ -1492,7 +1492,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                                                 int index = config.IndexOf("scripts", config.IndexOf("[kh1]"));
                                                 config = config.Remove(index, config.IndexOf("]", index) - index + 1);
                                                 config = config.Insert(index, "scripts = [{ path = \"scripts/kh1/\", relative = true }" +
-                                                    ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath, "..")), "kh1/scripts\" , relative = false}]").Replace("\\", "/"));
+                                                    ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath, "..")), "kh1/scripts\" , relative = false}]").Replace("\\", "/"));
                                                 break;
                                             }
                                         }
@@ -1502,7 +1502,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                                         int index = config.IndexOf("scripts", config.IndexOf("[kh1]"));
                                         config = config.Remove(index, config.IndexOf("]", index) - index + 1);
                                         config = config.Insert(index, "scripts = [{ path = \"scripts/kh1/\", relative = true }" +
-                                            ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath, "..")), "kh1/scripts\" , relative = false}]").Replace("\\", "/"));
+                                            ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath, "..")), "kh1/scripts\" , relative = false}]").Replace("\\", "/"));
                                     }
                                 }
                                 if (LuaScriptPaths.Contains("kh2") && GameCollection == 0)
@@ -1520,7 +1520,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                                                 int index = config.IndexOf("scripts", config.IndexOf("[kh2]"));
                                                 config = config.Remove(index, config.IndexOf("]", index) - index + 1);
                                                 config = config.Insert(index, "scripts = [{ path = \"scripts/kh2/\", relative = true }" +
-                                                    ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath, "..")), "kh2/scripts\" , relative = false}]").Replace("\\", "/"));
+                                                    ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath, "..")), "kh2/scripts\" , relative = false}]").Replace("\\", "/"));
                                                 break;
                                             }
                                         }
@@ -1530,7 +1530,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                                         int index = config.IndexOf("scripts", config.IndexOf("[kh2]"));
                                         config = config.Remove(index, config.IndexOf("]", index) - index + 1);
                                         config = config.Insert(index, "scripts = [{ path = \"scripts/kh2/\", relative = true }" +
-                                            ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath, "..")), "kh2/scripts\" , relative = false}]").Replace("\\", "/"));
+                                            ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath, "..")), "kh2/scripts\" , relative = false}]").Replace("\\", "/"));
                                     }
                                 }
                                 if (LuaScriptPaths.Contains("bbs") && GameCollection == 0)
@@ -1548,7 +1548,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                                                 int index = config.IndexOf("scripts", config.IndexOf("[bbs]"));
                                                 config = config.Remove(index, config.IndexOf("]", index) - index + 1);
                                                 config = config.Insert(index, "scripts = [{ path = \"scripts/bbs/\", relative = true }" +
-                                                    ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath, "..")), "bbs/scripts\" , relative = false}]").Replace("\\", "/"));
+                                                    ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath, "..")), "bbs/scripts\" , relative = false}]").Replace("\\", "/"));
                                                 break;
                                             }
                                         }
@@ -1558,7 +1558,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                                         int index = config.IndexOf("scripts", config.IndexOf("[bbs]"));
                                         config = config.Remove(index, config.IndexOf("]", index) - index + 1);
                                         config = config.Insert(index, "scripts = [{ path = \"scripts/bbs/\", relative = true }" +
-                                            ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath, "..")), "bbs/scripts\" , relative = false}]").Replace("\\", "/"));
+                                            ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath, "..")), "bbs/scripts\" , relative = false}]").Replace("\\", "/"));
                                     }
                                 }
                                 if (LuaScriptPaths.Contains("Recom") && GameCollection == 0)
@@ -1576,7 +1576,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                                                 int index = config.IndexOf("scripts", config.IndexOf("[recom]"));
                                                 config = config.Remove(index, config.IndexOf("]", index) - index + 1);
                                                 config = config.Insert(index, "scripts = [{ path = \"scripts/recom/\", relative = true }" +
-                                                    ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath, "..")), "Recom/scripts\" , relative = false}]").Replace("\\", "/"));
+                                                    ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath, "..")), "Recom/scripts\" , relative = false}]").Replace("\\", "/"));
                                                 break;
                                             }
                                         }
@@ -1586,7 +1586,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                                         int index = config.IndexOf("scripts", config.IndexOf("[recom]"));
                                         config = config.Remove(index, config.IndexOf("]", index) - index + 1);
                                         config = config.Insert(index, "scripts = [{ path = \"scripts/recom/\", relative = true }" +
-                                            ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath, "..")), "Recom/scripts\" , relative = false}]").Replace("\\", "/"));
+                                            ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath, "..")), "Recom/scripts\" , relative = false}]").Replace("\\", "/"));
                                     }
                                 }
                                 if (LuaScriptPaths.Contains("kh3d") && GameCollection == 1)
@@ -1604,7 +1604,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                                                 int index = config.IndexOf("scripts", config.IndexOf("[kh3d]"));
                                                 config = config.Remove(index, config.IndexOf("]", index) - index + 1);
                                                 config = config.Insert(index, "scripts = [{ path = \"scripts/kh3d/\", relative = true }" +
-                                                    ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath, "..")), "kh3d/scripts\" , relative = false}]").Replace("\\", "/"));
+                                                    ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath, "..")), "kh3d/scripts\" , relative = false}]").Replace("\\", "/"));
                                                 break;
                                             }
                                         }
@@ -1614,7 +1614,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                                         int index = config.IndexOf("scripts", config.IndexOf("[kh3d]"));
                                         config = config.Remove(index, config.IndexOf("]", index) - index + 1);
                                         config = config.Insert(index, "scripts = [{ path = \"scripts/kh3d/\", relative = true }" +
-                                            ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.GameModPath, "..")), "kh3d/scripts\" , relative = false}]").Replace("\\", "/"));
+                                            ", {path = \"" + Path.Combine(Path.GetFullPath(Path.Combine(ConfigurationService.CompiledModPath, "..")), "kh3d/scripts\" , relative = false}]").Replace("\\", "/"));
                                     }
                                 }
                                 if (ConfigurationService.PCVersion == "Steam")


### PR DESCRIPTION
Also ensures if both the path for the mods and mod are the same sub-folders are still created to prevent building mods causing overwrites and errors.