### PR TITLE
Fix all Git Problems on ModsManager

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/ModsService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ModsService.cs
@@ -296,7 +296,7 @@ namespace OpenKh.Tools.ModsManager.Services
             if (!string.IsNullOrWhiteSpace(branchName))
             {
                 progressOutput?.Invoke($"Fetching file {ModMetadata} from branch {branchName}");
-                var isValidMod = await RepositoryService.IsFileExists(repositoryName, branchName, ModMetadata, platformName);
+                var isValidMod = await RepositoryService.IsFileExists(repositoryName, branchName, ModMetadata, progressOutput, progressNumber, platformName);
                 if (!isValidMod)
                     throw new BranchNotValidException(repositoryName, branchName);
             }
@@ -304,7 +304,7 @@ namespace OpenKh.Tools.ModsManager.Services
             {
                 branchName = DefaultGitBranch;
                 progressOutput?.Invoke($"Fetching file {ModMetadata} from {branchName}");
-                var isValidMod = await RepositoryService.IsFileExists(repositoryName, branchName, ModMetadata, platformName);
+                var isValidMod = await RepositoryService.IsFileExists(repositoryName, branchName, ModMetadata, progressOutput, progressNumber, platformName);
                 if (!isValidMod)
                 {
                     progressOutput?.Invoke($"{ModMetadata} not found, fetching default branch name");
@@ -313,7 +313,7 @@ namespace OpenKh.Tools.ModsManager.Services
                         throw new RepositoryNotFoundException(repositoryName);
 
                     progressOutput?.Invoke($"Fetching file {ModMetadata} from {branchName}");
-                    isValidMod = await RepositoryService.IsFileExists(repositoryName, branchName, ModMetadata, platformName);
+                    isValidMod = await RepositoryService.IsFileExists(repositoryName, branchName, ModMetadata, progressOutput, progressNumber, platformName);
                 }
 
                 if (!isValidMod)

--- a/OpenKh.Tools.ModsManager/Services/ModsService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ModsService.cs
@@ -124,6 +124,15 @@ namespace OpenKh.Tools.ModsManager.Services
             string platformUrl = null,
             string branchName = null)
         {
+
+            if (name.Contains("@"))
+            {
+                var _fetchNameWithPlatform = name.Split("@");
+
+                name = _fetchNameWithPlatform[0];
+                platformUrl = _fetchNameWithPlatform[1];
+            }
+
             if (!isZipFile && !isLuaFile)
             {
                 return Task.Run(() => InstallModFromGit(name, progressOutput, progressNumber, platformUrl, branchName));

--- a/OpenKh.Tools.ModsManager/Services/RepositoryService.cs
+++ b/OpenKh.Tools.ModsManager/Services/RepositoryService.cs
@@ -1,4 +1,5 @@
 using LibGit2Sharp;
+using LibGit2Sharp.Handlers;
 using Newtonsoft.Json;
 using System;
 using System.IO;
@@ -40,23 +41,33 @@ namespace OpenKh.Tools.ModsManager.Services
             return JsonConvert.DeserializeObject<ReposResponse>(await response.Content.ReadAsStringAsync())?.DefaultBranch;
         }
 
-        public static Task<bool> IsFileExists(string repoName, string branch, string filePath, string platformUrl = null)
-        {
+        public static Task<bool> IsFileExists(string repoName, string branch, string filePath, Action<string> progressOutput = null, Action<float> progressNumber = null, string platformUrl = null)
+        {                                                                                      
             if (!string.IsNullOrEmpty(platformUrl))
             {
                 var _fetchBaseUri = new Uri(platformUrl.Contains("http") ? platformUrl : "https://" + platformUrl);
                 var _fetchRelativeUri = new Uri(_fetchBaseUri, $"{repoName}");
 
+                var _fetchRepoParent = $"gitfetch";
                 var _fetchRepoDirectory = $"gitfetch/{repoName}/{branch}";
 
                 var _cloneOptions = new CloneOptions
                 {
                     Checkout = false,
                     IsBare = true,
-                    BranchName = branch
+                    BranchName = branch,
                 };
 
+                _cloneOptions.FetchOptions.Depth = 1;
                 _cloneOptions.FetchOptions.Prune = true;
+
+                _cloneOptions.FetchOptions.OnTransferProgress = new TransferProgressHandler((progress) =>
+                {
+                    progressOutput.Invoke($"Checking if Git is a Mod: {progress.ReceivedObjects} / {progress.TotalObjects}");
+                    progressNumber.Invoke((float)progress.ReceivedObjects / (float)progress.TotalObjects);
+
+                    return true;
+                });
 
                 Repository.Clone(_fetchRelativeUri.ToString(), _fetchRepoDirectory, _cloneOptions);
                 var _fetchRepository = new Repository(_fetchRepoDirectory);
@@ -66,10 +77,10 @@ namespace OpenKh.Tools.ModsManager.Services
 
                 _fetchRepository.Dispose();
 
-                if (Directory.Exists(_fetchRepoDirectory))
+                if (Directory.Exists(_fetchRepoParent))
                 {
-                    var _fetchAllFiles = Directory.GetFiles(_fetchRepoDirectory, "*", SearchOption.AllDirectories);
-                    var _fetchAllDirectories = Directory.GetDirectories(_fetchRepoDirectory, "*", SearchOption.AllDirectories);
+                    var _fetchAllFiles = Directory.GetFiles(_fetchRepoParent, "*", SearchOption.AllDirectories);
+                    var _fetchAllDirectories = Directory.GetDirectories(_fetchRepoParent, "*", SearchOption.AllDirectories);
 
                     foreach (var _fetchFile in _fetchAllFiles)
                         File.SetAttributes(_fetchFile, FileAttributes.Normal);
@@ -77,7 +88,7 @@ namespace OpenKh.Tools.ModsManager.Services
                     foreach (string _fetchDirectory in _fetchAllDirectories)
                         File.SetAttributes(_fetchDirectory, FileAttributes.Normal);
 
-                    Directory.Delete(_fetchRepoDirectory, true);
+                    Directory.Delete(_fetchRepoParent, true);
                 }
 
                 return Task.FromResult(_doesModFileExist);

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -370,6 +370,21 @@ namespace OpenKh.Tools.ModsManager.ViewModels
 
         public MainViewModel()
         {
+            if (Directory.Exists($"gitfetch"))
+            {
+                var _fetchAllFiles = Directory.GetFiles($"gitfetch", "*", SearchOption.AllDirectories);
+                var _fetchAllDirectories = Directory.GetDirectories($"gitfetch", "*", SearchOption.AllDirectories);
+
+                foreach (var _fetchFile in _fetchAllFiles)
+                    File.SetAttributes(_fetchFile, FileAttributes.Normal);
+
+                foreach (string _fetchDirectory in _fetchAllDirectories)
+                    File.SetAttributes(_fetchDirectory, FileAttributes.Normal);
+
+                Directory.Delete($"gitfetch", true);
+            }
+
+
             if (ConfigurationService.GameEdition == SetupWizardViewModel.PC)
             {
                 PC = true;
@@ -771,6 +786,18 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                     searchWindow.Show();
                 }
             );
+
+            if (Directory.Exists(ConfigurationService.InstalledModsPath))
+            {
+                var _fetchAllFiles = Directory.GetFiles(ConfigurationService.InstalledModsPath, "*", SearchOption.AllDirectories);
+                var _fetchAllDirectories = Directory.GetDirectories(ConfigurationService.InstalledModsPath, "*", SearchOption.AllDirectories);
+
+                foreach (var _fetchFile in _fetchAllFiles)
+                    File.SetAttributes(_fetchFile, FileAttributes.Normal);
+
+                foreach (string _fetchDirectory in _fetchAllDirectories)
+                    File.SetAttributes(_fetchDirectory, FileAttributes.Normal);
+            }
 
             _pcsx2Injector = new Pcsx2Injector(new OperationDispatcher());
             _ = FetchUpdates();


### PR DESCRIPTION
This PR does the following:
- Add feedback if fetching the "mod.yml" from another Git service.
- Make it so that you can use an @ modifier for platform name instead of declaring it on the other box [Ex. KH-ReFined/KH2-MAIN@codeberg.org]
- Speed up fetching said repository from another Git service. (15 seconds Codeberg fetching "KH-ReFined/KH2-MAIN")
- Ensure "gitfetch" is permission fixed and deleted on initialization and mod installations.
- Ensure that all permissions for every single mod installed is updated on initialization. This should, hopefully, fix many issues regarding mods.