### PR TITLE
Dont show patching menu unless user specifically enables it.

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ConfigurationService.cs
@@ -69,7 +69,7 @@ namespace OpenKh.Tools.ModsManager.Services
             public bool SoundDebug { get; internal set; } = false;
             public bool EnableCache { get; internal set; } = true;
             public bool QuickMenu { get; internal set; } = false;
-            public bool DevView { get; internal set; } = false;
+            public bool EnablePatching { get; internal set; } = false;
             public bool AutoUpdateMods { get; internal set; }
             public string pcVersion { get; internal set; } = "EGS";
             public bool steamAPITrick1525 {  get; internal set; } = false;
@@ -495,12 +495,12 @@ namespace OpenKh.Tools.ModsManager.Services
                 _config.Save(ConfigPath);
             }
         }
-        public static bool DevView
+        public static bool EnablePatching
         {
-            get => _config.DevView;
+            get => _config.EnablePatching;
             set
             {
-                _config.DevView = value;
+                _config.EnablePatching = value;
                 _config.Save(ConfigPath);
             }
         }

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -46,7 +46,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         private bool _panaceaSoundDebugEnabled;
         private bool _panaceaCacheEnabled;
         private bool _panaceaQuickMenuEnabled;
-        private bool _devView;
+        private bool _enablePatching;
         private bool _autoUpdateMods = false;
         private string _launchGame = "kh2";
         private List<string> _supportedGames = new List<string>()
@@ -126,8 +126,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
 
         public Visibility IsModInfoVisible => IsModSelected ? Visibility.Visible : Visibility.Collapsed;
         public Visibility IsModUnselectedMessageVisible => !IsModSelected ? Visibility.Visible : Visibility.Collapsed;
-        public Visibility PatchVisible => PC && !PanaceaInstalled || PC && DevView ? Visibility.Visible : Visibility.Collapsed;
-        public Visibility ModLoader => !PC || PanaceaInstalled ? Visibility.Visible : Visibility.Collapsed;
+        public Visibility PatchVisible => PC &&  EnablePatching ? Visibility.Visible : Visibility.Collapsed;
         public Visibility notPC => !PC ? Visibility.Visible : Visibility.Collapsed;
         public Visibility isPC => PC ? Visibility.Visible : Visibility.Collapsed;
         public bool GameSelectInteractable => (PC && Directory.Exists(ConfigurationService.PcReleaseLocation)) || (PCSX2 && MultiEmuGames);
@@ -229,13 +228,13 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 UpdatePanaceaSettings();
             }
         }
-        public bool DevView
+        public bool EnablePatching
         {
-            get => _devView;
+            get => _enablePatching;
             set
             {
-                _devView = value;
-                ConfigurationService.DevView = DevView;
+                _enablePatching = value;
+                ConfigurationService.EnablePatching = EnablePatching;
                 OnPropertyChanged(nameof(PatchVisible));
             }
         }
@@ -255,7 +254,6 @@ namespace OpenKh.Tools.ModsManager.ViewModels
             {
                 _panaceaInstalled = value;
                 OnPropertyChanged(nameof(PatchVisible));
-                OnPropertyChanged(nameof(ModLoader));
                 OnPropertyChanged(nameof(PanaceaSettings));
             }
         }
@@ -267,7 +265,6 @@ namespace OpenKh.Tools.ModsManager.ViewModels
             {
                 _pc = value;
                 OnPropertyChanged(nameof(PC));
-                OnPropertyChanged(nameof(ModLoader));
                 OnPropertyChanged(nameof(PatchVisible));
                 OnPropertyChanged(nameof(notPC));
                 OnPropertyChanged(nameof(isPC));
@@ -284,7 +281,6 @@ namespace OpenKh.Tools.ModsManager.ViewModels
             {
                 _pcsx2 = value;
                 OnPropertyChanged(nameof(PCSX2));
-                OnPropertyChanged(nameof(ModLoader));
                 OnPropertyChanged(nameof(PatchVisible));
                 OnPropertyChanged(nameof(notPC));
                 OnPropertyChanged(nameof(isPC));
@@ -390,7 +386,7 @@ namespace OpenKh.Tools.ModsManager.ViewModels
                 PC = true;
                 PCSX2 = false;
                 PanaceaInstalled = ConfigurationService.PanaceaInstalled;
-                DevView = ConfigurationService.DevView;
+                EnablePatching = ConfigurationService.EnablePatching;
                 _panaceaConsoleEnabled = ConfigurationService.ShowConsole;
                 _panaceaDebugLogEnabled = ConfigurationService.DebugLog;
                 _panaceaSoundDebugEnabled = ConfigurationService.SoundDebug;

--- a/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/SetupWizardViewModel.cs
@@ -225,7 +225,6 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         public Visibility KH1RecognizedVisibility => !string.IsNullOrEmpty(_isoLocationKH1) ? Visibility.Visible : Visibility.Collapsed;
         public Visibility KH2RecognizedVisibility => !string.IsNullOrEmpty(_isoLocationKH2) ? Visibility.Visible : Visibility.Collapsed;
         public Visibility RecomRecognizedVisibility => !string.IsNullOrEmpty(_isoLocationRecom) ? Visibility.Visible : Visibility.Collapsed;
-        public Visibility OpenKhGameEngineVisible => ConfigurationService.DevView ? Visibility.Visible : Visibility.Collapsed;
 
         public bool IsGameSelected
         {

--- a/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
@@ -74,7 +74,7 @@
                 <Separator/>
                 <MenuItem Header="E_xit" Command="{Binding ExitCommand}" InputGestureText="Alt+F4"/>
             </MenuItem>
-            <MenuItem Header="Mod Loader" Visibility="{Binding ModLoader}">
+            <MenuItem Header="Mod Loader">
                 <MenuItem Header="Build and Run" Command="{Binding BuildAndRunCommand}" InputGestureText="F5"/>
                 <MenuItem Header="Build Only" Command="{Binding BuildCommand}" InputGestureText="Ctrl+B"/>
                 <MenuItem Header="Run Only" Command="{Binding RunCommand}" InputGestureText="Ctrl+F5"/>
@@ -151,7 +151,7 @@
                         <Image Source="{StaticResource WebURL_16x}"/>
                     </MenuItem.Icon>
                 </MenuItem>
-                <MenuItem Header="Dev View" IsCheckable="True" IsChecked="{Binding DevView}" StaysOpenOnClick="True"/>
+                <MenuItem Header="Enable Patching" IsCheckable="True" IsChecked="{Binding EnablePatching}" StaysOpenOnClick="True"/>
             </MenuItem>
             <MenuItem Header="Presets" Command="{Binding OpenPresetMenuCommand}"/>
             <MenuItem Header="PC Version" Focusable="False" IsHitTestVisible="False" Visibility="{Binding isPC}"/>


### PR DESCRIPTION
At this point I don't think many people are using OpenKH for patching but still want to keep mod managers abilities to do so.

The main thing this solves by not showing patching menu if panacea isn't installed is its very common for KH2 randomizers people get the patching menu to show either by not installing panacea or some other way and patch their game files. This causes extra troubleshooting and time in verifying game files/using the Restore button.

Not sure how far away Yokimitsuros mod manager port to avalonia is. This is a change that will save many more basic users just trying to play rando than work for people who still use patching to check the menu option. Ive considered moving Enable Patching to setting menu but I fear basic users will for some reason check that if its under settings.